### PR TITLE
Fixed Unused fields in various internal structs

### DIFF
--- a/asn-compiler/src/generator/int.rs
+++ b/asn-compiler/src/generator/int.rs
@@ -16,7 +16,7 @@ pub(crate) struct Generator {
     pub(crate) items: Vec<TokenStream>,
 
     // Rust module name.
-    pub(crate) name: String,
+    pub(crate) _name: String,
 
     // A counter to uniquify certain names
     pub(crate) counter: usize,
@@ -29,7 +29,7 @@ impl Generator {
     pub(crate) fn new(name: &str) -> Self {
         Generator {
             items: vec![],
-            name: name.to_string(),
+            _name: name.to_string(),
             counter: 1,
             aux_items: vec![],
         }

--- a/asn-compiler/src/parser/asn/defs.rs
+++ b/asn-compiler/src/parser/asn/defs.rs
@@ -369,7 +369,7 @@ fn parse_params(tokens: &[Token]) -> Result<(DefinitionParams, usize), Error> {
     let mut params = vec![];
     loop {
         // Try to parse the Governer: DummyReference if fails, whatever remains is a Type or Class
-        let (governer, dummyref) = if expect_tokens(
+        let (_governer, dummyref) = if expect_tokens(
             &tokens[consumed..],
             &[
                 &[
@@ -382,7 +382,7 @@ fn parse_params(tokens: &[Token]) -> Result<(DefinitionParams, usize), Error> {
             ],
         )? {
             let (g, r) = (&tokens[consumed], &tokens[consumed + 2]);
-            let governer = if g.is_object_class_reference() {
+            let _governer = if g.is_object_class_reference() {
                 ParamGoverner {
                     name: g.text.clone(),
                     kind: GovernerKind::Class,
@@ -394,30 +394,30 @@ fn parse_params(tokens: &[Token]) -> Result<(DefinitionParams, usize), Error> {
                 }
             };
             let dummyref = if r.is_value_reference() {
-                if governer.kind == GovernerKind::Class {
+                if _governer.kind == GovernerKind::Class {
                     ParamDummyReference {
                         name: r.text.clone(),
-                        kind: DummyReferenceKind::Object,
+                        _kind: DummyReferenceKind::Object,
                     }
                 } else {
                     ParamDummyReference {
                         name: r.text.clone(),
-                        kind: DummyReferenceKind::Value,
+                        _kind: DummyReferenceKind::Value,
                     }
                 }
-            } else if governer.kind == GovernerKind::Class {
+            } else if _governer.kind == GovernerKind::Class {
                 ParamDummyReference {
                     name: r.text.clone(),
-                    kind: DummyReferenceKind::ObjectSet,
+                    _kind: DummyReferenceKind::ObjectSet,
                 }
             } else {
                 ParamDummyReference {
                     name: r.text.clone(),
-                    kind: DummyReferenceKind::ValueSet,
+                    _kind: DummyReferenceKind::ValueSet,
                 }
             };
             consumed += 3;
-            (Some(governer), dummyref)
+            (Some(_governer), dummyref)
         } else if expect_one_of_tokens(
             &tokens[consumed..],
             &[Token::is_type_reference, Token::is_object_class_reference],
@@ -429,7 +429,7 @@ fn parse_params(tokens: &[Token]) -> Result<(DefinitionParams, usize), Error> {
                     None,
                     ParamDummyReference {
                         name: r.text.clone(),
-                        kind: DummyReferenceKind::Class,
+                        _kind: DummyReferenceKind::Class,
                     },
                 )
             } else {
@@ -437,7 +437,7 @@ fn parse_params(tokens: &[Token]) -> Result<(DefinitionParams, usize), Error> {
                     None,
                     ParamDummyReference {
                         name: r.text.clone(),
-                        kind: DummyReferenceKind::Type,
+                        _kind: DummyReferenceKind::Type,
                     },
                 )
             }
@@ -447,7 +447,10 @@ fn parse_params(tokens: &[Token]) -> Result<(DefinitionParams, usize), Error> {
                 tokens[consumed]
             ));
         };
-        let param = DefinitionParam { governer, dummyref };
+        let param = DefinitionParam {
+            _governer,
+            dummyref,
+        };
         params.push(param);
 
         if expect_token(&tokens[consumed..], Token::is_comma)? {

--- a/asn-compiler/src/parser/asn/module.rs
+++ b/asn-compiler/src/parser/asn/module.rs
@@ -231,7 +231,7 @@ mod tests {
 
         assert!(module.definitions.is_empty());
         assert!(module.imports.is_empty());
-        assert_eq!(module.tags, Asn1ModuleTag::Explicit);
+        assert_eq!(module._tags, Asn1ModuleTag::Explicit);
     }
     // TODO: Test Cases for imports (count), Tags (type), Definitions (count))
     // TODO: Test Cases for missing BEGIN, END, DEFINITIONS, ::=

--- a/asn-compiler/src/parser/asn/structs/defs.rs
+++ b/asn-compiler/src/parser/asn/structs/defs.rs
@@ -217,7 +217,7 @@ pub(crate) enum DummyReferenceKind {
 #[derive(Debug, Clone)]
 pub(crate) struct ParamDummyReference {
     pub(crate) name: String,
-    pub(crate) kind: DummyReferenceKind,
+    pub(crate) _kind: DummyReferenceKind,
 }
 
 #[derive(Debug, Clone)]
@@ -228,6 +228,6 @@ pub(crate) struct DefinitionParams {
 
 #[derive(Debug, Clone)]
 pub(crate) struct DefinitionParam {
-    pub(crate) governer: Option<ParamGoverner>,
+    pub(crate) _governer: Option<ParamGoverner>,
     pub(crate) dummyref: ParamDummyReference,
 }

--- a/asn-compiler/src/parser/asn/structs/module.rs
+++ b/asn-compiler/src/parser/asn/structs/module.rs
@@ -54,11 +54,11 @@ impl Asn1ModuleName {
 #[derive(Debug, Default)]
 pub struct Asn1Module {
     pub(in crate::parser) imports: HashMap<String, Asn1ModuleName>,
-    pub(in crate::parser) exports: Option<Vec<Asn1Definition>>,
+    pub(in crate::parser) _exports: Option<Vec<Asn1Definition>>,
     pub(in crate::parser) name: Asn1ModuleName,
-    pub(in crate::parser) tags: Asn1ModuleTag,
+    pub(in crate::parser) _tags: Asn1ModuleTag,
     pub(in crate::parser) definitions: HashMap<String, Asn1Definition>,
-    pub(in crate::parser) exports_all: bool,
+    pub(in crate::parser) _exports_all: bool,
 }
 
 impl Asn1Module {
@@ -66,8 +66,8 @@ impl Asn1Module {
         Self { name, ..self }
     }
 
-    pub fn tags(self, tags: Asn1ModuleTag) -> Self {
-        Self { tags, ..self }
+    pub fn tags(self, _tags: Asn1ModuleTag) -> Self {
+        Self { _tags, ..self }
     }
 
     pub fn imports(self, imports: HashMap<String, Asn1ModuleName>) -> Self {

--- a/asn-compiler/src/parser/asn/structs/types/constraints.rs
+++ b/asn-compiler/src/parser/asn/structs/types/constraints.rs
@@ -61,7 +61,7 @@ pub(crate) enum Asn1Constraint {
     Subtype(ElementSet),
     Table(TableConstraint),
     Contents {
-        containing: String,                   // Reference to referenced type
-        encoded_by: Option<ObjectIdentifier>, // Encoding Object Identifier (Right now always None)
+        _containing: String,                   // Reference to referenced type
+        _encoded_by: Option<ObjectIdentifier>, // Encoding Object Identifier (Right now always None)
     },
 }

--- a/asn-compiler/src/parser/asn/structs/types/constructed.rs
+++ b/asn-compiler/src/parser/asn/structs/types/constructed.rs
@@ -19,7 +19,7 @@ impl Component {
 pub(crate) struct SeqComponent {
     pub(crate) component: Component,
     pub(crate) optional: bool,
-    pub(crate) default: Option<String>, // FIXME: Should be Asn1Value later on
+    pub(crate) _default: Option<String>, // FIXME: Should be Asn1Value later on
 }
 
 impl SeqComponent {
@@ -30,7 +30,7 @@ impl SeqComponent {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SeqAdditionGroup {
-    pub(crate) version: Option<String>,
+    pub(crate) _version: Option<String>,
     pub(crate) components: Vec<SeqComponent>,
 }
 
@@ -46,7 +46,7 @@ impl SeqAdditionGroup {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ChoiceAdditionGroup {
-    pub(crate) version: Option<String>,
+    pub(crate) _version: Option<String>,
     pub(crate) components: Vec<Component>,
 }
 

--- a/asn-compiler/src/parser/asn/structs/types/ioc.rs
+++ b/asn-compiler/src/parser/asn/structs/types/ioc.rs
@@ -5,32 +5,13 @@ use std::collections::HashMap;
 use super::Asn1Type;
 
 #[derive(Debug, Clone)]
-pub(crate) struct FixedTypeValueFieldSpec {
-    pub(crate) id: String,
-
-    pub(crate) field_type: Asn1Type,
-    pub(crate) unique: bool,
-    pub(crate) default: Option<String>,
-    pub(crate) optional: bool,
-    pub(crate) with_syntax: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct TypeFieldSpec {
-    pub(crate) id: String,
-    pub(crate) optional: bool,
-    pub(crate) default: Option<Asn1Type>,
-    pub(crate) with_syntax: Option<String>,
-}
-
-#[derive(Debug, Clone)]
 pub(crate) enum ObjectClassFieldSpec {
     Type {
         id: String,
         default: Option<Asn1Type>,
         optional: bool,
         with_syntax: Option<String>,
-        resolved: bool,
+        _resolved: bool,
     },
     FixedTypeValue {
         id: String,
@@ -40,7 +21,7 @@ pub(crate) enum ObjectClassFieldSpec {
         default: Option<String>,
         optional: bool,
         with_syntax: Option<String>,
-        resolved: bool,
+        _resolved: bool,
     },
     // TODO: Following Field Specs are not implemented right now
     // VariableTypeValue(VariableTypeValueFieldSpec),

--- a/asn-compiler/src/parser/asn/types/constraints.rs
+++ b/asn-compiler/src/parser/asn/types/constraints.rs
@@ -354,7 +354,7 @@ fn parse_contents_constraint(tokens: &[Token]) -> Result<(Asn1Constraint, usize)
     }
     consumed += 1;
 
-    let containing = if expect_token(&tokens[consumed..], Token::is_type_reference)? {
+    let _containing = if expect_token(&tokens[consumed..], Token::is_type_reference)? {
         tokens[consumed].text.clone()
     } else {
         return Err(unexpected_token!("'TYPE Reference'", tokens[consumed]));
@@ -366,11 +366,11 @@ fn parse_contents_constraint(tokens: &[Token]) -> Result<(Asn1Constraint, usize)
     }
     consumed += 1;
 
-    let encoded_by = None;
+    let _encoded_by = None;
     Ok((
         Asn1Constraint::Contents {
-            containing,
-            encoded_by,
+            _containing,
+            _encoded_by,
         },
         consumed,
     ))

--- a/asn-compiler/src/parser/asn/types/constructed/choice.rs
+++ b/asn-compiler/src/parser/asn/types/constructed/choice.rs
@@ -89,7 +89,7 @@ pub(crate) fn parse_choice_type(tokens: &[Token]) -> Result<(Asn1TypeChoice, usi
     let additions = if extension_markers > 0 {
         if !no_ver_additions_components.is_empty() {
             let new_addition = ChoiceAdditionGroup {
-                version: None,
+                _version: None,
                 components: no_ver_additions_components,
             };
             additions.push(new_addition);
@@ -116,7 +116,7 @@ fn parse_choice_addition_group(tokens: &[Token]) -> Result<(ChoiceAdditionGroup,
     }
     consumed += 1;
 
-    let version = if expect_token(&tokens[consumed..], Token::is_numeric)? {
+    let _version = if expect_token(&tokens[consumed..], Token::is_numeric)? {
         let version = tokens[consumed].text.clone();
         consumed += 1;
         if !expect_token(&tokens[consumed..], Token::is_colon)? {
@@ -154,7 +154,7 @@ fn parse_choice_addition_group(tokens: &[Token]) -> Result<(ChoiceAdditionGroup,
     } else {
         Ok((
             ChoiceAdditionGroup {
-                version,
+                _version,
                 components,
             },
             consumed,

--- a/asn-compiler/src/parser/asn/types/constructed/seq.rs
+++ b/asn-compiler/src/parser/asn/types/constructed/seq.rs
@@ -143,7 +143,7 @@ fn parse_seq_component(tokens: &[Token]) -> Result<(Option<SeqComponent>, usize)
             false
         };
 
-        let default = if expect_keyword(&tokens[consumed..], "DEFAULT")? {
+        let _default = if expect_keyword(&tokens[consumed..], "DEFAULT")? {
             consumed += 1;
             let (value, value_consumed) = parse_value(&tokens[consumed..])?;
             consumed += value_consumed;
@@ -152,7 +152,7 @@ fn parse_seq_component(tokens: &[Token]) -> Result<(Option<SeqComponent>, usize)
             None
         };
 
-        if default.is_some() && optional {
+        if _default.is_some() && optional {
             return Err(parse_error!(
                 "Both OPTIONAL and DEFAULT not allowed for a value!"
             ));
@@ -162,7 +162,7 @@ fn parse_seq_component(tokens: &[Token]) -> Result<(Option<SeqComponent>, usize)
             Some(SeqComponent {
                 component,
                 optional,
-                default,
+                _default,
             }),
             consumed,
         ))
@@ -179,7 +179,7 @@ fn parse_seq_addition_group(tokens: &[Token]) -> Result<(SeqAdditionGroup, usize
     }
     consumed += 1;
 
-    let version = match expect_token(&tokens[consumed..], Token::is_numeric) {
+    let _version = match expect_token(&tokens[consumed..], Token::is_numeric) {
         Ok(success) => {
             if success {
                 let version = tokens[consumed].text.clone();
@@ -216,7 +216,7 @@ fn parse_seq_addition_group(tokens: &[Token]) -> Result<(SeqAdditionGroup, usize
         consumed += 1;
         Ok((
             SeqAdditionGroup {
-                version,
+                _version,
                 components,
             },
             consumed,

--- a/asn-compiler/src/parser/asn/types/ioc.rs
+++ b/asn-compiler/src/parser/asn/types/ioc.rs
@@ -138,7 +138,7 @@ fn parse_fixed_type_value_field_spec(
             optional,
             default,
             with_syntax,
-            resolved: false,
+            _resolved: false,
         },
         consumed,
     ))
@@ -194,7 +194,7 @@ fn parse_type_field_spec(tokens: &[Token]) -> Result<(ObjectClassFieldSpec, usiz
             optional,
             default,
             with_syntax,
-            resolved: false,
+            _resolved: false,
         },
         consumed,
     ))


### PR DESCRIPTION
Since we do not fully support all the features yet, certain fields of
the structs are reported as unused as warning by the clippy lint
`dead_code`. Marking all such fields as ignorable by renaming them. eg.
A field `id` that is unused is renamed to `_id`. When the proper support
will be added this will be renamed to `id` again (say).