### PR TITLE
Check bounds when encoding

### DIFF
--- a/codecs/src/aper/encode/encode_internal.rs
+++ b/codecs/src/aper/encode/encode_internal.rs
@@ -34,6 +34,13 @@ pub(super) fn encode_semi_constrained_whole_number(
     lb: i128,
     value: i128,
 ) -> Result<(), AperCodecError> {
+    if value < lb {
+        return Err(AperCodecError::new(format!(
+            "Cannot encode integer {} - less than lower bound {}",
+            value, lb,
+        )));
+    }
+
     encode_unconstrained_whole_number(data, value - lb)
 }
 
@@ -43,13 +50,21 @@ pub(super) fn encode_constrained_whole_number(
     ub: i128,
     value: i128,
 ) -> Result<(), AperCodecError> {
-    let range = ub - lb + 1;
-    if range <= 0 {
-        return Err(AperCodecError::new(
-            "Range for the Integer Constraint is negative.",
-        ));
-    };
+    if value < lb {
+        return Err(AperCodecError::new(format!(
+            "Cannot encode integer {} - less than lower bound {}",
+            value, lb,
+        )));
+    }
 
+    if value > ub {
+        return Err(AperCodecError::new(format!(
+            "Cannot encode integer {} - greater than upper bound {}",
+            value, ub,
+        )));
+    }
+
+    let range = ub - lb + 1;
     let value = value - lb;
 
     if range <= 256 {

--- a/codecs/src/aper/encode/mod.rs
+++ b/codecs/src/aper/encode/mod.rs
@@ -202,24 +202,6 @@ pub fn encode_length_determinent(
 ) -> Result<(), AperCodecError> {
     log::trace!("encode_length_determinent");
 
-    if let Some(l) = lb {
-        if value < l as usize {
-            return Err(AperCodecError::new(format!(
-                "Cannot encode length determinent {} - less than lower bound {}",
-                value, l,
-            )));
-        }
-    }
-
-    if let Some(u) = ub {
-        if value > u as usize {
-            return Err(AperCodecError::new(format!(
-                "Cannot encode length determinent {} - greater than upper bound {}",
-                value, u,
-            )));
-        }
-    }
-
     if normally_small {
         return encode_normally_small_length_determinent(data, value);
     }
@@ -228,7 +210,18 @@ pub fn encode_length_determinent(
         Some(ub) if ub < 65_536 => {
             encode_constrained_whole_number(data, lb.unwrap_or(0), ub, value as i128)
         }
-        _ => encode_indefinite_length_determinent(data, value),
+        _ => {
+            if let Some(l) = lb {
+                if value < l as usize {
+                    return Err(AperCodecError::new(format!(
+                        "Cannot encode length determinent {} - less than lower bound {}",
+                        value, l,
+                    )));
+                }
+            }
+
+            encode_indefinite_length_determinent(data, value)
+        }
     }
 }
 

--- a/codecs/src/aper/encode/mod.rs
+++ b/codecs/src/aper/encode/mod.rs
@@ -211,6 +211,15 @@ pub fn encode_length_determinent(
             encode_constrained_whole_number(data, lb.unwrap_or(0), ub, value as i128)
         }
         _ => {
+            if let Some(u) = ub {
+                if value > u as usize {
+                    return Err(AperCodecError::new(format!(
+                        "Cannot encode length determinent {} - greater than upper bound {}",
+                        value, u,
+                    )));
+                }
+            }
+
             if let Some(l) = lb {
                 if value < l as usize {
                     return Err(AperCodecError::new(format!(
@@ -383,6 +392,18 @@ mod tests {
         assert!(
             encode_length_determinent(&mut AperCodecData::new(), None, Some(1), false, 2,).is_err()
         );
+    }
+
+    #[test]
+    fn big_length_too_big() {
+        assert!(encode_length_determinent(
+            &mut AperCodecData::new(),
+            None,
+            Some(65536),
+            false,
+            65537,
+        )
+        .is_err());
     }
 
     #[test]

--- a/codecs/src/aper/encode/mod.rs
+++ b/codecs/src/aper/encode/mod.rs
@@ -202,6 +202,24 @@ pub fn encode_length_determinent(
 ) -> Result<(), AperCodecError> {
     log::trace!("encode_length_determinent");
 
+    if let Some(l) = lb {
+        if value < l as usize {
+            return Err(AperCodecError::new(format!(
+                "Cannot encode length determinent {} - less than lower bound {}",
+                value, l,
+            )));
+        }
+    }
+
+    if let Some(u) = ub {
+        if value > u as usize {
+            return Err(AperCodecError::new(format!(
+                "Cannot encode length determinent {} - greater than upper bound {}",
+                value, u,
+            )));
+        }
+    }
+
     if normally_small {
         return encode_normally_small_length_determinent(data, value);
     }
@@ -277,7 +295,6 @@ pub fn encode_utf8_string(
     log::trace!("encode_utf8_string");
     encode_string(data, lb, ub, is_extensible, value, extended)
 }
-
 #[cfg(test)]
 mod tests {
 
@@ -291,5 +308,113 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(data.bits.len(), 1);
         assert_eq!(data.bits[0], true);
+    }
+
+    #[test]
+    fn int_too_small() {
+        assert!(encode_integer(&mut AperCodecData::new(), Some(1), None, false, 0, false).is_err());
+    }
+
+    #[test]
+    fn int_too_big() {
+        assert!(encode_integer(
+            &mut AperCodecData::new(),
+            Some(-1),
+            Some(0),
+            false,
+            1,
+            false
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn octetstring_too_small() {
+        assert!(encode_octetstring(
+            &mut AperCodecData::new(),
+            Some(2),
+            None,
+            false,
+            &vec![0],
+            false
+        )
+        .is_err());
+    }
+    #[test]
+    fn octetstring_too_big() {
+        assert!(encode_octetstring(
+            &mut AperCodecData::new(),
+            None,
+            Some(1),
+            false,
+            &vec![0, 0],
+            false
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn string_too_small() {
+        assert!(encode_visible_string(
+            &mut AperCodecData::new(),
+            Some(2),
+            None,
+            false,
+            &"a".to_string(),
+            false
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn string_too_big() {
+        assert!(encode_visible_string(
+            &mut AperCodecData::new(),
+            None,
+            Some(1),
+            false,
+            &"aa".to_string(),
+            false
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn length_too_small() {
+        assert!(
+            encode_length_determinent(&mut AperCodecData::new(), Some(2), None, false, 1,).is_err()
+        );
+    }
+    #[test]
+    fn length_too_big() {
+        assert!(
+            encode_length_determinent(&mut AperCodecData::new(), None, Some(1), false, 2,).is_err()
+        );
+    }
+
+    #[test]
+    fn bitstring_too_small() {
+        assert!(encode_bitstring(
+            &mut AperCodecData::new(),
+            Some(2),
+            None,
+            false,
+            bits![Msb0,u8; 0],
+            false
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn bitstring_too_big() {
+        assert!(encode_bitstring(
+            &mut AperCodecData::new(),
+            None,
+            Some(1),
+            false,
+            bits![Msb0,u8; 0, 0],
+            false
+        )
+        .is_err());
     }
 }


### PR DESCRIPTION
Avoid invalid encoding if out of bounds values / lengths are passed in, and make these mistakes easier to debug.