### PR TITLE
Display error message

### DIFF
--- a/codecs/src/aper/error.rs
+++ b/codecs/src/aper/error.rs
@@ -16,7 +16,7 @@ impl Error {
 }
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "aper_error!")
+        write!(f, "{}", self.msg)
     }
 }
 


### PR DESCRIPTION
This prints the error message itself rather than "aper_error!" to help with debugging.