### PR TITLE
Fix string decode

### DIFF
--- a/codecs/src/aper/mod.rs
+++ b/codecs/src/aper/mod.rs
@@ -453,4 +453,22 @@ mod tests {
         d.append_bits(b.view_bits());
         assert_eq!(d.get_bytes(1).unwrap()[0], b);
     }
+
+    #[test]
+    fn printable_string_coding() {
+        let mut d = AperCodecData::new();
+        let s1 = "hello".to_string();
+        encode::encode_printable_string(&mut d, None, None, false, &s1, false).unwrap();
+        let s2 = decode::decode_printable_string(&mut d, None, None, false).unwrap();
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn empty_string() {
+        let mut d = AperCodecData::new();
+        let s1 = "".to_string();
+        encode::encode_printable_string(&mut d, None, None, false, &s1, false).unwrap();
+        let s2 = decode::decode_printable_string(&mut d, None, None, false).unwrap();
+        assert_eq!(s1, s2);
+    }
 }


### PR DESCRIPTION
#37 

In this code, the `map` was just getting the first bit of the chunk.
```
let decoded = bits
            .chunks_exact(num_bits)
            .map(|c| c[0] as u8)
            .collect::<Vec<u8>>();
```` 
So I changed to use `load`.
```
let bytes = bits
        .chunks_exact(num_bits)
        .map(|c| c.load::<u8>())
        .collect::<Vec<u8>>();
``` 

Got rid of a hittable unwrap() while I was at it.

Everything else is deduplicating or removing unused code.

The first new test `printable_string_coding()` is for the main fix and failed without the change above.  The second new test `empty_string()` was to double-check that my simplification of removing the mut String was ok.
