### PR TITLE
Initial implementation of using `rustfmt` binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Hampi Build on Pull Request. 
+name: Hampi Build on Pull Request.
 
 on:
   push:
@@ -13,10 +13,29 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    name: (${{ matrix.target}}, ${{ matrix.cfg_release_channel }})
+    strategy:
+      matrix:
+        target: [
+          x86_64-unknown-linux-gnu,
+        ]
+        cfg_release_channel: [ nightly, stable]
 
     steps:
     - uses: actions/checkout@v3
+    - name: install rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
+        sh rustup-init.sh -y --default-toolchain none
+        rustup target add ${{ matrix.target }}
+        rustup default ${{ matrix.cfg_release_channel }}
     - name: Build
-      run: cargo build --verbose
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo test --verbose

--- a/asn-compiler/Cargo.toml
+++ b/asn-compiler/Cargo.toml
@@ -19,9 +19,6 @@ topological-sort = { version = "0.1" }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }
 heck = { version = "0.4" }
-rustfmt = { version = "0.10" }
-#rustfmt-nightly = {git = "https://github.com/rust-lang/rustfmt", rev = "ef57c5bf6751e5a4f548c722d6aeb28f6d86664d" }
-#rustfmt-nightly = {git = "https://github.com/rust-lang/rustfmt", branch = "master" }
 bitvec = { version = "1.0" }
 
 


### PR DESCRIPTION
This should allow us to build with 'nightly' as well as we no longer
depend upon the old `rustfmt` crate.