### PR TITLE
Encode functions

### DIFF
--- a/codecs/src/aper/encode/encode_internal.rs
+++ b/codecs/src/aper/encode/encode_internal.rs
@@ -1,0 +1,150 @@
+use crate::aper::encode::encode_length_determinent;
+use crate::aper::AperCodecData;
+use crate::aper::AperCodecError;
+use bitvec::prelude::*;
+
+pub(super) fn encode_unconstrained_whole_number(
+    data: &mut AperCodecData,
+    value: i128,
+) -> Result<(), AperCodecError> {
+    let bytes = value.to_be_bytes();
+    let first_non_zero = bytes.iter().position(|x| *x != 0).unwrap_or(16);
+    data.align();
+    encode_length_determinent(data, None, None, false, 16 - first_non_zero)?;
+    data.append_bits(bytes[first_non_zero..16].view_bits())
+}
+
+pub(super) fn encode_semi_constrained_whole_number(
+    data: &mut AperCodecData,
+    lb: i128,
+    value: i128,
+) -> Result<(), AperCodecError> {
+    encode_unconstrained_whole_number(data, value - lb)
+}
+
+pub(super) fn encode_constrained_whole_number(
+    data: &mut AperCodecData,
+    lb: i128,
+    ub: i128,
+    value: i128,
+) -> Result<(), AperCodecError> {
+    let range = ub - lb;
+    if range < 0 {
+        return Err(AperCodecError::new(
+            "Range for the Integer Constraint is negative.",
+        ));
+    };
+
+    let value = value - lb;
+
+    if range < 256 {
+        let byte = value as u8;
+        let bits = match range as u8 {
+            0 => 0,
+            1 => 1,
+            2..=3 => 2,
+            4..=7 => 3,
+            8..=15 => 4,
+            16..=31 => 5,
+            32..=63 => 6,
+            64..=127 => 7,
+            128..=255 => 8,
+        };
+
+        data.append_bits(&byte.view_bits::<Msb0>()[(8 - bits)..8])?;
+    } else if range <= 65536 {
+        data.align();
+        let bytes = (value as u16).to_be_bytes();
+        data.append_bits(bytes.view_bits::<Msb0>())?;
+    } else {
+        encode_unconstrained_whole_number(data, value)?;
+    }
+    Ok(())
+}
+
+pub(super) fn encode_indefinite_length_determinent(
+    data: &mut AperCodecData,
+    value: usize,
+) -> Result<(), AperCodecError> {
+    data.align();
+    if value < 128 {
+        let byte = value as u8;
+        data.append_bits(&byte.view_bits::<Msb0>())
+    } else if value < 16384 {
+        let bytes = (value as u16 | 0x8000).to_be_bytes();
+        data.append_bits(&bytes.view_bits::<Msb0>())
+    } else {
+        Err(AperCodecError::new(
+            "Length determinent >= 16384 not implemented",
+        ))
+    }
+}
+
+pub(super) fn encode_normally_small_length_determinent(
+    data: &mut AperCodecData,
+    value: usize,
+) -> Result<(), AperCodecError> {
+    if value <= 32 {
+        let byte = (value - 1) as u8;
+        data.encode_bool(false)?;
+        data.append_bits(&byte.view_bits::<Msb0>()[2..8])
+    } else {
+        data.encode_bool(true)?;
+        encode_indefinite_length_determinent(data, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn encode_unconstrained() {
+        let mut data = AperCodecData::new();
+        encode_unconstrained_whole_number(&mut data, 1).unwrap();
+        assert_eq!(data.into_bytes(), [0x01, 0x01]);
+    }
+
+    #[test]
+    fn encode_tiny_constrained_integer() {
+        let mut data = AperCodecData::new();
+        encode_constrained_whole_number(&mut data, -2, 5, -1).unwrap();
+        assert_eq!(data.into_bytes(), [0x20]);
+    }
+
+    #[test]
+    fn encode_small_constrained_integer() {
+        let mut data = AperCodecData::new();
+        encode_constrained_whole_number(&mut data, 0, 1000, 1).unwrap();
+        assert_eq!(data.into_bytes(), [0x00, 0x01]);
+    }
+
+    #[test]
+    fn encode_large_constrained_integer() {
+        let mut data = AperCodecData::new();
+        encode_constrained_whole_number(&mut data, 0, 100_000, 1).unwrap();
+        assert_eq!(data.into_bytes(), [0x01, 0x01]);
+    }
+
+    #[test]
+    fn encode_tiny_indefinite_length_determinent() {
+        let mut data = AperCodecData::new();
+        encode_indefinite_length_determinent(&mut data, 1).unwrap();
+        assert_eq!(data.into_bytes(), [0x01]);
+    }
+
+    #[test]
+    fn encode_small_indefinite_length_determinent() {
+        let mut data = AperCodecData::new();
+        encode_indefinite_length_determinent(&mut data, 16383).unwrap();
+        assert_eq!(data.into_bytes(), [0xbf, 0xff]);
+    }
+
+    #[test]
+    fn encode_small_normally_small_length_determinent() {
+        let mut data = AperCodecData::new();
+        encode_normally_small_length_determinent(&mut data, 32).unwrap();
+        assert_eq!(data.into_bytes(), [0x3e]);
+    }
+}

--- a/codecs/src/aper/encode/mod.rs
+++ b/codecs/src/aper/encode/mod.rs
@@ -28,7 +28,7 @@ pub fn encode_choice_idx(
     }
 
     if is_extensible {
-        data.encode_bool(extended)?;
+        data.encode_bool(extended);
     }
     encode_integer(data, Some(lb), Some(ub), false, idx, false)
 }
@@ -49,10 +49,11 @@ pub fn encode_sequence_header(
     }
 
     if is_extensible {
-        data.encode_bool(extended)?;
+        data.encode_bool(extended);
     }
 
-    data.append_bits(optionals)
+    data.append_bits(optionals);
+    Ok(())
 }
 
 /// Encode an Integer
