### PR TITLE
Fix bugs with large int coding

### DIFF
--- a/codecs/src/aper/mod.rs
+++ b/codecs/src/aper/mod.rs
@@ -54,7 +54,7 @@ impl AperCodecData {
         self.bits.into()
     }
 
-    fn decode_align(&mut self) -> Result<(), AperCodecError> {
+    pub fn decode_align(&mut self) -> Result<(), AperCodecError> {
         if self.decode_offset % 8 == 0 {
             return Ok(());
         }
@@ -247,6 +247,15 @@ impl AperCodecData {
         other.align();
         self.append_bits(&other.bits)
     }
+}
+
+fn bytes_needed_for_range(range: i128) -> u8 {
+    let bits_needed: u8 = 128 - range.leading_zeros() as u8;
+    let mut bytes_needed = bits_needed / 8;
+    if bits_needed % 8 != 0 {
+        bytes_needed += 1
+    }
+    bytes_needed
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The relevant arm of my encode function was totally wrong.

Also found an out by 1 bug in your original decode function.  At least I'm pretty sure I did.  To try to prove this I added comments showing my workings at hand decoding the byte array in `test_decode_constrained_whole_number_gt_64k()`.

Finally, in passing I removed a superfluous `data.align()` in `encode_unconstrained_whole_number` which was confusing me.  The alignment is done inside `encode_length_determinent()`.