### PR TITLE
Fixes an issue with Derive Macro for OPEN Types

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,6 +14,7 @@ hex = "*"
 bitvec = { version = "0.22" }
 log = { version = "0.4.3" }
 criterion = { version = "0.3" }
+env_logger = "*"
 
 [[bench]]
 name = "ngap_bench"

--- a/examples/tests/13-ngap.rs
+++ b/examples/tests/13-ngap.rs
@@ -16105,11 +16105,21 @@ fn main() {
     use asn1_codecs::aper::*;
     eprintln!("NGAP");
 
-    let ngap_data = hex::decode(
-        "0015404a000004001b00084002f898000000000052400f06004d79206c6974746c6520674e420066001f01000000000002f8980001000800800000010002f8390001001881c00013880015400140",
-    )
-    .unwrap();
+    env_logger::init();
+
+    let ngap_byte_str = "0015404a000004001b00084002f898000000000052400f06004d79206c6974746c6520674e420066001f01000000000002f8980001000800800000010002f8390001001881c00013880015400140";
+    let ngap_data = hex::decode(ngap_byte_str).unwrap();
     let mut codec_data = AperCodecData::from_slice(&ngap_data);
     let ngap_pdu = NGAP_PDU::decode(&mut codec_data).unwrap();
+
+    eprintln!("ngap_pdu: {:#?}", ngap_pdu);
+    let mut encode_codec_data = AperCodecData::new();
+    let result = ngap_pdu.encode(&mut encode_codec_data);
+    eprintln!("result: {:#?}", result);
+    let ngap_encoded_data = encode_codec_data.get_inner().unwrap();
+    eprintln!("Original: {}", hex::encode(&ngap_encoded_data));
+    eprintln!("Encoded: {}", ngap_byte_str);
+    eprintln!("{}", ngap_data.len() == ngap_encoded_data.len());
+    let ngap_pdu = NGAP_PDU::decode(&mut encode_codec_data);
     eprintln!("ngap_pdu: {:#?}", ngap_pdu);
 }


### PR DESCRIPTION
There was an issue with the Derive Macro of OPEN type that would cause
incorrect encoding. This was related to the handling of the length of
encoding an open type (which was missed in the original implementation).
With this fix, now we are able to perform a roundtrip
decode/encode/decode of a string and verify that the strings and types
are identical.

This should fix #7.