@@ -72,7 +73,7 @@ pub fn encode_integer(
     }
 
     if is_extensible {
-        data.encode_bool(extended)?;
+        data.encode_bool(extended);
     }
 
     match (lb, ub) {
@@ -87,7 +88,8 @@ pub fn encode_integer(
 /// Encodes a boolean value into the passed `AperCodecData` structure.
 pub fn encode_bool(data: &mut AperCodecData, value: bool) -> Result<(), AperCodecError> {
     log::trace!("encode_bool");
-    data.encode_bool(value)
+    data.encode_bool(value);
+    Ok(())
 }
 
 /// Encode an Enumerated Value
@@ -107,7 +109,7 @@ pub fn encode_enumerated(
     }
 
     if is_extensible {
-        data.encode_bool(extended)?;
+        data.encode_bool(extended);
     }
 
     encode_integer(data, lb, ub, false, value, false)
@@ -131,7 +133,7 @@ pub fn encode_bitstring(
     }
 
     if is_extensible {
-        data.encode_bool(extended)?;
+        data.encode_bool(extended);
     }
 
     let length = bit_string.len();
@@ -146,7 +148,7 @@ pub fn encode_bitstring(
         if length > 16 {
             data.align();
         }
-        data.append_bits(bit_string)?;
+        data.append_bits(bit_string);
     }
     Ok(())
 }
@@ -169,7 +171,7 @@ pub fn encode_octetstring(
     }
 
     if is_extensible {
-        data.encode_bool(extended)?;
+        data.encode_bool(extended);
     }
 
     let length = octet_string.len();
@@ -185,7 +187,7 @@ pub fn encode_octetstring(
         if length > 2 {
             data.align();
         }
-        data.append_bits(octet_string.view_bits())?;
+        data.append_bits(octet_string.view_bits());
     }
     Ok(())
 }
@@ -227,13 +229,14 @@ fn encode_string(
     }
 
     if is_extensible {
-        data.encode_bool(extended)?;
+        data.encode_bool(extended);
     }
     encode_length_determinent(data, lb, ub, false, value.len())?;
     if value.len() > 2 {
         data.align();
     }
-    data.append_bits(value.as_bits())
+    data.append_bits(value.as_bits());
+    Ok(())
 }
 
 /// Encode a VisibleString CharacterString Type.

--- a/codecs/src/aper/encode/mod.rs
+++ b/codecs/src/aper/encode/mod.rs
@@ -2,20 +2,84 @@
 
 use crate::aper::AperCodecData;
 use crate::aper::AperCodecError;
