### PR TITLE
Encode support in Derive Macros *STRING types

### DIFF
--- a/codecs_derive/src/aper/bitstring.rs
+++ b/codecs_derive/src/aper/bitstring.rs
@@ -4,7 +4,7 @@ use quote::quote;
 
 use crate::{attrs::TyCodecParams, utils};
 
-pub(super) fn generate_aper_decode_for_asn_bitstring(
+pub(super) fn generate_aper_codec_for_asn_bitstring(
     ast: &syn::DeriveInput,
     params: &TyCodecParams,
 ) -> proc_macro::TokenStream {
@@ -42,6 +42,10 @@ pub(super) fn generate_aper_decode_for_asn_bitstring(
             fn decode(data: &mut asn1_codecs::aper::AperCodecData) -> Result<Self::Output, asn1_codecs::aper::AperCodecError> {
                 let decoded = asn1_codecs::aper::decode::decode_bitstring(data, #sz_lb, #sz_ub, #sz_ext)?;
                 Ok(Self(decoded))
+            }
+
+            fn encode(&self, data: &mut asn1_codecs::aper::AperCodecData) -> Result<(), asn1_codecs::aper::AperCodecError> {
+                asn1_codecs::aper::encode::encode_bitstring(data, #sz_lb, #sz_ub, #sz_ext, &self.0, false)
             }
         }
     };

--- a/codecs_derive/src/aper/mod.rs
+++ b/codecs_derive/src/aper/mod.rs
@@ -25,10 +25,10 @@ pub(crate) fn generate_decode(
         "CHOICE" => choice::generate_aper_codec_for_asn_choice(ast, params),
         "INTEGER" => integer::generate_aper_codec_for_asn_integer(ast, params),
         "ENUMERATED" => enumerated::generate_aper_codec_for_asn_enumerated(ast, params),
-        "BITSTRING" => bitstring::generate_aper_decode_for_asn_bitstring(ast, params),
-        "OCTET-STRING" => octetstring::generate_aper_decode_for_asn_octetstring(ast, params),
+        "BITSTRING" => bitstring::generate_aper_codec_for_asn_bitstring(ast, params),
+        "OCTET-STRING" => octetstring::generate_aper_codec_for_asn_octetstring(ast, params),
         "UTF8String" | "PrintableString" | "VisibleString" => {
-            charstring::generate_aper_decode_for_asn_charstring(ast, params)
+            charstring::generate_aper_codec_for_asn_charstring(ast, params)
         }
         "NULL" => null::generate_aper_codec_for_asn_null(ast, params),
         "SEQUENCE" => seq::generate_aper_codec_for_asn_sequence(ast, params),

--- a/codecs_derive/src/aper/octetstring.rs
+++ b/codecs_derive/src/aper/octetstring.rs
@@ -4,7 +4,7 @@ use quote::quote;
 
 use crate::{attrs::TyCodecParams, utils};
 
-pub(super) fn generate_aper_decode_for_asn_octetstring(
+pub(super) fn generate_aper_codec_for_asn_octetstring(
     ast: &syn::DeriveInput,
     params: &TyCodecParams,
 ) -> proc_macro::TokenStream {
@@ -42,6 +42,10 @@ pub(super) fn generate_aper_decode_for_asn_octetstring(
             fn decode(data: &mut asn1_codecs::aper::AperCodecData) -> Result<Self::Output, asn1_codecs::aper::AperCodecError> {
                 let decoded = asn1_codecs::aper::decode::decode_octetstring(data, #sz_lb, #sz_ub, #sz_ext)?;
                 Ok(Self(decoded))
+            }
+
+            fn encode(&self, data: &mut asn1_codecs::aper::AperCodecData) -> Result<(), asn1_codecs::aper::AperCodecError> {
+                asn1_codecs::aper::encode::encode_octetstring(data, #sz_lb, #sz_ub, #sz_ext, &self.0, false)
             }
         }
     };


### PR DESCRIPTION
Added `encode` support for BITSTRING, OCTETSTRING and other STRING types
in the `derive` macros.