+use bitvec::prelude::*;
+mod encode_internal;
+use bitvec::view::AsBits;
+use encode_internal::*;
 
 /// Encode a Choice Index
 ///
 /// During Encoding a 'CHOICE' Type to help decoding, the 'CHOICE' Index is encoded first, followed
 /// by the actual encoding of the 'CHOICE' variant.
 pub fn encode_choice_idx(
-    _data: &mut AperCodecData,
-    _lb: i128,
-    _ub: i128,
-    _is_extensible: bool,
-    _value: i128,
+    data: &mut AperCodecData,
+    lb: i128,
+    ub: i128,
+    is_extensible: bool,
+    idx: i128,
+    extended: bool,
 ) -> Result<(), AperCodecError> {
-    log::trace!("encode_bool");
-    todo!();
+    log::trace!("encode_choice_idx");
+
+    if extended {
+        return Err(AperCodecError::new(
+            "Encode of extended choice not yet implemented",
+        ));
+    }
+
+    if is_extensible {
+        data.encode_bool(extended)?;
+    }
+    encode_integer(data, Some(lb), Some(ub), false, idx, false)
+}
+
+/// Encode sequence header
+pub fn encode_sequence_header(
+    data: &mut AperCodecData,
+    is_extensible: bool,
+    optionals: &BitSlice<Msb0, u8>,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_sequence_header");
+
+    if extended {
+        return Err(AperCodecError::new(
+            "Encode of extended sequence not yet implemented",
+        ));
+    }
+
+    if is_extensible {
+        data.encode_bool(extended)?;
+    }
+
+    data.append_bits(optionals)
+}
+
+/// Encode an Integer
+pub fn encode_integer(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    value: i128,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_integer");
+    if extended {
+        return Err(AperCodecError::new(
+            "Encode of extended integer not yet implemented",
+        ));
+    }
+
+    if is_extensible {
+        data.encode_bool(extended)?;
+    }
+
+    match (lb, ub) {
+        (None, _) => encode_unconstrained_whole_number(data, value),
+        (Some(lb), None) => encode_semi_constrained_whole_number(data, lb, value),
+        (Some(lb), Some(ub)) => encode_constrained_whole_number(data, lb, ub, value),
+    }
 }
 
 /// Encode a BOOLEAN Value
@@ -24,6 +88,191 @@ pub fn encode_choice_idx(
 pub fn encode_bool(data: &mut AperCodecData, value: bool) -> Result<(), AperCodecError> {
     log::trace!("encode_bool");
     data.encode_bool(value)
+}
+
+/// Encode an Enumerated Value
+pub fn encode_enumerated(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    value: i128,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_enumerated");
+    if extended {
+        return Err(AperCodecError::new(
+            "Encode of extended enumerated not yet implemented",
+        ));
+    }
+
+    if is_extensible {
+        data.encode_bool(extended)?;
+    }
+
+    encode_integer(data, lb, ub, false, value, false)
+}
+
+/// Encode a Bit String
+pub fn encode_bitstring(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    bit_string: &BitSlice<Msb0, u8>,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_bitstring");
+
+    if extended {
+        return Err(AperCodecError::new(
+            "Encode of extended bitstring not yet implemented",
+        ));
+    }
+
+    if is_extensible {
+        data.encode_bool(extended)?;
+    }
+
+    let length = bit_string.len();
+    if length >= 16384 {
+        return Err(AperCodecError::new(
+            "Encode of fragmented bitstring not yet implemented",
+        ));
+    }
+
+    encode_length_determinent(data, lb, ub, false, length)?;
+    if length > 0 {
+        if length > 16 {
+            data.align();
+        }
+        data.append_bits(bit_string)?;
+    }
+    Ok(())
+}
+
+/// Encode an OCTET STRING
+pub fn encode_octetstring(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    octet_string: &Vec<u8>,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_octetstring");
+
+    if extended {
+        return Err(AperCodecError::new(
+            "Encode of extended octetstring not yet implemented",
+        ));
+    }
+
+    if is_extensible {
+        data.encode_bool(extended)?;
+    }
+
+    let length = octet_string.len();
+    if length >= 16384 {
+        return Err(AperCodecError::new(
+            "Encode of fragmented octetstring not yet implemented",
+        ));
+    }
+
+    encode_length_determinent(data, lb, ub, false, length)?;
+
+    if length > 0 {
+        if length > 2 {
+            data.align();
+        }
+        data.append_bits(octet_string.view_bits())?;
+    }
+    Ok(())
+}
+
+// Encode a Length Determinent
+pub fn encode_length_determinent(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    normally_small: bool,
+    value: usize,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_length_determinent");
+
+    if normally_small {
+        return encode_normally_small_length_determinent(data, value);
+    }
+
+    match ub {
+        Some(ub) if ub < 65_536 => {
+            encode_constrained_whole_number(data, lb.unwrap_or(0), ub, value as i128)
+        }
+        _ => encode_indefinite_length_determinent(data, value),
+    }
+}
+
+fn encode_string(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    value: &String,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    if extended {
+        return Err(AperCodecError::new(
+            "Encode of extended visible string not yet implemented",
+        ));
+    }
+
+    if is_extensible {
+        data.encode_bool(extended)?;
+    }
+    encode_length_determinent(data, lb, ub, false, value.len())?;
+    if value.len() > 2 {
+        data.align();
+    }
+    data.append_bits(value.as_bits())
+}
+
+/// Encode a VisibleString CharacterString Type.
+pub fn encode_visible_string(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    value: &String,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_visible_string");
+    encode_string(data, lb, ub, is_extensible, value, extended)
+}
+
+/// Encode a PrintableString CharacterString Type.
+pub fn encode_printable_string(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    value: &String,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_printable_string");
+    encode_string(data, lb, ub, is_extensible, value, extended)
+}
+
+/// Encode a UTF8String CharacterString Type.
+pub fn encode_utf8_string(
+    data: &mut AperCodecData,
+    lb: Option<i128>,
+    ub: Option<i128>,
+    is_extensible: bool,
+    value: &String,
+    extended: bool,
+) -> Result<(), AperCodecError> {
+    log::trace!("encode_utf8_string");
+    encode_string(data, lb, ub, is_extensible, value, extended)
 }
 
 #[cfg(test)]
@@ -37,7 +286,7 @@ mod tests {
 
         let result = encode_bool(&mut data, true);
         assert!(result.is_ok());
-        assert_eq!(data.offset, 1);
+        assert_eq!(data.bits.len(), 1);
         assert_eq!(data.bits[0], true);
     }
 }

--- a/codecs/src/aper/mod.rs
+++ b/codecs/src/aper/mod.rs
@@ -217,15 +217,13 @@ impl AperCodecData {
     // Encoding functions.
 
     /// Encode a bool.
-    fn encode_bool(&mut self, value: bool) -> Result<(), AperCodecError> {
+    fn encode_bool(&mut self, value: bool) {
         self.bits.push(value);
-        Ok(())
     }
 
     /// Add bits to the encoding buffer.
-    fn append_bits(&mut self, bits: &BitSlice<Msb0, u8>) -> Result<(), AperCodecError> {
+    fn append_bits(&mut self, bits: &BitSlice<Msb0, u8>) {
         self.bits.extend_from_bitslice(bits);
-        Ok(())
     }
 
     /// Byte align the encoding buffer by padding with zero bits.
@@ -244,7 +242,7 @@ impl AperCodecData {
 
     /// Append one encoding to another preserving byte alignment.
     /// This is useful when encoding an open type.
-    pub fn append_aligned(&mut self, other: &mut Self) -> Result<(), AperCodecError> {
+    pub fn append_aligned(&mut self, other: &mut Self) {
         self.align();
         other.align();
         self.append_bits(&other.bits)

--- a/codecs_derive/src/aper/choice.rs
+++ b/codecs_derive/src/aper/choice.rs
@@ -74,7 +74,7 @@ fn generate_choice_variant_decode_tokens_using_attrs(
                     ));
                         continue;
                     }
-                    let _extended = cp.extended.as_ref();
+                    let extended = cp.extended.as_ref();
                     let variant_ident = &variant.ident;
                     if let syn::Fields::Unnamed(ref fields) = variant.fields {
                         if fields.unnamed.len() == 1 {
@@ -84,7 +84,7 @@ fn generate_choice_variant_decode_tokens_using_attrs(
                             };
                             let variant_encode_token = quote! {
                                 Self::#variant_ident(ref v) => {
-                                    asn1_codecs::aper::encode::encode_choice_idx(data, #lb, #ub, #ext, #key, false)?;
+                                    asn1_codecs::aper::encode::encode_choice_idx(data, #lb, #ub, #ext, #key, #extended)?;
                                     v.encode(data)
                                 }
                             };

--- a/codecs_derive/src/aper/choice.rs
+++ b/codecs_derive/src/aper/choice.rs
@@ -84,7 +84,7 @@ fn generate_choice_variant_decode_tokens_using_attrs(
                             };
                             let variant_encode_token = quote! {
                                 Self::#variant_ident(ref v) => {
-                                    asn1_codecs::aper::encode::encode_choice_idx(data, #lb, #ub, #ext, #key)?;
+                                    asn1_codecs::aper::encode::encode_choice_idx(data, #lb, #ub, #ext, #key, false)?;
                                     v.encode(data)
                                 }
                             };


### PR DESCRIPTION
Hello again, here's a small initial attempt at helping with the encode effort.

- The use of tuples for certain encoded value types was intended to be tidily symmetrical with the result type returned by the decode() equivalent.  

-  I put encode_length_determinent() and the encode charstring fns in mod.rs rather than imitating the current structure of the decode equivalent.  Seems to me that these are all at the same level.  (i.e. they're all called by the codecs_derive derived code).
