### PR TITLE
Added CLI Switches for Codec and Derive support

### DIFF
--- a/asn-compiler/Cargo.toml
+++ b/asn-compiler/Cargo.toml
@@ -22,7 +22,6 @@ heck = { version = "0.4" }
 bitvec = { version = "1.0" }
 clap = { version = "4.0.10", features = ["derive"] }
 
-
 [[bin]]
 name = "hampi-asn1c"
 path = "src/bin/hampi-asn1c.rs"

--- a/asn-compiler/src/compiler.rs
+++ b/asn-compiler/src/compiler.rs
@@ -13,7 +13,7 @@ use crate::error::Error;
 
 use crate::parser::asn::structs::module::Asn1Module;
 
-use crate::generator::{Generator, Visibility};
+use crate::generator::{Codec, Derive, Generator, Visibility};
 use crate::resolver::Resolver;
 
 /// ASN.1 Compiler Struct.
@@ -42,17 +42,29 @@ pub struct Asn1Compiler {
 
 impl Default for Asn1Compiler {
     fn default() -> Self {
-        Asn1Compiler::new("default.rs", false, &Visibility::Public)
+        Asn1Compiler::new(
+            "default.rs",
+            false,
+            &Visibility::Public,
+            vec![Codec::Aper],
+            vec![],
+        )
     }
 }
 
 impl Asn1Compiler {
     /// Create a new Instance of the Compiler structure.
-    pub fn new(output: &str, debug: bool, visibility: &Visibility) -> Self {
+    pub fn new(
+        output: &str,
+        debug: bool,
+        visibility: &Visibility,
+        codecs: Vec<Codec>,
+        derives: Vec<Derive>,
+    ) -> Self {
         Asn1Compiler {
             modules: HashMap::new(),
             resolver: Resolver::new(),
-            generator: Generator::new(visibility), // FIXME: Hard coded
+            generator: Generator::new(visibility, codecs, derives), // FIXME: Hard coded
             output_filename: output.to_string(),
             debug,
         }

--- a/asn-compiler/src/generator/asn/types/base/bitstring.rs
+++ b/asn-compiler/src/generator/asn/types/base/bitstring.rs
@@ -24,9 +24,10 @@ impl Asn1ResolvedBitString {
         }
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         let struct_tokens = quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(#ty_attributes)]
             #vis struct #struct_name(#vis BitVec<u8, Msb0>);
         };

--- a/asn-compiler/src/generator/asn/types/base/boolean.rs
+++ b/asn-compiler/src/generator/asn/types/base/boolean.rs
@@ -14,9 +14,12 @@ impl Asn1ResolvedBoolean {
         generator: &mut Generator,
     ) -> Result<TokenStream, Error> {
         let type_name = generator.to_type_ident(name);
+
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
+
         Ok(quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(type = "BOOLEAN")]
             #vis struct #type_name(#vis bool);
         })

--- a/asn-compiler/src/generator/asn/types/base/charstring.rs
+++ b/asn-compiler/src/generator/asn/types/base/charstring.rs
@@ -26,9 +26,10 @@ impl Asn1ResolvedCharacterString {
         }
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         let struct_tokens = quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(#ty_attributes)]
             #vis struct #struct_name(#vis String);
         };

--- a/asn-compiler/src/generator/asn/types/base/enumerated.rs
+++ b/asn-compiler/src/generator/asn/types/base/enumerated.rs
@@ -28,9 +28,10 @@ impl Asn1ResolvedEnumerated {
         ty_attributes.extend(quote! { , ub =  #ub  });
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         let struct_tokens = quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(#ty_attributes)]
             #vis struct #struct_name(#vis #inner_type);
 

--- a/asn-compiler/src/generator/asn/types/base/integer.rs
+++ b/asn-compiler/src/generator/asn/types/base/integer.rs
@@ -53,9 +53,10 @@ impl Asn1ResolvedInteger {
         }
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         let struct_tokens = quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(#ty_tokens)]
             #vis struct #struct_name(#vis #inner_type);
         };

--- a/asn-compiler/src/generator/asn/types/base/null.rs
+++ b/asn-compiler/src/generator/asn/types/base/null.rs
@@ -16,9 +16,10 @@ impl Asn1ResolvedNull {
         let type_name = generator.to_type_ident(name);
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         Ok(quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(type = "NULL")]
             #vis struct #type_name;
         })

--- a/asn-compiler/src/generator/asn/types/base/octetstring.rs
+++ b/asn-compiler/src/generator/asn/types/base/octetstring.rs
@@ -24,9 +24,10 @@ impl Asn1ResolvedOctetString {
         }
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         let struct_tokens = quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(#ty_attributes)]
             #vis struct #struct_name(#vis Vec<u8>);
         };

--- a/asn-compiler/src/generator/asn/types/base/oid.rs
+++ b/asn-compiler/src/generator/asn/types/base/oid.rs
@@ -16,9 +16,10 @@ impl Asn1ResolvedObjectIdentifier {
         let type_name = generator.to_type_ident(name);
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         Ok(quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(type = "OBJECT-IDENTIFIER")]
             #vis struct #type_name;
         })

--- a/asn-compiler/src/generator/asn/types/constructed/choice.rs
+++ b/asn-compiler/src/generator/asn/types/constructed/choice.rs
@@ -49,12 +49,14 @@ impl ResolvedConstructedType {
             };
 
             let vis = generator.get_visibility_tokens();
+            let dir = generator.generate_derive_tokens();
             let struct_tokens =
                 ResolvedConstructedType::generate_struct_tokens_for_asn_choice_type(
                     &type_name,
                     &root_tokens,
                     &addition_tokens,
                     vis,
+                    dir,
                 )?;
 
             let _impl_tokens = ResolvedConstructedType::generate_impl_tokens_for_asn_choice_type(
@@ -77,6 +79,7 @@ impl ResolvedConstructedType {
         root_tokens: &[ChoiceComponentToken],
         addition_tokens: &Option<Vec<ChoiceComponentToken>>,
         vis: TokenStream,
+        dir: TokenStream,
     ) -> Result<TokenStream, Error> {
         let mut root_comp_tokens = TokenStream::new();
         for token in root_tokens {
@@ -128,7 +131,7 @@ impl ResolvedConstructedType {
         let ty_attributes = quote! { #[asn(type = "CHOICE", #lb_token, #ub_token, #additions)] };
 
         Ok(quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #ty_attributes
             #vis enum #type_name {
                 #root_comp_tokens

--- a/asn-compiler/src/generator/asn/types/constructed/seq.rs
+++ b/asn-compiler/src/generator/asn/types/constructed/seq.rs
@@ -79,8 +79,9 @@ impl ResolvedConstructedType {
                 ty_tokens.extend(quote! { , optional_fields = #optflds });
             }
 
+            let dir = generator.generate_derive_tokens();
             Ok(quote! {
-                #[derive(Debug, AperCodec)]
+                #dir
                 #[asn(#ty_tokens)]
                 #vis struct #type_name {
                     #comp_tokens

--- a/asn-compiler/src/generator/asn/types/constructed/seqof.rs
+++ b/asn-compiler/src/generator/asn/types/constructed/seqof.rs
@@ -41,9 +41,10 @@ impl ResolvedConstructedType {
             )?;
 
             let vis = generator.get_visibility_tokens();
+            let dir = generator.generate_derive_tokens();
 
             Ok(quote! {
-                #[derive(Debug, AperCodec)]
+                #dir
                 #[asn(#ty_attrs)]
                 #vis struct #seq_of_type_ident(#vis Vec<#seq_of_type>);
             })

--- a/asn-compiler/src/generator/asn/types/int.rs
+++ b/asn-compiler/src/generator/asn/types/int.rs
@@ -76,9 +76,10 @@ impl ResolvedSetType {
         let ty_elements = self.generate_aux_types(generator)?;
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         Ok(quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #vis enum #ty_ident {
                 #ty_elements
             }
@@ -98,9 +99,10 @@ impl ResolvedSetType {
         let ty_elements = self.generate_aux_types(generator)?;
 
         let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
 
         let set_ty = quote! {
-            #[derive(Debug, AperCodec)]
+            #dir
             #[asn(type = "OPEN")]
             #vis enum #ty_ident {
                 #ty_elements

--- a/asn-compiler/src/generator/mod.rs
+++ b/asn-compiler/src/generator/mod.rs
@@ -2,7 +2,7 @@
 
 mod int;
 
-pub use int::Visibility;
+pub use int::{Codec, Derive, Visibility};
 
 pub(crate) use int::Generator;
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,10 +11,11 @@ asn1-codecs = { path = "../codecs", version = "=0.2.0" }
 asn1_codecs_derive = { path = "../codecs_derive", version = "=0.2.0" }
 trybuild = { version = "1.0" }
 hex = { version = "0.4" }
-bitvec = { version = "1.0" }
+bitvec = { version = "1.0" , features = ["serde"]}
 log = { version = "0.4" }
 criterion = { version = "0.3" }
 env_logger = { version = "0.4" }
+serde = { version = "1.0" , features = ["derive"]}
 
 [[bench]]
 name = "ngap_bench"

--- a/examples/tests/11-ranap.rs
+++ b/examples/tests/11-ranap.rs
@@ -1,9 +1,8 @@
 #![allow(dead_code, unreachable_patterns, non_camel_case_types)]
-use asn1_codecs_derive::AperCodec;
 use bitvec::order::Msb0;
 use bitvec::vec::BitVec;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -12,7 +11,7 @@ use bitvec::vec::BitVec;
 )]
 pub struct APN(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct AccuracyFulfilmentIndicator(pub u8);
 impl AccuracyFulfilmentIndicator {
@@ -20,7 +19,7 @@ impl AccuracyFulfilmentIndicator {
     pub const REQUESTED_ACCURACY_NOT_FULFILLED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct Additional_CSPS_coordination_information {
     #[asn(optional_idx = 0)]
@@ -35,15 +34,15 @@ pub struct Additional_CSPS_coordination_information {
     pub ie_extensions: Option<Additional_CSPS_coordination_informationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct Additional_PositioningDataSet(pub Vec<Additional_PositioningMethodAndUsage>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct Additional_PositioningMethodAndUsage(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AllocationOrRetentionPriority {
     pub priority_level: PriorityLevel,
@@ -54,7 +53,7 @@ pub struct AllocationOrRetentionPriority {
     pub ie_extensions: Option<AllocationOrRetentionPriorityIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Alt_RAB_Parameter_ExtendedGuaranteedBitrateInf {
     pub alt_extended_guaranteed_bitrate_type: Alt_RAB_Parameter_GuaranteedBitrateType,
@@ -62,17 +61,17 @@ pub struct Alt_RAB_Parameter_ExtendedGuaranteedBitrateInf {
     pub alt_extended_guaranteed_bitrates: Option<Alt_RAB_Parameter_ExtendedGuaranteedBitrates>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Alt_RAB_Parameter_ExtendedGuaranteedBitrateList(pub Vec<ExtendedGuaranteedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct Alt_RAB_Parameter_ExtendedGuaranteedBitrates(
     pub Vec<Alt_RAB_Parameter_ExtendedGuaranteedBitrateList>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Alt_RAB_Parameter_ExtendedMaxBitrateInf {
     pub alt_extended_max_bitrate_type: Alt_RAB_Parameter_MaxBitrateType,
@@ -80,15 +79,15 @@ pub struct Alt_RAB_Parameter_ExtendedMaxBitrateInf {
     pub alt_extended_max_bitrates: Option<Alt_RAB_Parameter_ExtendedMaxBitrates>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Alt_RAB_Parameter_ExtendedMaxBitrateList(pub Vec<ExtendedMaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct Alt_RAB_Parameter_ExtendedMaxBitrates(pub Vec<Alt_RAB_Parameter_ExtendedMaxBitrateList>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Alt_RAB_Parameter_GuaranteedBitrateInf {
     pub alt_guaranteed_bitrate_type: Alt_RAB_Parameter_GuaranteedBitrateType,
@@ -96,11 +95,11 @@ pub struct Alt_RAB_Parameter_GuaranteedBitrateInf {
     pub alt_guaranteed_bitrates: Option<Alt_RAB_Parameter_GuaranteedBitrates>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Alt_RAB_Parameter_GuaranteedBitrateList(pub Vec<GuaranteedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct Alt_RAB_Parameter_GuaranteedBitrateType(pub u8);
 impl Alt_RAB_Parameter_GuaranteedBitrateType {
@@ -109,11 +108,11 @@ impl Alt_RAB_Parameter_GuaranteedBitrateType {
     pub const DISCRETE_VALUES: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct Alt_RAB_Parameter_GuaranteedBitrates(pub Vec<Alt_RAB_Parameter_GuaranteedBitrateList>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Alt_RAB_Parameter_MaxBitrateInf {
     pub alt_max_bitrate_type: Alt_RAB_Parameter_MaxBitrateType,
@@ -121,11 +120,11 @@ pub struct Alt_RAB_Parameter_MaxBitrateInf {
     pub alt_max_bitrates: Option<Alt_RAB_Parameter_MaxBitrates>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Alt_RAB_Parameter_MaxBitrateList(pub Vec<MaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct Alt_RAB_Parameter_MaxBitrateType(pub u8);
 impl Alt_RAB_Parameter_MaxBitrateType {
@@ -134,11 +133,11 @@ impl Alt_RAB_Parameter_MaxBitrateType {
     pub const DISCRETE_VALUES: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct Alt_RAB_Parameter_MaxBitrates(pub Vec<Alt_RAB_Parameter_MaxBitrateList>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct Alt_RAB_Parameter_SupportedGuaranteedBitrateInf {
     pub alt_supported_guaranteed_bitrate_type: Alt_RAB_Parameter_GuaranteedBitrateType,
@@ -148,13 +147,13 @@ pub struct Alt_RAB_Parameter_SupportedGuaranteedBitrateInf {
     pub ie_extensions: Option<Alt_RAB_Parameter_SupportedGuaranteedBitrateInfIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct Alt_RAB_Parameter_SupportedGuaranteedBitrates(
     pub Vec<SupportedRAB_ParameterBitrateList>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct Alt_RAB_Parameter_SupportedMaxBitrateInf {
     pub alt_supported_max_bitrate_type: Alt_RAB_Parameter_MaxBitrateType,
@@ -164,11 +163,11 @@ pub struct Alt_RAB_Parameter_SupportedMaxBitrateInf {
     pub ie_extensions: Option<Alt_RAB_Parameter_SupportedMaxBitrateInfIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct Alt_RAB_Parameter_SupportedMaxBitrates(pub Vec<SupportedRAB_ParameterBitrateList>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct Alt_RAB_Parameters {
     #[asn(optional_idx = 0)]
@@ -179,14 +178,14 @@ pub struct Alt_RAB_Parameters {
     pub ie_extensions: Option<Alt_RAB_ParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct AlternativeRABConfigurationRequest(pub u8);
 impl AlternativeRABConfigurationRequest {
     pub const ALTERNATIVE_RAB_CONFIGURATION_REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum AreaIdentity {
     #[asn(key = 0, extended = false)]
@@ -195,7 +194,7 @@ pub enum AreaIdentity {
     GeographicalArea(GeographicalArea),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = true)]
 pub enum AreaScopeForUEApplicationLayerMeasurementConfiguration {
     #[asn(key = 0, extended = false)]
@@ -208,23 +207,23 @@ pub enum AreaScopeForUEApplicationLayerMeasurementConfiguration {
     Plmn_area_based(PLMNBased),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Ass_RAB_Parameter_ExtendedGuaranteedBitrateList(pub Vec<ExtendedGuaranteedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Ass_RAB_Parameter_ExtendedMaxBitrateList(pub Vec<ExtendedMaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Ass_RAB_Parameter_GuaranteedBitrateList(pub Vec<GuaranteedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Ass_RAB_Parameter_MaxBitrateList(pub Vec<MaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct Ass_RAB_Parameters {
     #[asn(optional_idx = 0)]
@@ -235,11 +234,11 @@ pub struct Ass_RAB_Parameters {
     pub ie_extensions: Option<Ass_RAB_ParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct AuthorisedPLMNs(pub Vec<AuthorisedPLMNs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -248,15 +247,15 @@ pub struct AuthorisedPLMNs(pub Vec<AuthorisedPLMNs_Entry>);
 )]
 pub struct AuthorisedSNAs(pub Vec<SNAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "30000", ub = "115000")]
 pub struct BarometricPressure(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct BindingID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct BroadcastAssistanceDataDecipheringKeys {
     pub ciphering_key_flag: BIT_STRING_4,
@@ -264,7 +263,7 @@ pub struct BroadcastAssistanceDataDecipheringKeys {
     pub next_deciphering_key: BIT_STRING_6,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct CGI {
     pub plm_nidentity: PLMNidentity,
@@ -274,11 +273,11 @@ pub struct CGI {
     pub ie_extensions: Option<CGIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct CI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CN_DeactivateTrace {
     pub protocol_i_es: CN_DeactivateTraceProtocolIEs,
@@ -286,7 +285,7 @@ pub struct CN_DeactivateTrace {
     pub protocol_extensions: Option<CN_DeactivateTraceProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct CN_DomainIndicator(pub u8);
 impl CN_DomainIndicator {
@@ -294,11 +293,11 @@ impl CN_DomainIndicator {
     pub const PS_DOMAIN: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct CN_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CN_InvokeTrace {
     pub protocol_i_es: CN_InvokeTraceProtocolIEs,
@@ -306,7 +305,7 @@ pub struct CN_InvokeTrace {
     pub protocol_extensions: Option<CN_InvokeTraceProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CNMBMSLinkingInformation {
     pub joined_mbms_bearer_service_i_es: JoinedMBMSBearerService_IEs,
@@ -314,7 +313,7 @@ pub struct CNMBMSLinkingInformation {
     pub ie_extensions: Option<CNMBMSLinkingInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct CSFB_Information(pub u8);
 impl CSFB_Information {
@@ -322,11 +321,11 @@ impl CSFB_Information {
     pub const CSFB_HIGH_PRIORITY: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "27", sz_ub = "27")]
 pub struct CSG_Id(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -335,7 +334,7 @@ pub struct CSG_Id(pub BitVec<u8, Msb0>);
 )]
 pub struct CSG_Id_List(pub Vec<CSG_Id>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct CSG_Membership_Status(pub u8);
 impl CSG_Membership_Status {
@@ -343,7 +342,7 @@ impl CSG_Membership_Status {
     pub const NON_MEMBER: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "5", extensible = true)]
 pub enum Cause {
     #[asn(key = 0, extended = false)]
@@ -362,50 +361,50 @@ pub enum Cause {
     RadioNetworkExtension(CauseRadioNetworkExtension),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "113", ub = "128")]
 pub struct CauseMisc(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "81", ub = "96")]
 pub struct CauseNAS(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "129", ub = "256")]
 pub struct CauseNon_Standard(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "97", ub = "112")]
 pub struct CauseProtocol(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "64")]
 pub struct CauseRadioNetwork(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "257", ub = "512")]
 pub struct CauseRadioNetworkExtension(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "65", ub = "80")]
 pub struct CauseTransmissionNetwork(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Cell_Access_Mode(pub u8);
 impl Cell_Access_Mode {
     pub const HYBRID: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "100", extensible = true)]
 pub struct Cell_Capacity_Class_Value(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "268435455")]
 pub struct Cell_Id(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellBased {
     pub cell_id_list: CellIdList,
@@ -413,11 +412,11 @@ pub struct CellBased {
     pub ie_extensions: Option<CellBasedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct CellIdList(pub Vec<Cell_Id>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct CellLoadInformation {
     pub cell_capacity_class_value: Cell_Capacity_Class_Value,
@@ -430,7 +429,7 @@ pub struct CellLoadInformation {
     pub ie_extensions: Option<CellLoadInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct CellLoadInformationGroup {
     pub source_cell_id: SourceCellID,
@@ -442,7 +441,7 @@ pub struct CellLoadInformationGroup {
     pub ie_extensions: Option<CellLoadInformationGroupIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct CellType(pub u8);
 impl CellType {
@@ -456,19 +455,19 @@ pub type ChosenEncryptionAlgorithm = EncryptionAlgorithm;
 
 pub type ChosenIntegrityProtectionAlgorithm = IntegrityProtectionAlgorithm;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct CivicAddress(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct ClassmarkInformation2(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct ClassmarkInformation3(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "7")]
 pub struct ClientType(pub u8);
 impl ClientType {
@@ -482,7 +481,7 @@ impl ClientType {
     pub const P_LMN_OPERATOR_TARGET_MS_SERVICE_SUPPORT: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CommonID {
     pub protocol_i_es: CommonIDProtocolIEs,
@@ -490,11 +489,11 @@ pub struct CommonID {
     pub protocol_extensions: Option<CommonIDProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct Correlation_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct Criticality(pub u8);
 impl Criticality {
@@ -503,7 +502,7 @@ impl Criticality {
     pub const NOTIFY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct CriticalityDiagnostics {
     #[asn(optional_idx = 0)]
@@ -518,7 +517,7 @@ pub struct CriticalityDiagnostics {
     pub ie_extensions: Option<CriticalityDiagnosticsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -527,35 +526,35 @@ pub struct CriticalityDiagnostics {
 )]
 pub struct CriticalityDiagnostics_IE_List(pub Vec<CriticalityDiagnostics_IE_List_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1048575")]
 pub struct D_RNTI(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct DCH_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct DCN_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct DL_GTP_PDU_SequenceNumber(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct DL_N_PDU_SequenceNumber(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "6", ub = "9")]
 pub struct DRX_CycleLengthCoefficient(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct DSCH_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct DataPDUType(pub u8);
 impl DataPDUType {
@@ -563,15 +562,15 @@ impl DataPDUType {
     pub const P_D_UTYPE1: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct DataVolumeList(pub Vec<DataVolumeList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct DataVolumeReference(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DataVolumeReport {
     pub protocol_i_es: DataVolumeReportProtocolIEs,
@@ -579,7 +578,7 @@ pub struct DataVolumeReport {
     pub protocol_extensions: Option<DataVolumeReportProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DataVolumeReportRequest {
     pub protocol_i_es: DataVolumeReportRequestProtocolIEs,
@@ -587,7 +586,7 @@ pub struct DataVolumeReportRequest {
     pub protocol_extensions: Option<DataVolumeReportRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct DataVolumeReportingIndication(pub u8);
 impl DataVolumeReportingIndication {
@@ -595,7 +594,7 @@ impl DataVolumeReportingIndication {
     pub const DO_NOT_REPORT: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct DeliveryOfErroneousSDU(pub u8);
 impl DeliveryOfErroneousSDU {
@@ -604,7 +603,7 @@ impl DeliveryOfErroneousSDU {
     pub const NO_ERROR_DETECTION_CONSIDERATION: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct DeliveryOrder(pub u8);
 impl DeliveryOrder {
@@ -612,7 +611,7 @@ impl DeliveryOrder {
     pub const DELIVERY_ORDER_NOT_REQUESTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 3)]
 pub struct DeltaRAListofIdleModeUEs {
     #[asn(optional_idx = 0)]
@@ -623,7 +622,7 @@ pub struct DeltaRAListofIdleModeUEs {
     pub ie_extensions: Option<DeltaRAListofIdleModeUEsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DirectInformationTransfer {
     pub protocol_i_es: DirectInformationTransferProtocolIEs,
@@ -631,7 +630,7 @@ pub struct DirectInformationTransfer {
     pub protocol_extensions: Option<DirectInformationTransferProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct DirectReportingIndicator(pub u8);
 impl DirectReportingIndicator {
@@ -639,7 +638,7 @@ impl DirectReportingIndicator {
     pub const DIRECT_GEO: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DirectTransfer {
     pub protocol_i_es: DirectTransferProtocolIEs,
@@ -647,7 +646,7 @@ pub struct DirectTransfer {
     pub protocol_extensions: Option<DirectTransferProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DirectTransferInformationItem_RANAP_RelocInf {
     pub nas_pdu: NAS_PDU,
@@ -657,28 +656,28 @@ pub struct DirectTransferInformationItem_RANAP_RelocInf {
     pub ie_extensions: Option<DirectTransferInformationItem_RANAP_RelocInfIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "15")]
 pub struct DirectTransferInformationList_RANAP_RelocInf(
     pub Vec<DirectTransferInformationList_RANAP_RelocInf_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "7")]
 pub struct E_DCH_MAC_d_Flow_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct E_UTRAN_Service_Handover(pub u8);
 impl E_UTRAN_Service_Handover {
     pub const HANDOVER_TO_E_UTRAN_SHALL_NOT_BE_PERFORMED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "65536", ub = "262143", extensible = true)]
 pub struct EARFCN_Extended(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum ENB_ID {
     #[asn(key = 0, extended = false)]
@@ -691,15 +690,15 @@ pub enum ENB_ID {
     Long_macroENB_ID(BIT_STRING_10),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct EUTRANFrequencies(pub Vec<EUTRANFrequencies_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15")]
 pub struct EncryptionAlgorithm(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct EncryptionInformation {
     pub permitted_algorithms: PermittedEncryptionAlgorithms,
@@ -708,7 +707,7 @@ pub struct EncryptionInformation {
     pub ie_extensions: Option<EncryptionInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -717,14 +716,14 @@ pub struct EncryptionInformation {
 )]
 pub struct EncryptionKey(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct End_Of_CSFB(pub u8);
 impl End_Of_CSFB {
     pub const END_OF_CSFB: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EnhancedRelocationCompleteConfirm {
     pub protocol_i_es: EnhancedRelocationCompleteConfirmProtocolIEs,
@@ -732,7 +731,7 @@ pub struct EnhancedRelocationCompleteConfirm {
     pub protocol_extensions: Option<EnhancedRelocationCompleteConfirmProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EnhancedRelocationCompleteFailure {
     pub protocol_i_es: EnhancedRelocationCompleteFailureProtocolIEs,
@@ -740,7 +739,7 @@ pub struct EnhancedRelocationCompleteFailure {
     pub protocol_extensions: Option<EnhancedRelocationCompleteFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EnhancedRelocationCompleteRequest {
     pub protocol_i_es: EnhancedRelocationCompleteRequestProtocolIEs,
@@ -748,7 +747,7 @@ pub struct EnhancedRelocationCompleteRequest {
     pub protocol_extensions: Option<EnhancedRelocationCompleteRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EnhancedRelocationCompleteResponse {
     pub protocol_i_es: EnhancedRelocationCompleteResponseProtocolIEs,
@@ -756,7 +755,7 @@ pub struct EnhancedRelocationCompleteResponse {
     pub protocol_extensions: Option<EnhancedRelocationCompleteResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = true)]
 pub enum EquipmentsToBeTraced {
     #[asn(key = 0, extended = false)]
@@ -769,7 +768,7 @@ pub enum EquipmentsToBeTraced {
     IMEISVgroup(IMEISVGroup),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ErrorIndication {
     pub protocol_i_es: ErrorIndicationProtocolIEs,
@@ -777,7 +776,7 @@ pub struct ErrorIndication {
     pub protocol_extensions: Option<ErrorIndicationProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct Event(pub u8);
 impl Event {
@@ -786,32 +785,32 @@ impl Event {
     pub const CHANGE_OF_SERVICEAREA: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct Event1F_Parameters {
     pub measurement_quantity: MeasurementQuantity,
     pub threshold: INTEGER_12,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct Event1I_Parameters {
     pub threshold: INTEGER_13,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "16000001", ub = "256000000")]
 pub struct ExtendedGuaranteedBitrate(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "16000001", ub = "256000000")]
 pub struct ExtendedMaxBitrate(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "4096", ub = "65535")]
 pub struct ExtendedRNC_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ForwardSRNS_Context {
     pub protocol_i_es: ForwardSRNS_ContextProtocolIEs,
@@ -819,32 +818,32 @@ pub struct ForwardSRNS_Context {
     pub protocol_extensions: Option<ForwardSRNS_ContextProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ForwardingIndication(pub u8);
 impl ForwardingIndication {
     pub const FORWARDING_ADMITTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15")]
 pub struct FrameSequenceNumber(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct FrequenceLayerConvergenceFlag(pub u8);
 impl FrequenceLayerConvergenceFlag {
     pub const NO_FLC_FLAG: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct GA_AltitudeAndDirection {
     pub direction_of_altitude: ENUMERATED_14,
     pub altitude: INTEGER_15,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GA_EllipsoidArc {
     pub geographical_coordinates: GeographicalCoordinates,
@@ -857,7 +856,7 @@ pub struct GA_EllipsoidArc {
     pub ie_extensions: Option<GA_EllipsoidArcIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GA_Point {
     pub geographical_coordinates: GeographicalCoordinates,
@@ -865,7 +864,7 @@ pub struct GA_Point {
     pub ie_extensions: Option<GA_PointIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GA_PointWithAltitude {
     pub geographical_coordinates: GeographicalCoordinates,
@@ -874,7 +873,7 @@ pub struct GA_PointWithAltitude {
     pub ie_extensions: Option<GA_PointWithAltitudeIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GA_PointWithAltitudeAndUncertaintyEllipsoid {
     pub geographical_coordinates: GeographicalCoordinates,
@@ -886,7 +885,7 @@ pub struct GA_PointWithAltitudeAndUncertaintyEllipsoid {
     pub ie_extensions: Option<GA_PointWithAltitudeAndUncertaintyEllipsoidIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct GA_PointWithUnCertainty {
     pub geographical_coordinates: GeographicalCoordinates,
@@ -895,7 +894,7 @@ pub struct GA_PointWithUnCertainty {
     pub uncertainty_code: INTEGER_23,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GA_PointWithUnCertaintyEllipse {
     pub geographical_coordinates: GeographicalCoordinates,
@@ -905,11 +904,11 @@ pub struct GA_PointWithUnCertaintyEllipse {
     pub ie_extensions: Option<GA_PointWithUnCertaintyEllipseIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "15")]
 pub struct GA_Polygon(pub Vec<GA_Polygon_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct GA_UncertaintyEllipse {
     pub uncertainty_semi_major: INTEGER_25,
@@ -917,19 +916,19 @@ pub struct GA_UncertaintyEllipse {
     pub orientation_of_major_axis: INTEGER_27,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "9")]
 pub struct GANSS_PositioningDataSet(pub Vec<GANSS_PositioningMethodAndUsage>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct GANSS_PositioningMethodAndUsage(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct GERAN_BSC_Container(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct GERAN_Cell_ID {
     pub lai: LAI,
@@ -939,11 +938,11 @@ pub struct GERAN_Cell_ID {
     pub ie_extensions: Option<GERAN_Cell_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct GERAN_Classmark(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct GERAN_Iumode_RAB_Failed_RABAssgntResponse_Item {
     pub rab_id: RAB_ID,
@@ -954,7 +953,7 @@ pub struct GERAN_Iumode_RAB_Failed_RABAssgntResponse_Item {
     pub ie_extensions: Option<GERAN_Iumode_RAB_Failed_RABAssgntResponse_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -965,11 +964,11 @@ pub struct GERAN_Iumode_RAB_FailedList_RABAssgntResponse(
     pub Vec<GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct GTP_TEI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum GeographicalArea {
     #[asn(key = 0, extended = false)]
@@ -988,7 +987,7 @@ pub enum GeographicalArea {
     EllipsoidArc(GA_EllipsoidArc),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GeographicalCoordinates {
     pub latitude_sign: ENUMERATED_28,
@@ -998,29 +997,29 @@ pub struct GeographicalCoordinates {
     pub ie_extensions: Option<GeographicalCoordinatesIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalCN_ID {
     pub plm_nidentity: PLMNidentity,
     pub cn_id: CN_ID,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalRNC_ID {
     pub plm_nidentity: PLMNidentity,
     pub rnc_id: RNC_ID,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "16000000")]
 pub struct GuaranteedBitrate(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "7")]
 pub struct HS_DSCH_MAC_d_Flow_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct HigherBitratesThan16MbpsFlag(pub u8);
 impl HigherBitratesThan16MbpsFlag {
@@ -1028,14 +1027,14 @@ impl HigherBitratesThan16MbpsFlag {
     pub const NOT_ALLOWED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HorizontalSpeedAndBearing {
     pub bearing: INTEGER_31,
     pub horizontal_speed: INTEGER_32,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct HorizontalVelocity {
     pub horizontal_speed_and_bearing: HorizontalSpeedAndBearing,
@@ -1043,7 +1042,7 @@ pub struct HorizontalVelocity {
     pub ie_extensions: Option<HorizontalVelocityIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct HorizontalVelocityWithUncertainty {
     pub horizontal_speed_and_bearing: HorizontalSpeedAndBearing,
@@ -1052,7 +1051,7 @@ pub struct HorizontalVelocityWithUncertainty {
     pub ie_extensions: Option<HorizontalVelocityWithUncertaintyIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct HorizontalWithVerticalVelocity {
     pub horizontal_speed_and_bearing: HorizontalSpeedAndBearing,
@@ -1061,7 +1060,7 @@ pub struct HorizontalWithVerticalVelocity {
     pub ie_extensions: Option<HorizontalWithVerticalVelocityIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct HorizontalWithVerticalVelocityAndUncertainty {
     pub horizontal_speed_and_bearing: HorizontalSpeedAndBearing,
@@ -1072,11 +1071,11 @@ pub struct HorizontalWithVerticalVelocityAndUncertainty {
     pub ie_extensions: Option<HorizontalWithVerticalVelocityAndUncertaintyIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct IMEI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct IMEIGroup {
     pub imei: IMEI,
@@ -1085,15 +1084,15 @@ pub struct IMEIGroup {
     pub ie_extensions: Option<IMEIGroupIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct IMEIList(pub Vec<IMEI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct IMEISV(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct IMEISVGroup {
     pub imeisv: IMEISV,
@@ -1102,13 +1101,13 @@ pub struct IMEISVGroup {
     pub ie_extensions: Option<IMEISVGroupIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct IMEISVList(pub Vec<IMEISV>);
 
 pub type IMSI = TBCD_STRING;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -1117,7 +1116,7 @@ pub type IMSI = TBCD_STRING;
 )]
 pub struct IPMulticastAddress(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 3)]
 pub struct IRAT_Measurement_Configuration {
     #[asn(optional_idx = 0)]
@@ -1129,7 +1128,7 @@ pub struct IRAT_Measurement_Configuration {
     pub ie_extensions: Option<IRAT_Measurement_ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 2)]
 pub struct IRATmeasurementParameters {
     pub measurement_duration: INTEGER_40,
@@ -1139,7 +1138,7 @@ pub struct IRATmeasurementParameters {
     pub ie_extensions: Option<IRATmeasurementParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct ImmediateMDT {
     pub measurements_to_activate: MeasurementsToActivate,
@@ -1151,18 +1150,18 @@ pub struct ImmediateMDT {
     pub ie_extensions: Option<ImmediateMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "0")]
 pub struct IncludeVelocity(pub u8);
 impl IncludeVelocity {
     pub const REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1048575")]
 pub struct InformationExchangeID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct InformationExchangeType(pub u8);
 impl InformationExchangeType {
@@ -1170,7 +1169,7 @@ impl InformationExchangeType {
     pub const REQUEST: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum InformationRequestType {
     #[asn(key = 0, extended = false)]
@@ -1179,7 +1178,7 @@ pub enum InformationRequestType {
     PermanentNAS_UE_ID(PermanentNAS_UE_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum InformationRequested {
     #[asn(key = 0, extended = false)]
@@ -1188,7 +1187,7 @@ pub enum InformationRequested {
     RequestedMulticastServiceList(RequestedMulticastServiceList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InformationTransferConfirmation {
     pub protocol_i_es: InformationTransferConfirmationProtocolIEs,
@@ -1196,7 +1195,7 @@ pub struct InformationTransferConfirmation {
     pub protocol_extensions: Option<InformationTransferConfirmationProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InformationTransferFailure {
     pub protocol_i_es: InformationTransferFailureProtocolIEs,
@@ -1204,11 +1203,11 @@ pub struct InformationTransferFailure {
     pub protocol_extensions: Option<InformationTransferFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1048575")]
 pub struct InformationTransferID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InformationTransferIndication {
     pub protocol_i_es: InformationTransferIndicationProtocolIEs,
@@ -1216,14 +1215,14 @@ pub struct InformationTransferIndication {
     pub protocol_extensions: Option<InformationTransferIndicationProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum InformationTransferType {
     #[asn(key = 0, extended = false)]
     RNCTraceInformation(RNCTraceInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InitialUE_Message {
     pub protocol_i_es: InitialUE_MessageProtocolIEs,
@@ -1231,7 +1230,7 @@ pub struct InitialUE_Message {
     pub protocol_extensions: Option<InitialUE_MessageProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitiatingMessage {
     #[asn(key_field = true)]
@@ -1240,11 +1239,11 @@ pub struct InitiatingMessage {
     pub value: InitiatingMessageValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15")]
 pub struct IntegrityProtectionAlgorithm(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct IntegrityProtectionInformation {
     pub permitted_algorithms: PermittedIntegrityProtectionAlgorithms,
@@ -1253,7 +1252,7 @@ pub struct IntegrityProtectionInformation {
     pub ie_extensions: Option<IntegrityProtectionInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -1262,7 +1261,7 @@ pub struct IntegrityProtectionInformation {
 )]
 pub struct IntegrityProtectionKey(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct InterSystemInformation_TransparentContainer {
     #[asn(optional_idx = 0)]
@@ -1273,14 +1272,14 @@ pub struct InterSystemInformation_TransparentContainer {
     pub ie_extensions: Option<InterSystemInformation_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum InterSystemInformationTransferType {
     #[asn(key = 0, extended = false)]
     RIM_Transfer(RIM_Transfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InterfacesToTraceItem {
     pub interface: ENUMERATED_41,
@@ -1288,7 +1287,7 @@ pub struct InterfacesToTraceItem {
     pub ie_extensions: Option<InterfacesToTraceItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Iu_ReleaseCommand {
     pub protocol_i_es: Iu_ReleaseCommandProtocolIEs,
@@ -1296,7 +1295,7 @@ pub struct Iu_ReleaseCommand {
     pub protocol_extensions: Option<Iu_ReleaseCommandProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Iu_ReleaseComplete {
     pub protocol_i_es: Iu_ReleaseCompleteProtocolIEs,
@@ -1304,7 +1303,7 @@ pub struct Iu_ReleaseComplete {
     pub protocol_extensions: Option<Iu_ReleaseCompleteProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Iu_ReleaseRequest {
     pub protocol_i_es: Iu_ReleaseRequestProtocolIEs,
@@ -1312,11 +1311,11 @@ pub struct Iu_ReleaseRequest {
     pub protocol_extensions: Option<Iu_ReleaseRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "24", sz_ub = "24")]
 pub struct IuSignallingConnectionIdentifier(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum IuTransportAssociation {
     #[asn(key = 0, extended = false)]
@@ -1325,7 +1324,7 @@ pub enum IuTransportAssociation {
     BindingID(BindingID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1334,7 +1333,7 @@ pub enum IuTransportAssociation {
 )]
 pub struct JoinedMBMSBearerService_IEs(pub Vec<JoinedMBMSBearerService_IEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct KeyStatus(pub u8);
 impl KeyStatus {
@@ -1342,11 +1341,11 @@ impl KeyStatus {
     pub const NEW: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct L3_Information(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1355,7 +1354,7 @@ pub struct L3_Information(pub Vec<u8>);
 )]
 pub struct LA_LIST(pub Vec<LA_LIST_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LABased {
     pub lai_list: LAI_List,
@@ -1363,11 +1362,11 @@ pub struct LABased {
     pub ie_extensions: Option<LABasedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct LAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct LAI {
     pub plm_nidentity: PLMNidentity,
@@ -1376,11 +1375,11 @@ pub struct LAI {
     pub ie_extensions: Option<LAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct LAI_List(pub Vec<LAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1389,7 +1388,7 @@ pub struct LAI_List(pub Vec<LAI>);
 )]
 pub struct LAListofIdleModeUEs(pub Vec<LAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -1398,7 +1397,7 @@ pub struct LAListofIdleModeUEs(pub Vec<LAI>);
 )]
 pub struct LHN_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LastKnownServiceArea {
     pub sai: SAI,
@@ -1407,7 +1406,7 @@ pub struct LastKnownServiceArea {
     pub ie_extensions: Option<LastKnownServiceAreaIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LastVisitedUTRANCell_Item {
     pub utran_cell_id: UTRAN_CellID,
@@ -1417,7 +1416,7 @@ pub struct LastVisitedUTRANCell_Item {
     pub ie_extensions: Option<LastVisitedUTRANCell_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1426,7 +1425,7 @@ pub struct LastVisitedUTRANCell_Item {
 )]
 pub struct LeftMBMSBearerService_IEs(pub Vec<LeftMBMSBearerService_IEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct Links_to_log(pub u8);
 impl Links_to_log {
@@ -1435,7 +1434,7 @@ impl Links_to_log {
     pub const BOTH_UPLINK_AND_DOWNLINK: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1444,15 +1443,15 @@ impl Links_to_log {
 )]
 pub struct ListOF_SNAs(pub Vec<SNAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ListOfInterfacesToTrace(pub Vec<InterfacesToTraceItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "100")]
 pub struct LoadValue(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LocationRelatedDataFailure {
     pub protocol_i_es: LocationRelatedDataFailureProtocolIEs,
@@ -1460,7 +1459,7 @@ pub struct LocationRelatedDataFailure {
     pub protocol_extensions: Option<LocationRelatedDataFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LocationRelatedDataRequest {
     pub protocol_i_es: LocationRelatedDataRequestProtocolIEs,
@@ -1468,7 +1467,7 @@ pub struct LocationRelatedDataRequest {
     pub protocol_extensions: Option<LocationRelatedDataRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LocationRelatedDataRequestType {
     pub requested_location_related_data_type: RequestedLocationRelatedDataType,
@@ -1476,7 +1475,7 @@ pub struct LocationRelatedDataRequestType {
     pub requested_gps_assistance_data: Option<RequestedGPSAssistanceData>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct LocationRelatedDataRequestTypeSpecificToGERANIuMode(pub u8);
 impl LocationRelatedDataRequestTypeSpecificToGERANIuMode {
@@ -1485,7 +1484,7 @@ impl LocationRelatedDataRequestTypeSpecificToGERANIuMode {
     pub const DEDICATED_MOBILE_BASED_EOTD_ASSISTANCE_DATA: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LocationRelatedDataResponse {
     pub protocol_i_es: LocationRelatedDataResponseProtocolIEs,
@@ -1493,7 +1492,7 @@ pub struct LocationRelatedDataResponse {
     pub protocol_extensions: Option<LocationRelatedDataResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LocationReport {
     pub protocol_i_es: LocationReportProtocolIEs,
@@ -1501,7 +1500,7 @@ pub struct LocationReport {
     pub protocol_extensions: Option<LocationReportProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LocationReportingControl {
     pub protocol_i_es: LocationReportingControlProtocolIEs,
@@ -1509,7 +1508,7 @@ pub struct LocationReportingControl {
     pub protocol_extensions: Option<LocationReportingControlProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 12)]
 pub struct LocationReportingTransferInformation {
     #[asn(optional_idx = 0)]
@@ -1538,7 +1537,7 @@ pub struct LocationReportingTransferInformation {
     pub ie_extensions: Option<LocationReportingTransferInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LoggedMDT {
     pub logging_interval: LoggingInterval,
@@ -1547,7 +1546,7 @@ pub struct LoggedMDT {
     pub ie_extensions: Option<LoggedMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct LoggingDuration(pub u8);
 impl LoggingDuration {
@@ -1559,7 +1558,7 @@ impl LoggingDuration {
     pub const MIN120: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "7")]
 pub struct LoggingInterval(pub u8);
 impl LoggingInterval {
@@ -1573,7 +1572,7 @@ impl LoggingInterval {
     pub const S61D44: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum M1Report {
     #[asn(key = 0, extended = false)]
@@ -1582,7 +1581,7 @@ pub enum M1Report {
     Event1F(Event1F_Parameters),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum M2Report {
     #[asn(key = 0, extended = false)]
@@ -1591,7 +1590,7 @@ pub enum M2Report {
     Event1I(Event1I_Parameters),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct M4_Collection_Parameters {
     pub m4_period: M4_Period,
@@ -1601,7 +1600,7 @@ pub struct M4_Collection_Parameters {
     pub ie_extensions: Option<M4_Collection_ParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "7")]
 pub struct M4_Period(pub u8);
 impl M4_Period {
@@ -1615,11 +1614,11 @@ impl M4_Period {
     pub const MS6000: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "31")]
 pub struct M4_Threshold(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum M4Report {
     #[asn(key = 0, extended = false)]
@@ -1628,7 +1627,7 @@ pub enum M4Report {
     M4_collection_parameters(M4_Collection_Parameters),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "7")]
 pub struct M5_Period(pub u8);
 impl M5_Period {
@@ -1642,7 +1641,7 @@ impl M5_Period {
     pub const MS6000: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum M5Report {
     #[asn(key = 0, extended = false)]
@@ -1651,7 +1650,7 @@ pub enum M5Report {
     M5_period(M5_Period),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "12")]
 pub struct M6_Period(pub u8);
 impl M6_Period {
@@ -1670,7 +1669,7 @@ impl M6_Period {
     pub const MS64000: u8 = 12u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M6Report {
     pub m6_period: M6_Period,
@@ -1679,7 +1678,7 @@ pub struct M6Report {
     pub ie_extensions: Option<M6ReportIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "12")]
 pub struct M7_Period(pub u8);
 impl M7_Period {
@@ -1698,7 +1697,7 @@ impl M7_Period {
     pub const MS64000: u8 = 12u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M7Report {
     pub m7_period: M7_Period,
@@ -1707,11 +1706,11 @@ pub struct M7Report {
     pub ie_extensions: Option<M7ReportIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct MBMS_PTP_RAB_ID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct MBMSBearerServiceType(pub u8);
 impl MBMSBearerServiceType {
@@ -1719,7 +1718,7 @@ impl MBMSBearerServiceType {
     pub const BROADCAST: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct MBMSCNDe_Registration(pub u8);
 impl MBMSCNDe_Registration {
@@ -1727,7 +1726,7 @@ impl MBMSCNDe_Registration {
     pub const DEREGISTER: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSCNDe_RegistrationRequest {
     pub protocol_i_es: MBMSCNDe_RegistrationRequestProtocolIEs,
@@ -1735,7 +1734,7 @@ pub struct MBMSCNDe_RegistrationRequest {
     pub protocol_extensions: Option<MBMSCNDe_RegistrationRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSCNDe_RegistrationResponse {
     pub protocol_i_es: MBMSCNDe_RegistrationResponseProtocolIEs,
@@ -1743,7 +1742,7 @@ pub struct MBMSCNDe_RegistrationResponse {
     pub protocol_extensions: Option<MBMSCNDe_RegistrationResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct MBMSCountingInformation(pub u8);
 impl MBMSCountingInformation {
@@ -1751,7 +1750,7 @@ impl MBMSCountingInformation {
     pub const NOTCOUNTING: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct MBMSHCIndicator(pub u8);
 impl MBMSHCIndicator {
@@ -1759,7 +1758,7 @@ impl MBMSHCIndicator {
     pub const COMPRESSED_HEADER: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1768,7 +1767,7 @@ impl MBMSHCIndicator {
 )]
 pub struct MBMSIPMulticastAddressandAPNRequest(pub Vec<TMGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSIPMulticastAddressandAPNlist {
     pub tmgi: TMGI,
@@ -1778,14 +1777,14 @@ pub struct MBMSIPMulticastAddressandAPNlist {
     pub ie_extensions: Option<MBMSIPMulticastAddressandAPNlistIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct MBMSLinkingInformation(pub u8);
 impl MBMSLinkingInformation {
     pub const U_E_HAS_JOINED_MULTICAST_SERVICES: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSRABEstablishmentIndication {
     pub protocol_i_es: MBMSRABEstablishmentIndicationProtocolIEs,
@@ -1793,7 +1792,7 @@ pub struct MBMSRABEstablishmentIndication {
     pub protocol_extensions: Option<MBMSRABEstablishmentIndicationProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSRABRelease {
     pub protocol_i_es: MBMSRABReleaseProtocolIEs,
@@ -1801,7 +1800,7 @@ pub struct MBMSRABRelease {
     pub protocol_extensions: Option<MBMSRABReleaseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSRABReleaseFailure {
     pub protocol_i_es: MBMSRABReleaseFailureProtocolIEs,
@@ -1809,7 +1808,7 @@ pub struct MBMSRABReleaseFailure {
     pub protocol_extensions: Option<MBMSRABReleaseFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSRABReleaseRequest {
     pub protocol_i_es: MBMSRABReleaseRequestProtocolIEs,
@@ -1817,7 +1816,7 @@ pub struct MBMSRABReleaseRequest {
     pub protocol_extensions: Option<MBMSRABReleaseRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSRegistrationFailure {
     pub protocol_i_es: MBMSRegistrationFailureProtocolIEs,
@@ -1825,7 +1824,7 @@ pub struct MBMSRegistrationFailure {
     pub protocol_extensions: Option<MBMSRegistrationFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSRegistrationRequest {
     pub protocol_i_es: MBMSRegistrationRequestProtocolIEs,
@@ -1833,7 +1832,7 @@ pub struct MBMSRegistrationRequest {
     pub protocol_extensions: Option<MBMSRegistrationRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct MBMSRegistrationRequestType(pub u8);
 impl MBMSRegistrationRequestType {
@@ -1841,7 +1840,7 @@ impl MBMSRegistrationRequestType {
     pub const DEREGISTER: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSRegistrationResponse {
     pub protocol_i_es: MBMSRegistrationResponseProtocolIEs,
@@ -1849,23 +1848,23 @@ pub struct MBMSRegistrationResponse {
     pub protocol_extensions: Option<MBMSRegistrationResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct MBMSServiceArea(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct MBMSSessionDuration(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct MBMSSessionIdentity(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct MBMSSessionRepetitionNumber(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionStart {
     pub protocol_i_es: MBMSSessionStartProtocolIEs,
@@ -1873,7 +1872,7 @@ pub struct MBMSSessionStart {
     pub protocol_extensions: Option<MBMSSessionStartProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionStartFailure {
     pub protocol_i_es: MBMSSessionStartFailureProtocolIEs,
@@ -1881,7 +1880,7 @@ pub struct MBMSSessionStartFailure {
     pub protocol_extensions: Option<MBMSSessionStartFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionStartResponse {
     pub protocol_i_es: MBMSSessionStartResponseProtocolIEs,
@@ -1889,7 +1888,7 @@ pub struct MBMSSessionStartResponse {
     pub protocol_extensions: Option<MBMSSessionStartResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionStop {
     pub protocol_i_es: MBMSSessionStopProtocolIEs,
@@ -1897,7 +1896,7 @@ pub struct MBMSSessionStop {
     pub protocol_extensions: Option<MBMSSessionStopProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionStopResponse {
     pub protocol_i_es: MBMSSessionStopResponseProtocolIEs,
@@ -1905,7 +1904,7 @@ pub struct MBMSSessionStopResponse {
     pub protocol_extensions: Option<MBMSSessionStopResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionUpdate {
     pub protocol_i_es: MBMSSessionUpdateProtocolIEs,
@@ -1913,7 +1912,7 @@ pub struct MBMSSessionUpdate {
     pub protocol_extensions: Option<MBMSSessionUpdateProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionUpdateFailure {
     pub protocol_i_es: MBMSSessionUpdateFailureProtocolIEs,
@@ -1921,7 +1920,7 @@ pub struct MBMSSessionUpdateFailure {
     pub protocol_extensions: Option<MBMSSessionUpdateFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSessionUpdateResponse {
     pub protocol_i_es: MBMSSessionUpdateResponseProtocolIEs,
@@ -1929,7 +1928,7 @@ pub struct MBMSSessionUpdateResponse {
     pub protocol_extensions: Option<MBMSSessionUpdateResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSSynchronisationInformation {
     pub mbmshc_indicator: MBMSHCIndicator,
@@ -1939,7 +1938,7 @@ pub struct MBMSSynchronisationInformation {
     pub ie_extensions: Option<MBMSSynchronisationInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSUELinkingRequest {
     pub protocol_i_es: MBMSUELinkingRequestProtocolIEs,
@@ -1947,7 +1946,7 @@ pub struct MBMSUELinkingRequest {
     pub protocol_extensions: Option<MBMSUELinkingRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MBMSUELinkingResponse {
     pub protocol_i_es: MBMSUELinkingResponseProtocolIEs,
@@ -1955,7 +1954,7 @@ pub struct MBMSUELinkingResponse {
     pub protocol_extensions: Option<MBMSUELinkingResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct MDT_Activation(pub u8);
 impl MDT_Activation {
@@ -1964,7 +1963,7 @@ impl MDT_Activation {
     pub const IMMEDIATE_MD_TAND_TRACE: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MDT_Configuration {
     pub mdt_activation: MDT_Activation,
@@ -1974,18 +1973,18 @@ pub struct MDT_Configuration {
     pub ie_extensions: Option<MDT_ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct MDT_PLMN_List(pub Vec<PLMNidentity>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MDT_Report_Parameters {
     pub report_interval: ReportInterval,
     pub report_amount: ReportAmount,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = true)]
 pub enum MDTAreaScope {
     #[asn(key = 0, extended = false)]
@@ -1998,7 +1997,7 @@ pub enum MDTAreaScope {
     Plmn_area_based(NULL_45),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum MDTMode {
     #[asn(key = 0, extended = false)]
@@ -2007,26 +2006,26 @@ pub enum MDTMode {
     LoggedMDT(LoggedMDT),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "9")]
 pub struct MSISDN(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Management_Based_MDT_Allowed(pub u8);
 impl Management_Based_MDT_Allowed {
     pub const ALLOWED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "16000000")]
 pub struct MaxBitrate(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "32768")]
 pub struct MaxSDU_Size(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "5")]
 pub struct MeasBand(pub u8);
 impl MeasBand {
@@ -2038,7 +2037,7 @@ impl MeasBand {
     pub const V100: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct MeasurementQuantity(pub u8);
 impl MeasurementQuantity {
@@ -2047,11 +2046,11 @@ impl MeasurementQuantity {
     pub const PATHLOSS: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct MeasurementsToActivate(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2060,27 +2059,27 @@ pub struct MeasurementsToActivate(pub BitVec<u8, Msb0>);
 )]
 pub struct MessageStructure(pub Vec<MessageStructure_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NAS_PDU(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct NAS_SequenceNumber(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct NAS_SynchronisationIndicator(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "3")]
 pub struct NRTLoadInformationValue(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NewBSS_To_OldBSS_Information(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2089,7 +2088,7 @@ pub struct NewBSS_To_OldBSS_Information(pub Vec<u8>);
 )]
 pub struct NewRAListofIdleModeUEs(pub Vec<RAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct NonSearchingIndication(pub u8);
 impl NonSearchingIndication {
@@ -2097,7 +2096,7 @@ impl NonSearchingIndication {
     pub const SEARCHING: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct NotEmptyRAListofIdleModeUEs {
     pub r_aof_idle_mode_u_es: RAofIdleModeUEs,
@@ -2105,19 +2104,19 @@ pub struct NotEmptyRAListofIdleModeUEs {
     pub ie_extensions: Option<NotEmptyRAListofIdleModeUEsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "10", sz_ub = "10")]
 pub struct Null_NRI(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "2")]
 pub struct NumberOfIuInstances(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "16")]
 pub struct NumberOfSteps(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -2126,7 +2125,7 @@ pub struct NumberOfSteps(pub u8);
 )]
 pub struct OMC_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Offload_RAB_Parameters {
     pub access_point_name: Offload_RAB_Parameters_APN,
@@ -2135,7 +2134,7 @@ pub struct Offload_RAB_Parameters {
     pub ie_extensions: Option<Offload_RAB_ParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -2144,22 +2143,22 @@ pub struct Offload_RAB_Parameters {
 )]
 pub struct Offload_RAB_Parameters_APN(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct Offload_RAB_Parameters_ChargingCharacteristics(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OldBSS_ToNewBSS_Information(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Out_Of_UTRAN(pub u8);
 impl Out_Of_UTRAN {
     pub const CELL_RESELECTION_TO_EUTRAN: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Outcome {
     #[asn(key_field = true)]
@@ -2168,7 +2167,7 @@ pub struct Outcome {
     pub value: OutcomeValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Overload {
     pub protocol_i_es: OverloadProtocolIEs,
@@ -2176,11 +2175,11 @@ pub struct Overload {
     pub protocol_extensions: Option<OverloadProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct P_TMSI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct PDP_Type(pub u8);
 impl PDP_Type {
@@ -2191,26 +2190,26 @@ impl PDP_Type {
     pub const IPV6: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct PDP_Type_extension(pub u8);
 impl PDP_Type_extension {
     pub const IPV4_AND_IPV6: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct PDP_TypeInformation(pub Vec<PDP_Type>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct PDP_TypeInformation_extension(pub Vec<PDP_Type_extension>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "3")]
 pub struct PDUType14FrameSequenceNumber(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PLMNBased {
     pub plmn_list: PLMNList,
@@ -2218,17 +2217,17 @@ pub struct PLMNBased {
     pub ie_extensions: Option<PLMNBasedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct PLMNList(pub Vec<PLMNidentity>);
 
 pub type PLMNidentity = TBCD_STRING;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct PLMNs_in_shared_network(pub Vec<PLMNs_in_shared_network_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Paging {
     pub protocol_i_es: PagingProtocolIEs,
@@ -2236,7 +2235,7 @@ pub struct Paging {
     pub protocol_extensions: Option<PagingProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum PagingAreaID {
     #[asn(key = 0, extended = false)]
@@ -2245,7 +2244,7 @@ pub enum PagingAreaID {
     RAI(RAI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct PagingCause(pub u8);
 impl PagingCause {
@@ -2256,7 +2255,7 @@ impl PagingCause {
     pub const TERMINATING_LOW_PRIORITY_SIGNALLING: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PeriodicLocationInfo {
     pub reporting_amount: INTEGER_46,
@@ -2265,7 +2264,7 @@ pub struct PeriodicLocationInfo {
     pub ie_extensions: Option<PeriodicLocationInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct PeriodicReportingIndicator(pub u8);
 impl PeriodicReportingIndicator {
@@ -2273,26 +2272,26 @@ impl PeriodicReportingIndicator {
     pub const PERIODIC_GEO: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum PermanentNAS_UE_ID {
     #[asn(key = 0, extended = false)]
     IMSI(IMSI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct PermittedEncryptionAlgorithms(pub Vec<EncryptionAlgorithm>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct PermittedIntegrityProtectionAlgorithms(pub Vec<IntegrityProtectionAlgorithm>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct Port_Number(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PositionData {
     pub positioning_data_discriminator: PositioningDataDiscriminator,
@@ -2302,23 +2301,23 @@ pub struct PositionData {
     pub ie_extensions: Option<PositionDataIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct PositionDataSpecificToGERANIuMode(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct PositioningDataDiscriminator(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "9")]
 pub struct PositioningDataSet(pub Vec<PositioningMethodAndUsage>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct PositioningMethodAndUsage(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct PositioningPriority(pub u8);
 impl PositioningPriority {
@@ -2326,7 +2325,7 @@ impl PositioningPriority {
     pub const NORMAL_PRIORITY: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct PowerSavingIndicator(pub u8);
 impl PowerSavingIndicator {
@@ -2334,7 +2333,7 @@ impl PowerSavingIndicator {
     pub const E_DRX_CONFIGURED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct Pre_emptionCapability(pub u8);
 impl Pre_emptionCapability {
@@ -2342,7 +2341,7 @@ impl Pre_emptionCapability {
     pub const MAY_TRIGGER_PRE_EMPTION: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct Pre_emptionVulnerability(pub u8);
 impl Pre_emptionVulnerability {
@@ -2350,7 +2349,7 @@ impl Pre_emptionVulnerability {
     pub const PRE_EMPTABLE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct Presence(pub u8);
 impl Presence {
@@ -2359,15 +2358,15 @@ impl Presence {
     pub const MANDATORY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct Priority_Class_Indicator(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15")]
 pub struct PriorityLevel(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum PrivateIE_ID {
     #[asn(key = 0, extended = false)]
@@ -2376,32 +2375,32 @@ pub enum PrivateIE_ID {
     Global(OBJECT_IDENTIFIER_49),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PrivateMessage {
     pub private_i_es: PrivateMessagePrivateIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct ProcedureCode(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct ProtocolExtensionID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct ProtocolIE_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum ProvidedData {
     #[asn(key = 0, extended = false)]
     Shared_network_information(Shared_Network_Information),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct QueuingAllowed(pub u8);
 impl QueuingAllowed {
@@ -2409,7 +2408,7 @@ impl QueuingAllowed {
     pub const QUEUEING_ALLOWED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_AssignmentRequest {
     pub protocol_i_es: RAB_AssignmentRequestProtocolIEs,
@@ -2417,7 +2416,7 @@ pub struct RAB_AssignmentRequest {
     pub protocol_extensions: Option<RAB_AssignmentRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_AssignmentResponse {
     pub protocol_i_es: RAB_AssignmentResponseProtocolIEs,
@@ -2425,7 +2424,7 @@ pub struct RAB_AssignmentResponse {
     pub protocol_extensions: Option<RAB_AssignmentResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct RAB_AsymmetryIndicator(pub u8);
 impl RAB_AsymmetryIndicator {
@@ -2435,7 +2434,7 @@ impl RAB_AsymmetryIndicator {
     pub const ASYMMETRIC_BIDIRECTIONAL: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2444,7 +2443,7 @@ impl RAB_AsymmetryIndicator {
 )]
 pub struct RAB_ContextFailedtoTransferList(pub Vec<RAB_ContextFailedtoTransferList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct RAB_ContextItem {
     pub rab_id: RAB_ID,
@@ -2460,7 +2459,7 @@ pub struct RAB_ContextItem {
     pub ie_extensions: Option<RAB_ContextItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct RAB_ContextItem_RANAP_RelocInf {
     pub rab_id: RAB_ID,
@@ -2476,7 +2475,7 @@ pub struct RAB_ContextItem_RANAP_RelocInf {
     pub ie_extensions: Option<RAB_ContextItem_RANAP_RelocInfIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2485,7 +2484,7 @@ pub struct RAB_ContextItem_RANAP_RelocInf {
 )]
 pub struct RAB_ContextList(pub Vec<RAB_ContextList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2494,7 +2493,7 @@ pub struct RAB_ContextList(pub Vec<RAB_ContextList_Entry>);
 )]
 pub struct RAB_ContextList_RANAP_RelocInf(pub Vec<RAB_ContextList_RANAP_RelocInf_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_DataForwardingItem {
     pub rab_id: RAB_ID,
@@ -2504,7 +2503,7 @@ pub struct RAB_DataForwardingItem {
     pub ie_extensions: Option<RAB_DataForwardingItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_DataForwardingItem_SRNS_CtxReq {
     pub rab_id: RAB_ID,
@@ -2512,7 +2511,7 @@ pub struct RAB_DataForwardingItem_SRNS_CtxReq {
     pub ie_extensions: Option<RAB_DataForwardingItem_SRNS_CtxReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2521,7 +2520,7 @@ pub struct RAB_DataForwardingItem_SRNS_CtxReq {
 )]
 pub struct RAB_DataForwardingList(pub Vec<RAB_DataForwardingList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2530,7 +2529,7 @@ pub struct RAB_DataForwardingList(pub Vec<RAB_DataForwardingList_Entry>);
 )]
 pub struct RAB_DataForwardingList_SRNS_CtxReq(pub Vec<RAB_DataForwardingList_SRNS_CtxReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct RAB_DataVolumeReportItem {
     pub rab_id: RAB_ID,
@@ -2540,7 +2539,7 @@ pub struct RAB_DataVolumeReportItem {
     pub ie_extensions: Option<RAB_DataVolumeReportItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2549,7 +2548,7 @@ pub struct RAB_DataVolumeReportItem {
 )]
 pub struct RAB_DataVolumeReportList(pub Vec<RAB_DataVolumeReportList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_DataVolumeReportRequestItem {
     pub rab_id: RAB_ID,
@@ -2557,7 +2556,7 @@ pub struct RAB_DataVolumeReportRequestItem {
     pub ie_extensions: Option<RAB_DataVolumeReportRequestItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2566,7 +2565,7 @@ pub struct RAB_DataVolumeReportRequestItem {
 )]
 pub struct RAB_DataVolumeReportRequestList(pub Vec<RAB_DataVolumeReportRequestList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_FailedItem {
     pub rab_id: RAB_ID,
@@ -2575,7 +2574,7 @@ pub struct RAB_FailedItem {
     pub ie_extensions: Option<RAB_FailedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_FailedItem_EnhRelocInfoRes {
     pub cn_domain_indicator: CN_DomainIndicator,
@@ -2585,7 +2584,7 @@ pub struct RAB_FailedItem_EnhRelocInfoRes {
     pub ie_extensions: Option<RAB_FailedItem_EnhRelocInfoResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2594,7 +2593,7 @@ pub struct RAB_FailedItem_EnhRelocInfoRes {
 )]
 pub struct RAB_FailedList(pub Vec<RAB_FailedList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2603,7 +2602,7 @@ pub struct RAB_FailedList(pub Vec<RAB_FailedList_Entry>);
 )]
 pub struct RAB_FailedList_EnhRelocInfoRes(pub Vec<RAB_FailedList_EnhRelocInfoRes_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2612,11 +2611,11 @@ pub struct RAB_FailedList_EnhRelocInfoRes(pub Vec<RAB_FailedList_EnhRelocInfoRes
 )]
 pub struct RAB_FailedtoReportList(pub Vec<RAB_FailedtoReportList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct RAB_ID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_ModifyItem {
     pub rab_id: RAB_ID,
@@ -2625,7 +2624,7 @@ pub struct RAB_ModifyItem {
     pub ie_extensions: Option<RAB_ModifyItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2634,7 +2633,7 @@ pub struct RAB_ModifyItem {
 )]
 pub struct RAB_ModifyList(pub Vec<RAB_ModifyList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_ModifyRequest {
     pub protocol_i_es: RAB_ModifyRequestProtocolIEs,
@@ -2642,23 +2641,23 @@ pub struct RAB_ModifyRequest {
     pub protocol_extensions: Option<RAB_ModifyRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct RAB_Parameter_ExtendedGuaranteedBitrateList(pub Vec<ExtendedGuaranteedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct RAB_Parameter_ExtendedMaxBitrateList(pub Vec<ExtendedMaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct RAB_Parameter_GuaranteedBitrateList(pub Vec<GuaranteedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct RAB_Parameter_MaxBitrateList(pub Vec<MaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 7)]
 pub struct RAB_Parameters {
     pub traffic_class: TrafficClass,
@@ -2683,7 +2682,7 @@ pub struct RAB_Parameters {
     pub ie_extensions: Option<RAB_ParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_QueuedItem {
     pub rab_id: RAB_ID,
@@ -2691,7 +2690,7 @@ pub struct RAB_QueuedItem {
     pub ie_extensions: Option<RAB_QueuedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2702,7 +2701,7 @@ pub struct RAB_QueuedList(pub Vec<RAB_QueuedList_Entry>);
 
 pub type RAB_ReleaseFailedList = RAB_FailedList;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_ReleaseItem {
     pub rab_id: RAB_ID,
@@ -2711,7 +2710,7 @@ pub struct RAB_ReleaseItem {
     pub ie_extensions: Option<RAB_ReleaseItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2720,7 +2719,7 @@ pub struct RAB_ReleaseItem {
 )]
 pub struct RAB_ReleaseList(pub Vec<RAB_ReleaseList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_ReleaseRequest {
     pub protocol_i_es: RAB_ReleaseRequestProtocolIEs,
@@ -2728,7 +2727,7 @@ pub struct RAB_ReleaseRequest {
     pub protocol_extensions: Option<RAB_ReleaseRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct RAB_ReleasedItem {
     pub rab_id: RAB_ID,
@@ -2742,7 +2741,7 @@ pub struct RAB_ReleasedItem {
     pub ie_extensions: Option<RAB_ReleasedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct RAB_ReleasedItem_IuRelComp {
     pub rab_id: RAB_ID,
@@ -2754,7 +2753,7 @@ pub struct RAB_ReleasedItem_IuRelComp {
     pub ie_extensions: Option<RAB_ReleasedItem_IuRelCompIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2763,7 +2762,7 @@ pub struct RAB_ReleasedItem_IuRelComp {
 )]
 pub struct RAB_ReleasedList(pub Vec<RAB_ReleasedList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2772,7 +2771,7 @@ pub struct RAB_ReleasedList(pub Vec<RAB_ReleasedList_Entry>);
 )]
 pub struct RAB_ReleasedList_IuRelComp(pub Vec<RAB_ReleasedList_IuRelComp_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_RelocationReleaseItem {
     pub rab_id: RAB_ID,
@@ -2780,7 +2779,7 @@ pub struct RAB_RelocationReleaseItem {
     pub ie_extensions: Option<RAB_RelocationReleaseItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2789,7 +2788,7 @@ pub struct RAB_RelocationReleaseItem {
 )]
 pub struct RAB_RelocationReleaseList(pub Vec<RAB_RelocationReleaseList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 7)]
 pub struct RAB_SetupItem_EnhRelocInfoReq {
     pub rab_id: RAB_ID,
@@ -2812,7 +2811,7 @@ pub struct RAB_SetupItem_EnhRelocInfoReq {
     pub ie_extensions: Option<RAB_SetupItem_EnhRelocInfoReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct RAB_SetupItem_EnhRelocInfoRes {
     pub cn_domain_indicator: CN_DomainIndicator,
@@ -2825,7 +2824,7 @@ pub struct RAB_SetupItem_EnhRelocInfoRes {
     pub ie_extensions: Option<RAB_SetupItem_EnhRelocInfoResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct RAB_SetupItem_EnhancedRelocCompleteReq {
     pub rab_id: RAB_ID,
@@ -2839,7 +2838,7 @@ pub struct RAB_SetupItem_EnhancedRelocCompleteReq {
     pub ie_extensions: Option<RAB_SetupItem_EnhancedRelocCompleteReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct RAB_SetupItem_EnhancedRelocCompleteRes {
     pub rab_id: RAB_ID,
@@ -2856,7 +2855,7 @@ pub struct RAB_SetupItem_EnhancedRelocCompleteRes {
     pub ie_extensions: Option<RAB_SetupItem_EnhancedRelocCompleteResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct RAB_SetupItem_RelocReq {
     pub rab_id: RAB_ID,
@@ -2876,7 +2875,7 @@ pub struct RAB_SetupItem_RelocReq {
     pub ie_extensions: Option<RAB_SetupItem_RelocReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct RAB_SetupItem_RelocReqAck {
     pub rab_id: RAB_ID,
@@ -2888,7 +2887,7 @@ pub struct RAB_SetupItem_RelocReqAck {
     pub ie_extensions: Option<RAB_SetupItem_RelocReqAckIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2897,7 +2896,7 @@ pub struct RAB_SetupItem_RelocReqAck {
 )]
 pub struct RAB_SetupList_EnhRelocInfoReq(pub Vec<RAB_SetupList_EnhRelocInfoReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2906,7 +2905,7 @@ pub struct RAB_SetupList_EnhRelocInfoReq(pub Vec<RAB_SetupList_EnhRelocInfoReq_E
 )]
 pub struct RAB_SetupList_EnhRelocInfoRes(pub Vec<RAB_SetupList_EnhRelocInfoRes_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2917,7 +2916,7 @@ pub struct RAB_SetupList_EnhancedRelocCompleteReq(
     pub Vec<RAB_SetupList_EnhancedRelocCompleteReq_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2928,7 +2927,7 @@ pub struct RAB_SetupList_EnhancedRelocCompleteRes(
     pub Vec<RAB_SetupList_EnhancedRelocCompleteRes_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2937,7 +2936,7 @@ pub struct RAB_SetupList_EnhancedRelocCompleteRes(
 )]
 pub struct RAB_SetupList_RelocReq(pub Vec<RAB_SetupList_RelocReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2946,7 +2945,7 @@ pub struct RAB_SetupList_RelocReq(pub Vec<RAB_SetupList_RelocReq_Entry>);
 )]
 pub struct RAB_SetupList_RelocReqAck(pub Vec<RAB_SetupList_RelocReqAck_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct RAB_SetupOrModifiedItem {
     pub rab_id: RAB_ID,
@@ -2960,7 +2959,7 @@ pub struct RAB_SetupOrModifiedItem {
     pub ie_extensions: Option<RAB_SetupOrModifiedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2969,7 +2968,7 @@ pub struct RAB_SetupOrModifiedItem {
 )]
 pub struct RAB_SetupOrModifiedList(pub Vec<RAB_SetupOrModifiedList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 6)]
 pub struct RAB_SetupOrModifyItemFirst {
     pub rab_id: RAB_ID,
@@ -2987,7 +2986,7 @@ pub struct RAB_SetupOrModifyItemFirst {
     pub ie_extensions: Option<RAB_SetupOrModifyItemFirstIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 7)]
 pub struct RAB_SetupOrModifyItemSecond {
     #[asn(optional_idx = 0)]
@@ -3006,7 +3005,7 @@ pub struct RAB_SetupOrModifyItemSecond {
     pub ie_extensions: Option<RAB_SetupOrModifyItemSecondIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3015,11 +3014,11 @@ pub struct RAB_SetupOrModifyItemSecond {
 )]
 pub struct RAB_SetupOrModifyList(pub Vec<RAB_SetupOrModifyList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "16000000")]
 pub struct RAB_SubflowCombinationBitRate(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_ToBeReleasedItem_EnhancedRelocCompleteRes {
     pub rab_id: RAB_ID,
@@ -3028,7 +3027,7 @@ pub struct RAB_ToBeReleasedItem_EnhancedRelocCompleteRes {
     pub ie_extensions: Option<RAB_ToBeReleasedItem_EnhancedRelocCompleteResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3039,7 +3038,7 @@ pub struct RAB_ToBeReleasedList_EnhancedRelocCompleteRes(
     pub Vec<RAB_ToBeReleasedList_EnhancedRelocCompleteRes_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3048,7 +3047,7 @@ pub struct RAB_ToBeReleasedList_EnhancedRelocCompleteRes(
 )]
 pub struct RAB_TrCH_Mapping(pub Vec<RAB_TrCH_MappingItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAB_TrCH_MappingItem {
     pub rab_id: RAB_ID,
@@ -3057,11 +3056,11 @@ pub struct RAB_TrCH_MappingItem {
     pub ie_extensions: Option<RAB_TrCH_MappingItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct RABDataVolumeReport(pub Vec<RABDataVolumeReport_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3070,7 +3069,7 @@ pub struct RABDataVolumeReport(pub Vec<RABDataVolumeReport_Entry>);
 )]
 pub struct RABParametersList(pub Vec<RABParametersList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RABased {
     pub rai_list: RAI_List,
@@ -3078,7 +3077,7 @@ pub struct RABased {
     pub ie_extensions: Option<RABasedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RABs_ContextFailedtoTransferItem {
     pub rab_id: RAB_ID,
@@ -3087,7 +3086,7 @@ pub struct RABs_ContextFailedtoTransferItem {
     pub ie_extensions: Option<RABs_ContextFailedtoTransferItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RABs_failed_to_reportItem {
     pub rab_id: RAB_ID,
@@ -3096,11 +3095,11 @@ pub struct RABs_failed_to_reportItem {
     pub ie_extensions: Option<RABs_failed_to_reportItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct RAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RAI {
     pub lai: LAI,
@@ -3109,11 +3108,11 @@ pub struct RAI {
     pub ie_extensions: Option<RAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct RAI_List(pub Vec<RAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum RAListofIdleModeUEs {
     #[asn(key = 0, extended = false)]
@@ -3122,7 +3121,7 @@ pub enum RAListofIdleModeUEs {
     EmptyFullRAListofIdleModeUEs(ENUMERATED_50),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3131,7 +3130,7 @@ pub enum RAListofIdleModeUEs {
 )]
 pub struct RAListwithNoIdleModeUEsAnyMore(pub Vec<RAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RANAP_EnhancedRelocationInformationRequest {
     pub protocol_i_es: RANAP_EnhancedRelocationInformationRequestProtocolIEs,
@@ -3139,7 +3138,7 @@ pub struct RANAP_EnhancedRelocationInformationRequest {
     pub protocol_extensions: Option<RANAP_EnhancedRelocationInformationRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RANAP_EnhancedRelocationInformationResponse {
     pub protocol_i_es: RANAP_EnhancedRelocationInformationResponseProtocolIEs,
@@ -3147,7 +3146,7 @@ pub struct RANAP_EnhancedRelocationInformationResponse {
     pub protocol_extensions: Option<RANAP_EnhancedRelocationInformationResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = true)]
 pub enum RANAP_PDU {
     #[asn(key = 0, extended = false)]
@@ -3160,7 +3159,7 @@ pub enum RANAP_PDU {
     Outcome(Outcome),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RANAP_RelocationInformation {
     pub protocol_i_es: RANAP_RelocationInformationProtocolIEs,
@@ -3168,7 +3167,7 @@ pub struct RANAP_RelocationInformation {
     pub protocol_extensions: Option<RANAP_RelocationInformationProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct RAT_Type(pub u8);
 impl RAT_Type {
@@ -3176,7 +3175,7 @@ impl RAT_Type {
     pub const GERAN: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3185,7 +3184,7 @@ impl RAT_Type {
 )]
 pub struct RAofIdleModeUEs(pub Vec<RAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 2)]
 pub struct RIM_Transfer {
     pub rim_information: RIMInformation,
@@ -3195,11 +3194,11 @@ pub struct RIM_Transfer {
     pub ie_extensions: Option<RIM_TransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct RIMInformation(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum RIMRoutingAddress {
     #[asn(key = 0, extended = false)]
@@ -3210,11 +3209,11 @@ pub enum RIMRoutingAddress {
     TargeteNB_ID(TargetENB_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct RNC_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 2)]
 pub struct RNCTraceInformation {
     pub trace_reference: TraceReference,
@@ -3225,7 +3224,7 @@ pub struct RNCTraceInformation {
     pub ie_extensions: Option<RNCTraceInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct RNSAPRelocationParameters {
     #[asn(optional_idx = 0)]
@@ -3240,29 +3239,29 @@ pub struct RNSAPRelocationParameters {
     pub ie_extensions: Option<RNSAPRelocationParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct RRC_Container(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "-30", ub = "46", extensible = true)]
 pub struct RSRQ_Extension(pub i8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RSRQ_Type {
     pub all_symbols: BOOLEAN_52,
     pub wide_band: BOOLEAN_53,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct RSRVCC_HO_Indication(pub u8);
 impl RSRVCC_HO_Indication {
     pub const PS_ONLY: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RSRVCC_Information {
     pub nonce: BIT_STRING_54,
@@ -3271,18 +3270,18 @@ pub struct RSRVCC_Information {
     pub ie_extensions: Option<RSRVCC_InformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct RSRVCC_Operation_Possible(pub u8);
 impl RSRVCC_Operation_Possible {
     pub const RSRVCC_POSSIBLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "100")]
 pub struct RTLoadValue(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct RateControlAllowed(pub u8);
 impl RateControlAllowed {
@@ -3290,18 +3289,18 @@ impl RateControlAllowed {
     pub const ALLOWED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct RedirectAttemptFlag;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct RedirectionCompleted(pub u8);
 impl RedirectionCompleted {
     pub const REDIRECTION_COMPLETED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3310,7 +3309,7 @@ impl RedirectionCompleted {
 )]
 pub struct RedirectionIndication(pub Vec<RedirectionIndication_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct RejectCauseValue(pub u8);
 impl RejectCauseValue {
@@ -3322,7 +3321,7 @@ impl RejectCauseValue {
     pub const C_S_PS_COORDINATION_REQUIRED: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationCancel {
     pub protocol_i_es: RelocationCancelProtocolIEs,
@@ -3330,7 +3329,7 @@ pub struct RelocationCancel {
     pub protocol_extensions: Option<RelocationCancelProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationCancelAcknowledge {
     pub protocol_i_es: RelocationCancelAcknowledgeProtocolIEs,
@@ -3338,7 +3337,7 @@ pub struct RelocationCancelAcknowledge {
     pub protocol_extensions: Option<RelocationCancelAcknowledgeProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationCommand {
     pub protocol_i_es: RelocationCommandProtocolIEs,
@@ -3346,7 +3345,7 @@ pub struct RelocationCommand {
     pub protocol_extensions: Option<RelocationCommandProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationComplete {
     pub protocol_i_es: RelocationCompleteProtocolIEs,
@@ -3354,7 +3353,7 @@ pub struct RelocationComplete {
     pub protocol_extensions: Option<RelocationCompleteProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationDetect {
     pub protocol_i_es: RelocationDetectProtocolIEs,
@@ -3362,7 +3361,7 @@ pub struct RelocationDetect {
     pub protocol_extensions: Option<RelocationDetectProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationFailure {
     pub protocol_i_es: RelocationFailureProtocolIEs,
@@ -3370,7 +3369,7 @@ pub struct RelocationFailure {
     pub protocol_extensions: Option<RelocationFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationPreparationFailure {
     pub protocol_i_es: RelocationPreparationFailureProtocolIEs,
@@ -3378,7 +3377,7 @@ pub struct RelocationPreparationFailure {
     pub protocol_extensions: Option<RelocationPreparationFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationRequest {
     pub protocol_i_es: RelocationRequestProtocolIEs,
@@ -3386,7 +3385,7 @@ pub struct RelocationRequest {
     pub protocol_extensions: Option<RelocationRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationRequestAcknowledge {
     pub protocol_i_es: RelocationRequestAcknowledgeProtocolIEs,
@@ -3394,7 +3393,7 @@ pub struct RelocationRequestAcknowledge {
     pub protocol_extensions: Option<RelocationRequestAcknowledgeProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RelocationRequired {
     pub protocol_i_es: RelocationRequiredProtocolIEs,
@@ -3402,7 +3401,7 @@ pub struct RelocationRequired {
     pub protocol_extensions: Option<RelocationRequiredProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct RelocationRequirement(pub u8);
 impl RelocationRequirement {
@@ -3410,7 +3409,7 @@ impl RelocationRequirement {
     pub const NONE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct RelocationType(pub u8);
 impl RelocationType {
@@ -3418,15 +3417,15 @@ impl RelocationType {
     pub const UE_INVOLVED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct RepetitionNumber0(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "256")]
 pub struct RepetitionNumber1(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "7")]
 pub struct ReportAmount(pub u8);
 impl ReportAmount {
@@ -3440,7 +3439,7 @@ impl ReportAmount {
     pub const INFINITY: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ReportArea(pub u8);
 impl ReportArea {
@@ -3448,14 +3447,14 @@ impl ReportArea {
     pub const GEOGRAPHICAL_AREA: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ReportChangeOfSAI(pub u8);
 impl ReportChangeOfSAI {
     pub const REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "12")]
 pub struct ReportInterval(pub u8);
 impl ReportInterval {
@@ -3474,7 +3473,7 @@ impl ReportInterval {
     pub const MS64000: u8 = 12u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RequestType {
     pub event: Event,
@@ -3483,25 +3482,25 @@ pub struct RequestType {
     pub accuracy_code: Option<INTEGER_56>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Requested_RAB_Parameter_ExtendedGuaranteedBitrateList(
     pub Vec<ExtendedGuaranteedBitrate>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Requested_RAB_Parameter_ExtendedMaxBitrateList(pub Vec<ExtendedMaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Requested_RAB_Parameter_GuaranteedBitrateList(pub Vec<GuaranteedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct Requested_RAB_Parameter_MaxBitrateList(pub Vec<MaxBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct Requested_RAB_Parameter_Values {
     #[asn(optional_idx = 0)]
@@ -3512,7 +3511,7 @@ pub struct Requested_RAB_Parameter_Values {
     pub ie_extensions: Option<Requested_RAB_Parameter_ValuesIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -3521,7 +3520,7 @@ pub struct Requested_RAB_Parameter_Values {
 )]
 pub struct RequestedGANSSAssistanceData(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -3530,7 +3529,7 @@ pub struct RequestedGANSSAssistanceData(pub Vec<u8>);
 )]
 pub struct RequestedGPSAssistanceData(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct RequestedLocationRelatedDataType(pub u8);
 impl RequestedLocationRelatedDataType {
@@ -3540,7 +3539,7 @@ impl RequestedLocationRelatedDataType {
     pub const DEDICATED_ASSISTANCE_DATA_ASSISTED_GPS: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3549,7 +3548,7 @@ impl RequestedLocationRelatedDataType {
 )]
 pub struct RequestedMBMSIPMulticastAddressandAPNRequest(pub Vec<MBMSIPMulticastAddressandAPNlist>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3558,7 +3557,7 @@ pub struct RequestedMBMSIPMulticastAddressandAPNRequest(pub Vec<MBMSIPMulticastA
 )]
 pub struct RequestedMulticastServiceList(pub Vec<TMGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RerouteNASRequest {
     pub protocol_i_es: RerouteNASRequestProtocolIEs,
@@ -3566,7 +3565,7 @@ pub struct RerouteNASRequest {
     pub protocol_extensions: Option<RerouteNASRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Reset {
     pub protocol_i_es: ResetProtocolIEs,
@@ -3574,7 +3573,7 @@ pub struct Reset {
     pub protocol_extensions: Option<ResetProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ResetAcknowledge {
     pub protocol_i_es: ResetAcknowledgeProtocolIEs,
@@ -3582,7 +3581,7 @@ pub struct ResetAcknowledge {
     pub protocol_extensions: Option<ResetAcknowledgeProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ResetResource {
     pub protocol_i_es: ResetResourceProtocolIEs,
@@ -3590,7 +3589,7 @@ pub struct ResetResource {
     pub protocol_extensions: Option<ResetResourceProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ResetResourceAckItem {
     pub iu_sig_con_id: IuSignallingConnectionIdentifier,
@@ -3598,7 +3597,7 @@ pub struct ResetResourceAckItem {
     pub ie_extensions: Option<ResetResourceAckItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3607,7 +3606,7 @@ pub struct ResetResourceAckItem {
 )]
 pub struct ResetResourceAckList(pub Vec<ResetResourceAckList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ResetResourceAcknowledge {
     pub protocol_i_es: ResetResourceAcknowledgeProtocolIEs,
@@ -3615,7 +3614,7 @@ pub struct ResetResourceAcknowledge {
     pub protocol_extensions: Option<ResetResourceAcknowledgeProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ResetResourceItem {
     pub iu_sig_con_id: IuSignallingConnectionIdentifier,
@@ -3623,7 +3622,7 @@ pub struct ResetResourceItem {
     pub ie_extensions: Option<ResetResourceItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3632,7 +3631,7 @@ pub struct ResetResourceItem {
 )]
 pub struct ResetResourceList(pub Vec<ResetResourceList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct ResidualBitErrorRatio {
     pub mantissa: INTEGER_57,
@@ -3641,7 +3640,7 @@ pub struct ResidualBitErrorRatio {
     pub ie_extensions: Option<ResidualBitErrorRatioIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ResponseTime(pub u8);
 impl ResponseTime {
@@ -3649,11 +3648,11 @@ impl ResponseTime {
     pub const DELAYTOLERANT: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct SAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct SAI {
     pub plm_nidentity: PLMNidentity,
@@ -3663,7 +3662,7 @@ pub struct SAI {
     pub ie_extensions: Option<SAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SAPI(pub u8);
 impl SAPI {
@@ -3671,7 +3670,7 @@ impl SAPI {
     pub const SAPI_3: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct SDU_ErrorRatio {
     pub mantissa: INTEGER_59,
@@ -3680,19 +3679,19 @@ pub struct SDU_ErrorRatio {
     pub ie_extensions: Option<SDU_ErrorRatioIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct SDU_FormatInformationParameters(pub Vec<SDU_FormatInformationParameters_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "7")]
 pub struct SDU_Parameters(pub Vec<SDU_Parameters_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct SGSN_Group_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum SGSN_Group_Identity {
     #[asn(key = 0, extended = false)]
@@ -3701,7 +3700,7 @@ pub enum SGSN_Group_Identity {
     SGSN_Group_ID(SGSN_Group_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SNA_Access_Information {
     pub authorised_plm_ns: AuthorisedPLMNs,
@@ -3709,19 +3708,19 @@ pub struct SNA_Access_Information {
     pub ie_extensions: Option<SNA_Access_InformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct SNAC(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "32")]
 pub struct SRB_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct SRB_TrCH_Mapping(pub Vec<SRB_TrCH_MappingItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SRB_TrCH_MappingItem {
     pub srb_id: SRB_ID,
@@ -3730,7 +3729,7 @@ pub struct SRB_TrCH_MappingItem {
     pub ie_extensions: Option<SRB_TrCH_MappingItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SRNS_ContextRequest {
     pub protocol_i_es: SRNS_ContextRequestProtocolIEs,
@@ -3738,7 +3737,7 @@ pub struct SRNS_ContextRequest {
     pub protocol_extensions: Option<SRNS_ContextRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SRNS_ContextResponse {
     pub protocol_i_es: SRNS_ContextResponseProtocolIEs,
@@ -3746,7 +3745,7 @@ pub struct SRNS_ContextResponse {
     pub protocol_extensions: Option<SRNS_ContextResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SRNS_DataForwardCommand {
     pub protocol_i_es: SRNS_DataForwardCommandProtocolIEs,
@@ -3754,7 +3753,7 @@ pub struct SRNS_DataForwardCommand {
     pub protocol_extensions: Option<SRNS_DataForwardCommandProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SRVCC_CSKeysRequest {
     pub protocol_i_es: SRVCC_CSKeysRequestProtocolIEs,
@@ -3762,7 +3761,7 @@ pub struct SRVCC_CSKeysRequest {
     pub protocol_extensions: Option<SRVCC_CSKeysRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SRVCC_CSKeysResponse {
     pub protocol_i_es: SRVCC_CSKeysResponseProtocolIEs,
@@ -3770,7 +3769,7 @@ pub struct SRVCC_CSKeysResponse {
     pub protocol_extensions: Option<SRVCC_CSKeysResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SRVCC_HO_Indication(pub u8);
 impl SRVCC_HO_Indication {
@@ -3778,7 +3777,7 @@ impl SRVCC_HO_Indication {
     pub const CS_ONLY: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SRVCC_Information {
     pub nonce: BIT_STRING_61,
@@ -3786,21 +3785,21 @@ pub struct SRVCC_Information {
     pub ie_extensions: Option<SRVCC_InformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SRVCC_Operation_Possible(pub u8);
 impl SRVCC_Operation_Possible {
     pub const SRVCC_POSSIBLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SRVCCSource(pub u8);
 impl SRVCCSource {
     pub const V5_G: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SecurityModeCommand {
     pub protocol_i_es: SecurityModeCommandProtocolIEs,
@@ -3808,7 +3807,7 @@ pub struct SecurityModeCommand {
     pub protocol_extensions: Option<SecurityModeCommandProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SecurityModeComplete {
     pub protocol_i_es: SecurityModeCompleteProtocolIEs,
@@ -3816,7 +3815,7 @@ pub struct SecurityModeComplete {
     pub protocol_extensions: Option<SecurityModeCompleteProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SecurityModeReject {
     pub protocol_i_es: SecurityModeRejectProtocolIEs,
@@ -3824,7 +3823,7 @@ pub struct SecurityModeReject {
     pub protocol_extensions: Option<SecurityModeRejectProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct Service_Handover(pub u8);
 impl Service_Handover {
@@ -3833,7 +3832,7 @@ impl Service_Handover {
     pub const HANDOVER_TO_GSM_SHALL_NOT_BE_PERFORMED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ServiceType(pub u8);
 impl ServiceType {
@@ -3841,18 +3840,18 @@ impl ServiceType {
     pub const Q_MC_FOR_MSTI_SERVICE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Session_Re_establishment_Indicator(pub u8);
 impl Session_Re_establishment_Indicator {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1048575")]
 pub struct SessionUpdateID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Shared_Network_Information {
     pub plm_ns_in_shared_network: PLMNs_in_shared_network,
@@ -3860,22 +3859,22 @@ pub struct Shared_Network_Information {
     pub ie_extensions: Option<Shared_Network_InformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SignallingIndication(pub u8);
 impl SignallingIndication {
     pub const SIGNALLING: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Source_ToTarget_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct SourceBSS_ToTargetBSS_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum SourceCellID {
     #[asn(key = 0, extended = false)]
@@ -3884,7 +3883,7 @@ pub enum SourceCellID {
     SourceGERANCellID(CGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum SourceID {
     #[asn(key = 0, extended = false)]
@@ -3893,7 +3892,7 @@ pub enum SourceID {
     SAI(SAI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct SourceRNC_ID {
     pub plm_nidentity: PLMNidentity,
@@ -3902,7 +3901,7 @@ pub struct SourceRNC_ID {
     pub ie_extensions: Option<SourceRNC_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 10)]
 pub struct SourceRNC_ToTargetRNC_TransparentContainer {
     pub rrc_container: RRC_Container,
@@ -3930,7 +3929,7 @@ pub struct SourceRNC_ToTargetRNC_TransparentContainer {
     pub ie_extensions: Option<SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SourceStatisticsDescriptor(pub u8);
 impl SourceStatisticsDescriptor {
@@ -3938,7 +3937,7 @@ impl SourceStatisticsDescriptor {
     pub const UNKNOWN: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct SourceUTRANCellID {
     pub plm_nidentity: PLMNidentity,
@@ -3947,19 +3946,19 @@ pub struct SourceUTRANCellID {
     pub ie_extensions: Option<SourceUTRANCellIDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct SourceeNodeB_ToTargeteNodeB_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct SubflowSDU_Size(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "256")]
 pub struct SubscriberProfileIDforRFP(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SuccessfulOutcome {
     #[asn(key_field = true)]
@@ -3968,19 +3967,19 @@ pub struct SuccessfulOutcome {
     pub value: SuccessfulOutcomeValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "1000000000", extensible = true)]
 pub struct SupportedBitrate(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct SupportedRAB_ParameterBitrateList(pub Vec<SupportedBitrate>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct TAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct TAI {
     pub plm_nidentity: PLMNidentity,
@@ -3989,11 +3988,11 @@ pub struct TAI {
     pub ie_extensions: Option<TAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TBCD_STRING(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct TMGI {
     pub plm_nidentity: PLMNidentity,
@@ -4002,11 +4001,11 @@ pub struct TMGI {
     pub ie_extensions: Option<TMGIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct TMSI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TNLInformationEnhRelInfoReq {
     pub transport_layer_address: TransportLayerAddress,
@@ -4015,7 +4014,7 @@ pub struct TNLInformationEnhRelInfoReq {
     pub ie_extensions: Option<TNLInformationEnhRelInfoReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TNLInformationEnhRelInfoRes {
     pub dl_forwarding_transport_layer_address: TransportLayerAddress,
@@ -4024,19 +4023,19 @@ pub struct TNLInformationEnhRelInfoRes {
     pub ie_extensions: Option<TNLInformationEnhRelInfoResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Target_ToSource_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TargetBSS_ToSourceBSS_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "268435455")]
 pub struct TargetCellId(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargetENB_ID {
     pub plm_nidentity: PLMNidentity,
@@ -4046,7 +4045,7 @@ pub struct TargetENB_ID {
     pub selected_tai: TAI,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum TargetID {
     #[asn(key = 0, extended = false)]
@@ -4057,7 +4056,7 @@ pub enum TargetID {
     TargeteNB_ID(TargetENB_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 2)]
 pub struct TargetRNC_ID {
     pub lai: LAI,
@@ -4068,7 +4067,7 @@ pub struct TargetRNC_ID {
     pub ie_extensions: Option<TargetRNC_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TargetRNC_ToSourceRNC_TransparentContainer {
     pub rrc_container: RRC_Container,
@@ -4078,11 +4077,11 @@ pub struct TargetRNC_ToSourceRNC_TransparentContainer {
     pub ie_extensions: Option<TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TargeteNodeB_ToSourceeNodeB_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum TemporaryUE_ID {
     #[asn(key = 0, extended = false)]
@@ -4091,23 +4090,23 @@ pub enum TemporaryUE_ID {
     P_TMSI(P_TMSI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct Time_UE_StayedInCell(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "40950")]
 pub struct Time_UE_StayedInCell_EnhancedGranularity(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct TimeToMBMSDataTransfer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct TimingDifferenceULDL(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct TrCH_ID {
     #[asn(optional_idx = 0)]
@@ -4120,11 +4119,11 @@ pub struct TrCH_ID {
     pub ie_extensions: Option<TrCH_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "7")]
 pub struct TrCH_ID_List(pub Vec<TrCH_ID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct TraceDepth(pub u8);
 impl TraceDepth {
@@ -4133,7 +4132,7 @@ impl TraceDepth {
     pub const MAXIMUM: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TraceInformation {
     pub trace_reference: TraceReference,
@@ -4144,7 +4143,7 @@ pub struct TraceInformation {
     pub ie_extensions: Option<TraceInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TracePropagationParameters {
     pub trace_recording_session_reference: TraceRecordingSessionReference,
@@ -4155,7 +4154,7 @@ pub struct TracePropagationParameters {
     pub ie_extensions: Option<TracePropagationParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TraceRecordingSessionInformation {
     pub trace_reference: TraceReference,
@@ -4164,19 +4163,19 @@ pub struct TraceRecordingSessionInformation {
     pub ie_extensions: Option<TraceRecordingSessionInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct TraceRecordingSessionReference(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "3")]
 pub struct TraceReference(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct TraceType(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct TrafficClass(pub u8);
 impl TrafficClass {
@@ -4186,19 +4185,19 @@ impl TrafficClass {
     pub const BACKGROUND: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15")]
 pub struct TrafficHandlingPriority(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct TransferDelay(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "1", sz_ub = "160")]
 pub struct TransportLayerAddress(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TransportLayerInformation {
     pub transport_layer_address: TransportLayerAddress,
@@ -4207,7 +4206,7 @@ pub struct TransportLayerInformation {
     pub ie_extensions: Option<TransportLayerInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -4216,7 +4215,7 @@ pub struct TransportLayerInformation {
 )]
 pub struct TriggerID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "3")]
 pub struct TriggeringMessage(pub u8);
 impl TriggeringMessage {
@@ -4226,7 +4225,7 @@ impl TriggeringMessage {
     pub const OUTCOME: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TunnelInformation {
     pub transport_layer_address: TransportLayerAddress,
@@ -4236,7 +4235,7 @@ pub struct TunnelInformation {
     pub ie_extensions: Option<TunnelInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct TypeOfError(pub u8);
 impl TypeOfError {
@@ -4244,7 +4243,7 @@ impl TypeOfError {
     pub const MISSING: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UE_AggregateMaximumBitRate {
     #[asn(optional_idx = 0)]
@@ -4253,19 +4252,19 @@ pub struct UE_AggregateMaximumBitRate {
     pub ue_aggregate_maximum_bit_rate_uplink: Option<UE_AggregateMaximumBitRateUplink>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "1000000000")]
 pub struct UE_AggregateMaximumBitRateDownlink(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "1000000000")]
 pub struct UE_AggregateMaximumBitRateUplink(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct UE_Application_Layer_Measurement_Capability(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UE_Application_Layer_Measurement_Configuration {
     pub application_layer_container_for_measurement_configuration: OCTET_STRING_63,
@@ -4274,7 +4273,7 @@ pub struct UE_Application_Layer_Measurement_Configuration {
     pub service_type: ServiceType,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UE_Application_Layer_Measurement_Configuration_For_Relocation {
     pub area_scope_for_ue_application_layer_measurement_configuration:
@@ -4287,11 +4286,11 @@ pub struct UE_Application_Layer_Measurement_Configuration_For_Relocation {
     pub service_type: ServiceType,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UE_History_Information(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum UE_ID {
     #[asn(key = 0, extended = false)]
@@ -4302,7 +4301,7 @@ pub enum UE_ID {
     Imeisv(IMEISV),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UE_IsNotServed {
     pub permanent_nas_ue_id: PermanentNAS_UE_ID,
@@ -4310,7 +4309,7 @@ pub struct UE_IsNotServed {
     pub ie_extensions: Option<UE_IsNotServedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UE_IsServed {
     pub permanent_nas_ue_id: PermanentNAS_UE_ID,
@@ -4319,11 +4318,11 @@ pub struct UE_IsServed {
     pub ie_extensions: Option<UE_IsServedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct UE_Usage_Type(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum UERegistrationQueryResult {
     #[asn(key = 0, extended = false)]
@@ -4332,7 +4331,7 @@ pub enum UERegistrationQueryResult {
     UE_IsNotServed(UE_IsNotServed),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct UESBI_Iu {
     #[asn(optional_idx = 0)]
@@ -4343,15 +4342,15 @@ pub struct UESBI_Iu {
     pub ie_extensions: Option<UESBI_IuIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "1", sz_ub = "128")]
 pub struct UESBI_IuA(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "1", sz_ub = "128")]
 pub struct UESBI_IuB(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UESpecificInformationIndication {
     pub protocol_i_es: UESpecificInformationIndicationProtocolIEs,
@@ -4359,19 +4358,19 @@ pub struct UESpecificInformationIndication {
     pub protocol_extensions: Option<UESpecificInformationIndicationProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct UL_GTP_PDU_SequenceNumber(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct UL_N_PDU_SequenceNumber(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct UP_ModeVersions(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UPInformation {
     pub frame_seq_no_ul: FrameSequenceNumber,
@@ -4384,15 +4383,15 @@ pub struct UPInformation {
     pub ie_extensions: Option<UPInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UPInitialisationFrame(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct USCH_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct UTRAN_CellID {
     pub plm_nidentity: PLMNidentity,
@@ -4401,11 +4400,11 @@ pub struct UTRAN_CellID {
     pub ie_extensions: Option<UTRAN_CellIDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct UeApplicationLayerMeasurementSupportIndication(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UeRadioCapabilityMatchRequest {
     pub protocol_i_es: UeRadioCapabilityMatchRequestProtocolIEs,
@@ -4413,7 +4412,7 @@ pub struct UeRadioCapabilityMatchRequest {
     pub protocol_extensions: Option<UeRadioCapabilityMatchRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UeRadioCapabilityMatchResponse {
     pub protocol_i_es: UeRadioCapabilityMatchResponseProtocolIEs,
@@ -4421,7 +4420,7 @@ pub struct UeRadioCapabilityMatchResponse {
     pub protocol_extensions: Option<UeRadioCapabilityMatchResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UeRegistrationQueryRequest {
     pub protocol_i_es: UeRegistrationQueryRequestProtocolIEs,
@@ -4429,7 +4428,7 @@ pub struct UeRegistrationQueryRequest {
     pub protocol_extensions: Option<UeRegistrationQueryRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UeRegistrationQueryResponse {
     pub protocol_i_es: UeRegistrationQueryResponseProtocolIEs,
@@ -4437,7 +4436,7 @@ pub struct UeRegistrationQueryResponse {
     pub protocol_extensions: Option<UeRegistrationQueryResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4446,7 +4445,7 @@ pub struct UeRegistrationQueryResponse {
 )]
 pub struct UnsuccessfulLinking_IEs(pub Vec<UnsuccessfulLinking_IEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UnsuccessfulOutcome {
     #[asn(key_field = true)]
@@ -4455,11 +4454,11 @@ pub struct UnsuccessfulOutcome {
     pub value: UnsuccessfulOutcomeValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4294967295")]
 pub struct UnsuccessfullyTransmittedDataVolume(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UplinkInformationExchangeFailure {
     pub protocol_i_es: UplinkInformationExchangeFailureProtocolIEs,
@@ -4467,7 +4466,7 @@ pub struct UplinkInformationExchangeFailure {
     pub protocol_extensions: Option<UplinkInformationExchangeFailureProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UplinkInformationExchangeRequest {
     pub protocol_i_es: UplinkInformationExchangeRequestProtocolIEs,
@@ -4475,7 +4474,7 @@ pub struct UplinkInformationExchangeRequest {
     pub protocol_extensions: Option<UplinkInformationExchangeRequestProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UplinkInformationExchangeResponse {
     pub protocol_i_es: UplinkInformationExchangeResponseProtocolIEs,
@@ -4483,7 +4482,7 @@ pub struct UplinkInformationExchangeResponse {
     pub protocol_extensions: Option<UplinkInformationExchangeResponseProtocolExtensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UserPlaneInformation {
     pub user_plane_mode: UserPlaneMode,
@@ -4492,7 +4491,7 @@ pub struct UserPlaneInformation {
     pub ie_extensions: Option<UserPlaneInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct UserPlaneMode(pub u8);
 impl UserPlaneMode {
@@ -4500,7 +4499,7 @@ impl UserPlaneMode {
     pub const SUPPORT_MODE_FOR_PREDEFINED_SDU_SIZES: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = true)]
 pub enum VelocityEstimate {
     #[asn(key = 0, extended = false)]
@@ -4513,11 +4512,11 @@ pub enum VelocityEstimate {
     HorizontalWithVeritcalVelocityAndUncertainty(HorizontalWithVerticalVelocityAndUncertainty),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct VerticalAccuracyCode(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct VerticalSpeedDirection(pub u8);
 impl VerticalSpeedDirection {
@@ -4525,14 +4524,14 @@ impl VerticalSpeedDirection {
     pub const DOWNWARD: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct VerticalVelocity {
     pub veritcal_speed: INTEGER_64,
     pub veritcal_speed_direction: VerticalSpeedDirection,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct VoiceSupportMatchIndicator(pub u8);
 impl VoiceSupportMatchIndicator {
@@ -4540,19 +4539,19 @@ impl VoiceSupportMatchIndicator {
     pub const NOT_SUPPORTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "10", sz_ub = "10")]
 pub struct BIT_STRING_2(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_3;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Additional_CSPS_coordination_informationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4563,11 +4562,11 @@ pub struct Additional_CSPS_coordination_informationIE_Extensions(
     pub Vec<Additional_CSPS_coordination_informationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AllocationOrRetentionPriorityIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4578,11 +4577,11 @@ pub struct AllocationOrRetentionPriorityIE_Extensions(
     pub Vec<AllocationOrRetentionPriorityIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Alt_RAB_Parameter_SupportedGuaranteedBitrateInfIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4593,11 +4592,11 @@ pub struct Alt_RAB_Parameter_SupportedGuaranteedBitrateInfIE_Extensions(
     pub Vec<Alt_RAB_Parameter_SupportedGuaranteedBitrateInfIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Alt_RAB_Parameter_SupportedMaxBitrateInfIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4608,7 +4607,7 @@ pub struct Alt_RAB_Parameter_SupportedMaxBitrateInfIE_Extensions(
     pub Vec<Alt_RAB_Parameter_SupportedMaxBitrateInfIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Alt_RAB_ParametersIE_Extensions_EntryExtensionValue {
     #[asn(key = 172)]
@@ -4627,7 +4626,7 @@ pub enum Alt_RAB_ParametersIE_Extensions_EntryExtensionValue {
     Id_AlternativeRABConfiguration(RAB_Parameters),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Alt_RAB_ParametersIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -4636,7 +4635,7 @@ pub struct Alt_RAB_ParametersIE_Extensions_Entry {
     pub extension_value: Alt_RAB_ParametersIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4645,7 +4644,7 @@ pub struct Alt_RAB_ParametersIE_Extensions_Entry {
 )]
 pub struct Alt_RAB_ParametersIE_Extensions(pub Vec<Alt_RAB_ParametersIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Ass_RAB_ParametersIE_Extensions_EntryExtensionValue {
     #[asn(key = 174)]
@@ -4660,7 +4659,7 @@ pub enum Ass_RAB_ParametersIE_Extensions_EntryExtensionValue {
     Id_Ass_RAB_Parameter_SupportedMaxBitrateList(SupportedRAB_ParameterBitrateList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Ass_RAB_ParametersIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -4669,7 +4668,7 @@ pub struct Ass_RAB_ParametersIE_Extensions_Entry {
     pub extension_value: Ass_RAB_ParametersIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4678,11 +4677,11 @@ pub struct Ass_RAB_ParametersIE_Extensions_Entry {
 )]
 pub struct Ass_RAB_ParametersIE_Extensions(pub Vec<Ass_RAB_ParametersIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AuthorisedPLMNs_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4691,7 +4690,7 @@ pub struct AuthorisedPLMNs_EntryIE_Extensions_Entry {}
 )]
 pub struct AuthorisedPLMNs_EntryIE_Extensions(pub Vec<AuthorisedPLMNs_EntryIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct AuthorisedPLMNs_Entry {
     pub plm_nidentity: PLMNidentity,
@@ -4701,26 +4700,26 @@ pub struct AuthorisedPLMNs_Entry {
     pub ie_extensions: Option<AuthorisedPLMNs_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct BIT_STRING_4(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "56", sz_ub = "56")]
 pub struct BIT_STRING_5(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "56", sz_ub = "56")]
 pub struct BIT_STRING_6(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CGIIE_Extensions_EntryExtensionValue {
     #[asn(key = 55)]
     Id_RAC(RAC),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CGIIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -4729,7 +4728,7 @@ pub struct CGIIE_Extensions_Entry {
     pub extension_value: CGIIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4738,7 +4737,7 @@ pub struct CGIIE_Extensions_Entry {
 )]
 pub struct CGIIE_Extensions(pub Vec<CGIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CN_DeactivateTraceProtocolIEs_EntryValue {
     #[asn(key = 65)]
@@ -4747,7 +4746,7 @@ pub enum CN_DeactivateTraceProtocolIEs_EntryValue {
     Id_TriggerID(TriggerID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CN_DeactivateTraceProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -4756,7 +4755,7 @@ pub struct CN_DeactivateTraceProtocolIEs_Entry {
     pub value: CN_DeactivateTraceProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4765,11 +4764,11 @@ pub struct CN_DeactivateTraceProtocolIEs_Entry {
 )]
 pub struct CN_DeactivateTraceProtocolIEs(pub Vec<CN_DeactivateTraceProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CN_DeactivateTraceProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4780,7 +4779,7 @@ pub struct CN_DeactivateTraceProtocolExtensions(
     pub Vec<CN_DeactivateTraceProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CN_InvokeTraceProtocolIEs_EntryValue {
     #[asn(key = 19)]
@@ -4795,7 +4794,7 @@ pub enum CN_InvokeTraceProtocolIEs_EntryValue {
     Id_UE_ID(UE_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CN_InvokeTraceProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -4804,7 +4803,7 @@ pub struct CN_InvokeTraceProtocolIEs_Entry {
     pub value: CN_InvokeTraceProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4813,7 +4812,7 @@ pub struct CN_InvokeTraceProtocolIEs_Entry {
 )]
 pub struct CN_InvokeTraceProtocolIEs(pub Vec<CN_InvokeTraceProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CN_InvokeTraceProtocolExtensions_EntryExtensionValue {
     #[asn(key = 244)]
@@ -4828,7 +4827,7 @@ pub enum CN_InvokeTraceProtocolExtensions_EntryExtensionValue {
     ),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CN_InvokeTraceProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -4837,7 +4836,7 @@ pub struct CN_InvokeTraceProtocolExtensions_Entry {
     pub extension_value: CN_InvokeTraceProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4846,11 +4845,11 @@ pub struct CN_InvokeTraceProtocolExtensions_Entry {
 )]
 pub struct CN_InvokeTraceProtocolExtensions(pub Vec<CN_InvokeTraceProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CNMBMSLinkingInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4861,11 +4860,11 @@ pub struct CNMBMSLinkingInformationIE_Extensions(
     pub Vec<CNMBMSLinkingInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellBasedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4874,11 +4873,11 @@ pub struct CellBasedIE_Extensions_Entry {}
 )]
 pub struct CellBasedIE_Extensions(pub Vec<CellBasedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellLoadInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4887,11 +4886,11 @@ pub struct CellLoadInformationIE_Extensions_Entry {}
 )]
 pub struct CellLoadInformationIE_Extensions(pub Vec<CellLoadInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellLoadInformationGroupIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4902,14 +4901,14 @@ pub struct CellLoadInformationGroupIE_Extensions(
     pub Vec<CellLoadInformationGroupIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CommonIDProtocolIEs_EntryValue {
     #[asn(key = 23)]
     Id_PermanentNAS_UE_ID(PermanentNAS_UE_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CommonIDProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -4918,7 +4917,7 @@ pub struct CommonIDProtocolIEs_Entry {
     pub value: CommonIDProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4927,7 +4926,7 @@ pub struct CommonIDProtocolIEs_Entry {
 )]
 pub struct CommonIDProtocolIEs(pub Vec<CommonIDProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CommonIDProtocolExtensions_EntryExtensionValue {
     #[asn(key = 234)]
@@ -4954,7 +4953,7 @@ pub enum CommonIDProtocolExtensions_EntryExtensionValue {
     Id_UESBI_Iu(UESBI_Iu),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CommonIDProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -4963,7 +4962,7 @@ pub struct CommonIDProtocolExtensions_Entry {
     pub extension_value: CommonIDProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4972,11 +4971,11 @@ pub struct CommonIDProtocolExtensions_Entry {
 )]
 pub struct CommonIDProtocolExtensions(pub Vec<CommonIDProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CriticalityDiagnosticsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4985,7 +4984,7 @@ pub struct CriticalityDiagnosticsIE_Extensions_Entry {}
 )]
 pub struct CriticalityDiagnosticsIE_Extensions(pub Vec<CriticalityDiagnosticsIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CriticalityDiagnostics_IE_List_EntryIE_Extensions_EntryExtensionValue {
     #[asn(key = 88)]
@@ -4994,7 +4993,7 @@ pub enum CriticalityDiagnostics_IE_List_EntryIE_Extensions_EntryExtensionValue {
     Id_TypeOfError(TypeOfError),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CriticalityDiagnostics_IE_List_EntryIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -5003,7 +5002,7 @@ pub struct CriticalityDiagnostics_IE_List_EntryIE_Extensions_Entry {
     pub extension_value: CriticalityDiagnostics_IE_List_EntryIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5014,7 +5013,7 @@ pub struct CriticalityDiagnostics_IE_List_EntryIE_Extensions(
     pub Vec<CriticalityDiagnostics_IE_List_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct CriticalityDiagnostics_IE_List_Entry {
     pub ie_criticality: Criticality,
@@ -5025,11 +5024,11 @@ pub struct CriticalityDiagnostics_IE_List_Entry {
     pub ie_extensions: Option<CriticalityDiagnostics_IE_List_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DataVolumeList_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5038,7 +5037,7 @@ pub struct DataVolumeList_EntryIE_Extensions_Entry {}
 )]
 pub struct DataVolumeList_EntryIE_Extensions(pub Vec<DataVolumeList_EntryIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct DataVolumeList_Entry {
     pub dl_unsuccessfully_transmitted_data_volume: UnsuccessfullyTransmittedDataVolume,
@@ -5048,7 +5047,7 @@ pub struct DataVolumeList_Entry {
     pub ie_extensions: Option<DataVolumeList_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DataVolumeReportProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -5059,7 +5058,7 @@ pub enum DataVolumeReportProtocolIEs_EntryValue {
     Id_RAB_FailedtoReportList(RAB_FailedtoReportList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DataVolumeReportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5068,7 +5067,7 @@ pub struct DataVolumeReportProtocolIEs_Entry {
     pub value: DataVolumeReportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5077,11 +5076,11 @@ pub struct DataVolumeReportProtocolIEs_Entry {
 )]
 pub struct DataVolumeReportProtocolIEs(pub Vec<DataVolumeReportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DataVolumeReportProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5090,14 +5089,14 @@ pub struct DataVolumeReportProtocolExtensions_Entry {}
 )]
 pub struct DataVolumeReportProtocolExtensions(pub Vec<DataVolumeReportProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DataVolumeReportRequestProtocolIEs_EntryValue {
     #[asn(key = 33)]
     Id_RAB_DataVolumeReportRequestList(RAB_DataVolumeReportRequestList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DataVolumeReportRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5106,7 +5105,7 @@ pub struct DataVolumeReportRequestProtocolIEs_Entry {
     pub value: DataVolumeReportRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5115,11 +5114,11 @@ pub struct DataVolumeReportRequestProtocolIEs_Entry {
 )]
 pub struct DataVolumeReportRequestProtocolIEs(pub Vec<DataVolumeReportRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DataVolumeReportRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5130,7 +5129,7 @@ pub struct DataVolumeReportRequestProtocolExtensions(
     pub Vec<DataVolumeReportRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DeltaRAListofIdleModeUEsIE_Extensions_EntryExtensionValue {
     #[asn(key = 182)]
@@ -5139,7 +5138,7 @@ pub enum DeltaRAListofIdleModeUEsIE_Extensions_EntryExtensionValue {
     Id_newLAListofIdleModeUEs(LAListofIdleModeUEs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DeltaRAListofIdleModeUEsIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -5148,7 +5147,7 @@ pub struct DeltaRAListofIdleModeUEsIE_Extensions_Entry {
     pub extension_value: DeltaRAListofIdleModeUEsIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5159,7 +5158,7 @@ pub struct DeltaRAListofIdleModeUEsIE_Extensions(
     pub Vec<DeltaRAListofIdleModeUEsIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DirectInformationTransferProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -5172,7 +5171,7 @@ pub enum DirectInformationTransferProtocolIEs_EntryValue {
     Id_InterSystemInformationTransferType(InterSystemInformationTransferType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DirectInformationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5181,7 +5180,7 @@ pub struct DirectInformationTransferProtocolIEs_Entry {
     pub value: DirectInformationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5192,14 +5191,14 @@ pub struct DirectInformationTransferProtocolIEs(
     pub Vec<DirectInformationTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DirectInformationTransferProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DirectInformationTransferProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -5208,7 +5207,7 @@ pub struct DirectInformationTransferProtocolExtensions_Entry {
     pub extension_value: DirectInformationTransferProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5219,7 +5218,7 @@ pub struct DirectInformationTransferProtocolExtensions(
     pub Vec<DirectInformationTransferProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DirectTransferProtocolIEs_EntryValue {
     #[asn(key = 15)]
@@ -5234,7 +5233,7 @@ pub enum DirectTransferProtocolIEs_EntryValue {
     Id_SAPI(SAPI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DirectTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5243,7 +5242,7 @@ pub struct DirectTransferProtocolIEs_Entry {
     pub value: DirectTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5252,7 +5251,7 @@ pub struct DirectTransferProtocolIEs_Entry {
 )]
 pub struct DirectTransferProtocolIEs(pub Vec<DirectTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DirectTransferProtocolExtensions_EntryExtensionValue {
     #[asn(key = 241)]
@@ -5269,7 +5268,7 @@ pub enum DirectTransferProtocolExtensions_EntryExtensionValue {
     Id_SubscriberProfileIDforRFP(SubscriberProfileIDforRFP),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DirectTransferProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -5278,7 +5277,7 @@ pub struct DirectTransferProtocolExtensions_Entry {
     pub extension_value: DirectTransferProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5287,11 +5286,11 @@ pub struct DirectTransferProtocolExtensions_Entry {
 )]
 pub struct DirectTransferProtocolExtensions(pub Vec<DirectTransferProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DirectTransferInformationItem_RANAP_RelocInfIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5302,14 +5301,14 @@ pub struct DirectTransferInformationItem_RANAP_RelocInfIE_Extensions(
     pub Vec<DirectTransferInformationItem_RANAP_RelocInfIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DirectTransferInformationList_RANAP_RelocInf_Entry_EntryValue {
     #[asn(key = 80)]
     Id_DirectTransferInformationItem_RANAP_RelocInf(DirectTransferInformationItem_RANAP_RelocInf),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DirectTransferInformationList_RANAP_RelocInf_Entry_Entry {
     #[asn(key_field = true)]
@@ -5318,7 +5317,7 @@ pub struct DirectTransferInformationList_RANAP_RelocInf_Entry_Entry {
     pub value: DirectTransferInformationList_RANAP_RelocInf_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5329,34 +5328,34 @@ pub struct DirectTransferInformationList_RANAP_RelocInf_Entry(
     pub Vec<DirectTransferInformationList_RANAP_RelocInf_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "20", sz_ub = "20")]
 pub struct BIT_STRING_7(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "28", sz_ub = "28")]
 pub struct BIT_STRING_8(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "18", sz_ub = "18")]
 pub struct BIT_STRING_9(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "21", sz_ub = "21")]
 pub struct BIT_STRING_10(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct INTEGER_11(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum EUTRANFrequencies_EntryIE_Extensions_EntryExtensionValue {
     #[asn(key = 271)]
     Id_EARFCN_Extended(EARFCN_Extended),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EUTRANFrequencies_EntryIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -5365,7 +5364,7 @@ pub struct EUTRANFrequencies_EntryIE_Extensions_Entry {
     pub extension_value: EUTRANFrequencies_EntryIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5376,7 +5375,7 @@ pub struct EUTRANFrequencies_EntryIE_Extensions(
     pub Vec<EUTRANFrequencies_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 2)]
 pub struct EUTRANFrequencies_Entry {
     pub earfcn: INTEGER_11,
@@ -5386,11 +5385,11 @@ pub struct EUTRANFrequencies_Entry {
     pub ie_extensions: Option<EUTRANFrequencies_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EncryptionInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5399,14 +5398,14 @@ pub struct EncryptionInformationIE_Extensions_Entry {}
 )]
 pub struct EncryptionInformationIE_Extensions(pub Vec<EncryptionInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum EnhancedRelocationCompleteConfirmProtocolIEs_EntryValue {
     #[asn(key = 35)]
     Id_RAB_FailedList(RAB_FailedList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteConfirmProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5415,7 +5414,7 @@ pub struct EnhancedRelocationCompleteConfirmProtocolIEs_Entry {
     pub value: EnhancedRelocationCompleteConfirmProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5426,11 +5425,11 @@ pub struct EnhancedRelocationCompleteConfirmProtocolIEs(
     pub Vec<EnhancedRelocationCompleteConfirmProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteConfirmProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5441,7 +5440,7 @@ pub struct EnhancedRelocationCompleteConfirmProtocolExtensions(
     pub Vec<EnhancedRelocationCompleteConfirmProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum EnhancedRelocationCompleteFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -5450,7 +5449,7 @@ pub enum EnhancedRelocationCompleteFailureProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5459,7 +5458,7 @@ pub struct EnhancedRelocationCompleteFailureProtocolIEs_Entry {
     pub value: EnhancedRelocationCompleteFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5470,11 +5469,11 @@ pub struct EnhancedRelocationCompleteFailureProtocolIEs(
     pub Vec<EnhancedRelocationCompleteFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteFailureProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5485,7 +5484,7 @@ pub struct EnhancedRelocationCompleteFailureProtocolExtensions(
     pub Vec<EnhancedRelocationCompleteFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum EnhancedRelocationCompleteRequestProtocolIEs_EntryValue {
     #[asn(key = 79)]
@@ -5504,7 +5503,7 @@ pub enum EnhancedRelocationCompleteRequestProtocolIEs_EntryValue {
     Id_Relocation_TargetRNC_ID(GlobalRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5513,7 +5512,7 @@ pub struct EnhancedRelocationCompleteRequestProtocolIEs_Entry {
     pub value: EnhancedRelocationCompleteRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5524,7 +5523,7 @@ pub struct EnhancedRelocationCompleteRequestProtocolIEs(
     pub Vec<EnhancedRelocationCompleteRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum EnhancedRelocationCompleteRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 203)]
@@ -5543,7 +5542,7 @@ pub enum EnhancedRelocationCompleteRequestProtocolExtensions_EntryExtensionValue
     Id_Tunnel_Information_for_BBF(TunnelInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -5552,7 +5551,7 @@ pub struct EnhancedRelocationCompleteRequestProtocolExtensions_Entry {
     pub extension_value: EnhancedRelocationCompleteRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5563,7 +5562,7 @@ pub struct EnhancedRelocationCompleteRequestProtocolExtensions(
     pub Vec<EnhancedRelocationCompleteRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum EnhancedRelocationCompleteResponseProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -5574,7 +5573,7 @@ pub enum EnhancedRelocationCompleteResponseProtocolIEs_EntryValue {
     Id_RAB_ToBeReleasedList_EnhancedRelocCompleteRes(RAB_ToBeReleasedList_EnhancedRelocCompleteRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5583,7 +5582,7 @@ pub struct EnhancedRelocationCompleteResponseProtocolIEs_Entry {
     pub value: EnhancedRelocationCompleteResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5594,7 +5593,7 @@ pub struct EnhancedRelocationCompleteResponseProtocolIEs(
     pub Vec<EnhancedRelocationCompleteResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum EnhancedRelocationCompleteResponseProtocolExtensions_EntryExtensionValue {
     #[asn(key = 234)]
@@ -5605,7 +5604,7 @@ pub enum EnhancedRelocationCompleteResponseProtocolExtensions_EntryExtensionValu
     Id_UE_AggregateMaximumBitRate(UE_AggregateMaximumBitRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EnhancedRelocationCompleteResponseProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -5614,7 +5613,7 @@ pub struct EnhancedRelocationCompleteResponseProtocolExtensions_Entry {
     pub extension_value: EnhancedRelocationCompleteResponseProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5625,7 +5624,7 @@ pub struct EnhancedRelocationCompleteResponseProtocolExtensions(
     pub Vec<EnhancedRelocationCompleteResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ErrorIndicationProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -5638,7 +5637,7 @@ pub enum ErrorIndicationProtocolIEs_EntryValue {
     Id_GlobalRNC_ID(GlobalRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ErrorIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5647,7 +5646,7 @@ pub struct ErrorIndicationProtocolIEs_Entry {
     pub value: ErrorIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5656,7 +5655,7 @@ pub struct ErrorIndicationProtocolIEs_Entry {
 )]
 pub struct ErrorIndicationProtocolIEs(pub Vec<ErrorIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ErrorIndicationProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
@@ -5665,7 +5664,7 @@ pub enum ErrorIndicationProtocolExtensions_EntryExtensionValue {
     Id_GlobalCN_ID(GlobalCN_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ErrorIndicationProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -5674,7 +5673,7 @@ pub struct ErrorIndicationProtocolExtensions_Entry {
     pub extension_value: ErrorIndicationProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5683,22 +5682,22 @@ pub struct ErrorIndicationProtocolExtensions_Entry {
 )]
 pub struct ErrorIndicationProtocolExtensions(pub Vec<ErrorIndicationProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "-120", ub = "165")]
 pub struct INTEGER_12(pub i8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "-120", ub = "-25")]
 pub struct INTEGER_13(pub i8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ForwardSRNS_ContextProtocolIEs_EntryValue {
     #[asn(key = 25)]
     Id_RAB_ContextList(RAB_ContextList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ForwardSRNS_ContextProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5707,7 +5706,7 @@ pub struct ForwardSRNS_ContextProtocolIEs_Entry {
     pub value: ForwardSRNS_ContextProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5716,14 +5715,14 @@ pub struct ForwardSRNS_ContextProtocolIEs_Entry {
 )]
 pub struct ForwardSRNS_ContextProtocolIEs(pub Vec<ForwardSRNS_ContextProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ForwardSRNS_ContextProtocolExtensions_EntryExtensionValue {
     #[asn(key = 103)]
     Id_SourceRNC_PDCP_context_info(RRC_Container),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ForwardSRNS_ContextProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -5732,7 +5731,7 @@ pub struct ForwardSRNS_ContextProtocolExtensions_Entry {
     pub extension_value: ForwardSRNS_ContextProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5743,7 +5742,7 @@ pub struct ForwardSRNS_ContextProtocolExtensions(
     pub Vec<ForwardSRNS_ContextProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct ENUMERATED_14(pub u8);
 impl ENUMERATED_14 {
@@ -5751,35 +5750,35 @@ impl ENUMERATED_14 {
     pub const DEPTH: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "32767")]
 pub struct INTEGER_15(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct INTEGER_16(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_17(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "179")]
 pub struct INTEGER_18(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "179")]
 pub struct INTEGER_19(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_20(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GA_EllipsoidArcIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5788,11 +5787,11 @@ pub struct GA_EllipsoidArcIE_Extensions_Entry {}
 )]
 pub struct GA_EllipsoidArcIE_Extensions(pub Vec<GA_EllipsoidArcIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GA_PointIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5801,11 +5800,11 @@ pub struct GA_PointIE_Extensions_Entry {}
 )]
 pub struct GA_PointIE_Extensions(pub Vec<GA_PointIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GA_PointWithAltitudeIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5814,19 +5813,19 @@ pub struct GA_PointWithAltitudeIE_Extensions_Entry {}
 )]
 pub struct GA_PointWithAltitudeIE_Extensions(pub Vec<GA_PointWithAltitudeIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_21(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_22(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GA_PointWithAltitudeAndUncertaintyEllipsoidIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5837,11 +5836,11 @@ pub struct GA_PointWithAltitudeAndUncertaintyEllipsoidIE_Extensions(
     pub Vec<GA_PointWithAltitudeAndUncertaintyEllipsoidIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GA_PointWithUnCertaintyIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5852,19 +5851,19 @@ pub struct GA_PointWithUnCertaintyIE_Extensions(
     pub Vec<GA_PointWithUnCertaintyIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_23(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_24(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GA_PointWithUnCertaintyEllipseIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5875,11 +5874,11 @@ pub struct GA_PointWithUnCertaintyEllipseIE_Extensions(
     pub Vec<GA_PointWithUnCertaintyEllipseIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GA_Polygon_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5888,7 +5887,7 @@ pub struct GA_Polygon_EntryIE_Extensions_Entry {}
 )]
 pub struct GA_Polygon_EntryIE_Extensions(pub Vec<GA_Polygon_EntryIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GA_Polygon_Entry {
     pub geographical_coordinates: GeographicalCoordinates,
@@ -5896,23 +5895,23 @@ pub struct GA_Polygon_Entry {
     pub ie_extensions: Option<GA_Polygon_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_25(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_26(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "179")]
 pub struct INTEGER_27(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GERAN_Cell_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5921,11 +5920,11 @@ pub struct GERAN_Cell_IDIE_Extensions_Entry {}
 )]
 pub struct GERAN_Cell_IDIE_Extensions(pub Vec<GERAN_Cell_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GERAN_Iumode_RAB_Failed_RABAssgntResponse_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5936,7 +5935,7 @@ pub struct GERAN_Iumode_RAB_Failed_RABAssgntResponse_ItemIE_Extensions(
     pub Vec<GERAN_Iumode_RAB_Failed_RABAssgntResponse_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry_EntryValue {
     #[asn(key = 109)]
@@ -5945,7 +5944,7 @@ pub enum GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry_EntryValue {
     ),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry_Entry {
     #[asn(key_field = true)]
@@ -5954,7 +5953,7 @@ pub struct GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry_Entry {
     pub value: GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5965,7 +5964,7 @@ pub struct GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry(
     pub Vec<GERAN_Iumode_RAB_FailedList_RABAssgntResponse_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct ENUMERATED_28(pub u8);
 impl ENUMERATED_28 {
@@ -5973,19 +5972,19 @@ impl ENUMERATED_28 {
     pub const SOUTH: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "8388607")]
 pub struct INTEGER_29(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "-8388608", ub = "8388607")]
 pub struct INTEGER_30(pub i32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GeographicalCoordinatesIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5996,19 +5995,19 @@ pub struct GeographicalCoordinatesIE_Extensions(
     pub Vec<GeographicalCoordinatesIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "359")]
 pub struct INTEGER_31(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "2047")]
 pub struct INTEGER_32(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HorizontalVelocityIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6017,15 +6016,15 @@ pub struct HorizontalVelocityIE_Extensions_Entry {}
 )]
 pub struct HorizontalVelocityIE_Extensions(pub Vec<HorizontalVelocityIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct INTEGER_33(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HorizontalVelocityWithUncertaintyIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6036,11 +6035,11 @@ pub struct HorizontalVelocityWithUncertaintyIE_Extensions(
     pub Vec<HorizontalVelocityWithUncertaintyIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HorizontalWithVerticalVelocityIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6051,19 +6050,19 @@ pub struct HorizontalWithVerticalVelocityIE_Extensions(
     pub Vec<HorizontalWithVerticalVelocityIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct INTEGER_34(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct INTEGER_35(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HorizontalWithVerticalVelocityAndUncertaintyIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6074,15 +6073,15 @@ pub struct HorizontalWithVerticalVelocityAndUncertaintyIE_Extensions(
     pub Vec<HorizontalWithVerticalVelocityAndUncertaintyIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "7", sz_ub = "7")]
 pub struct BIT_STRING_36(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IMEIGroupIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6091,15 +6090,15 @@ pub struct IMEIGroupIE_Extensions_Entry {}
 )]
 pub struct IMEIGroupIE_Extensions(pub Vec<IMEIGroupIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "7", sz_ub = "7")]
 pub struct BIT_STRING_37(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IMEISVGroupIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6108,15 +6107,15 @@ pub struct IMEISVGroupIE_Extensions_Entry {}
 )]
 pub struct IMEISVGroupIE_Extensions(pub Vec<IMEISVGroupIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "97")]
 pub struct INTEGER_38(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "34")]
 pub struct INTEGER_39(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum IRAT_Measurement_ConfigurationIE_Extensions_EntryExtensionValue {
     #[asn(key = 279)]
@@ -6125,7 +6124,7 @@ pub enum IRAT_Measurement_ConfigurationIE_Extensions_EntryExtensionValue {
     Id_RSRQ_Type(RSRQ_Type),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IRAT_Measurement_ConfigurationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6134,7 +6133,7 @@ pub struct IRAT_Measurement_ConfigurationIE_Extensions_Entry {
     pub extension_value: IRAT_Measurement_ConfigurationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6145,15 +6144,15 @@ pub struct IRAT_Measurement_ConfigurationIE_Extensions(
     pub Vec<IRAT_Measurement_ConfigurationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "100")]
 pub struct INTEGER_40(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IRATmeasurementParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6164,7 +6163,7 @@ pub struct IRATmeasurementParametersIE_Extensions(
     pub Vec<IRATmeasurementParametersIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ImmediateMDTIE_Extensions_EntryExtensionValue {
     #[asn(key = 265)]
@@ -6177,7 +6176,7 @@ pub enum ImmediateMDTIE_Extensions_EntryExtensionValue {
     Id_M7Report(M7Report),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ImmediateMDTIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6186,7 +6185,7 @@ pub struct ImmediateMDTIE_Extensions_Entry {
     pub extension_value: ImmediateMDTIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6195,7 +6194,7 @@ pub struct ImmediateMDTIE_Extensions_Entry {
 )]
 pub struct ImmediateMDTIE_Extensions(pub Vec<ImmediateMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InformationTransferConfirmationProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -6208,7 +6207,7 @@ pub enum InformationTransferConfirmationProtocolIEs_EntryValue {
     Id_InformationTransferID(InformationTransferID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InformationTransferConfirmationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6217,7 +6216,7 @@ pub struct InformationTransferConfirmationProtocolIEs_Entry {
     pub value: InformationTransferConfirmationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6228,14 +6227,14 @@ pub struct InformationTransferConfirmationProtocolIEs(
     pub Vec<InformationTransferConfirmationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InformationTransferConfirmationProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InformationTransferConfirmationProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -6244,7 +6243,7 @@ pub struct InformationTransferConfirmationProtocolExtensions_Entry {
     pub extension_value: InformationTransferConfirmationProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6255,7 +6254,7 @@ pub struct InformationTransferConfirmationProtocolExtensions(
     pub Vec<InformationTransferConfirmationProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InformationTransferFailureProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -6270,7 +6269,7 @@ pub enum InformationTransferFailureProtocolIEs_EntryValue {
     Id_InformationTransferID(InformationTransferID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InformationTransferFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6279,7 +6278,7 @@ pub struct InformationTransferFailureProtocolIEs_Entry {
     pub value: InformationTransferFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6290,14 +6289,14 @@ pub struct InformationTransferFailureProtocolIEs(
     pub Vec<InformationTransferFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InformationTransferFailureProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InformationTransferFailureProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -6306,7 +6305,7 @@ pub struct InformationTransferFailureProtocolExtensions_Entry {
     pub extension_value: InformationTransferFailureProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6317,7 +6316,7 @@ pub struct InformationTransferFailureProtocolExtensions(
     pub Vec<InformationTransferFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InformationTransferIndicationProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -6330,7 +6329,7 @@ pub enum InformationTransferIndicationProtocolIEs_EntryValue {
     Id_ProvidedData(ProvidedData),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InformationTransferIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6339,7 +6338,7 @@ pub struct InformationTransferIndicationProtocolIEs_Entry {
     pub value: InformationTransferIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6350,11 +6349,11 @@ pub struct InformationTransferIndicationProtocolIEs(
     pub Vec<InformationTransferIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InformationTransferIndicationProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6365,7 +6364,7 @@ pub struct InformationTransferIndicationProtocolExtensions(
     pub Vec<InformationTransferIndicationProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialUE_MessageProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -6384,7 +6383,7 @@ pub enum InitialUE_MessageProtocolIEs_EntryValue {
     Id_SAI(SAI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialUE_MessageProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6393,7 +6392,7 @@ pub struct InitialUE_MessageProtocolIEs_Entry {
     pub value: InitialUE_MessageProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6402,7 +6401,7 @@ pub struct InitialUE_MessageProtocolIEs_Entry {
 )]
 pub struct InitialUE_MessageProtocolIEs(pub Vec<InitialUE_MessageProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialUE_MessageProtocolExtensions_EntryExtensionValue {
     #[asn(key = 203)]
@@ -6441,7 +6440,7 @@ pub enum InitialUE_MessageProtocolExtensions_EntryExtensionValue {
     Id_UE_Usage_Type(UE_Usage_Type),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialUE_MessageProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -6450,7 +6449,7 @@ pub struct InitialUE_MessageProtocolExtensions_Entry {
     pub extension_value: InitialUE_MessageProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6459,7 +6458,7 @@ pub struct InitialUE_MessageProtocolExtensions_Entry {
 )]
 pub struct InitialUE_MessageProtocolExtensions(pub Vec<InitialUE_MessageProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitiatingMessageValue {
     #[asn(key = 26)]
@@ -6562,11 +6561,11 @@ pub enum InitiatingMessageValue {
     Id_privateMessage(PrivateMessage),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntegrityProtectionInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6577,11 +6576,11 @@ pub struct IntegrityProtectionInformationIE_Extensions(
     pub Vec<IntegrityProtectionInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InterSystemInformation_TransparentContainerIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6592,7 +6591,7 @@ pub struct InterSystemInformation_TransparentContainerIE_Extensions(
     pub Vec<InterSystemInformation_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct ENUMERATED_41(pub u8);
 impl ENUMERATED_41 {
@@ -6603,11 +6602,11 @@ impl ENUMERATED_41 {
     pub const UU: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InterfacesToTraceItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6616,14 +6615,14 @@ pub struct InterfacesToTraceItemIE_Extensions_Entry {}
 )]
 pub struct InterfacesToTraceItemIE_Extensions(pub Vec<InterfacesToTraceItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Iu_ReleaseCommandProtocolIEs_EntryValue {
     #[asn(key = 4)]
     Id_Cause(Cause),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Iu_ReleaseCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6632,7 +6631,7 @@ pub struct Iu_ReleaseCommandProtocolIEs_Entry {
     pub value: Iu_ReleaseCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6641,7 +6640,7 @@ pub struct Iu_ReleaseCommandProtocolIEs_Entry {
 )]
 pub struct Iu_ReleaseCommandProtocolIEs(pub Vec<Iu_ReleaseCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Iu_ReleaseCommandProtocolExtensions_EntryExtensionValue {
     #[asn(key = 252)]
@@ -6652,7 +6651,7 @@ pub enum Iu_ReleaseCommandProtocolExtensions_EntryExtensionValue {
     Id_Out_Of_UTRAN(Out_Of_UTRAN),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Iu_ReleaseCommandProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -6661,7 +6660,7 @@ pub struct Iu_ReleaseCommandProtocolExtensions_Entry {
     pub extension_value: Iu_ReleaseCommandProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6670,7 +6669,7 @@ pub struct Iu_ReleaseCommandProtocolExtensions_Entry {
 )]
 pub struct Iu_ReleaseCommandProtocolExtensions(pub Vec<Iu_ReleaseCommandProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Iu_ReleaseCompleteProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -6681,7 +6680,7 @@ pub enum Iu_ReleaseCompleteProtocolIEs_EntryValue {
     Id_RAB_ReleasedList_IuRelComp(RAB_ReleasedList_IuRelComp),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Iu_ReleaseCompleteProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6690,7 +6689,7 @@ pub struct Iu_ReleaseCompleteProtocolIEs_Entry {
     pub value: Iu_ReleaseCompleteProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6699,11 +6698,11 @@ pub struct Iu_ReleaseCompleteProtocolIEs_Entry {
 )]
 pub struct Iu_ReleaseCompleteProtocolIEs(pub Vec<Iu_ReleaseCompleteProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Iu_ReleaseCompleteProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6714,14 +6713,14 @@ pub struct Iu_ReleaseCompleteProtocolExtensions(
     pub Vec<Iu_ReleaseCompleteProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Iu_ReleaseRequestProtocolIEs_EntryValue {
     #[asn(key = 4)]
     Id_Cause(Cause),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Iu_ReleaseRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6730,7 +6729,7 @@ pub struct Iu_ReleaseRequestProtocolIEs_Entry {
     pub value: Iu_ReleaseRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6739,11 +6738,11 @@ pub struct Iu_ReleaseRequestProtocolIEs_Entry {
 )]
 pub struct Iu_ReleaseRequestProtocolIEs(pub Vec<Iu_ReleaseRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Iu_ReleaseRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6752,11 +6751,11 @@ pub struct Iu_ReleaseRequestProtocolExtensions_Entry {}
 )]
 pub struct Iu_ReleaseRequestProtocolExtensions(pub Vec<Iu_ReleaseRequestProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct JoinedMBMSBearerService_IEs_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6767,7 +6766,7 @@ pub struct JoinedMBMSBearerService_IEs_EntryIE_Extensions(
     pub Vec<JoinedMBMSBearerService_IEs_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct JoinedMBMSBearerService_IEs_Entry {
     pub tmgi: TMGI,
@@ -6776,11 +6775,11 @@ pub struct JoinedMBMSBearerService_IEs_Entry {
     pub ie_extensions: Option<JoinedMBMSBearerService_IEs_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LA_LIST_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6789,7 +6788,7 @@ pub struct LA_LIST_EntryIE_Extensions_Entry {}
 )]
 pub struct LA_LIST_EntryIE_Extensions(pub Vec<LA_LIST_EntryIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LA_LIST_Entry {
     pub lac: LAC,
@@ -6798,11 +6797,11 @@ pub struct LA_LIST_Entry {
     pub ie_extensions: Option<LA_LIST_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LABasedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6811,11 +6810,11 @@ pub struct LABasedIE_Extensions_Entry {}
 )]
 pub struct LABasedIE_Extensions(pub Vec<LABasedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6824,15 +6823,15 @@ pub struct LAIIE_Extensions_Entry {}
 )]
 pub struct LAIIE_Extensions(pub Vec<LAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "32767")]
 pub struct INTEGER_42(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LastKnownServiceAreaIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6841,7 +6840,7 @@ pub struct LastKnownServiceAreaIE_Extensions_Entry {}
 )]
 pub struct LastKnownServiceAreaIE_Extensions(pub Vec<LastKnownServiceAreaIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LastVisitedUTRANCell_ItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 257)]
@@ -6850,7 +6849,7 @@ pub enum LastVisitedUTRANCell_ItemIE_Extensions_EntryExtensionValue {
     Id_Time_UE_StayedInCell_EnhancedGranularity(Time_UE_StayedInCell_EnhancedGranularity),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LastVisitedUTRANCell_ItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6859,7 +6858,7 @@ pub struct LastVisitedUTRANCell_ItemIE_Extensions_Entry {
     pub extension_value: LastVisitedUTRANCell_ItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6870,11 +6869,11 @@ pub struct LastVisitedUTRANCell_ItemIE_Extensions(
     pub Vec<LastVisitedUTRANCell_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LeftMBMSBearerService_IEs_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6885,7 +6884,7 @@ pub struct LeftMBMSBearerService_IEs_EntryIE_Extensions(
     pub Vec<LeftMBMSBearerService_IEs_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LeftMBMSBearerService_IEs_Entry {
     pub tmgi: TMGI,
@@ -6893,14 +6892,14 @@ pub struct LeftMBMSBearerService_IEs_Entry {
     pub ie_extensions: Option<LeftMBMSBearerService_IEs_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationRelatedDataFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
     Id_Cause(Cause),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationRelatedDataFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6909,7 +6908,7 @@ pub struct LocationRelatedDataFailureProtocolIEs_Entry {
     pub value: LocationRelatedDataFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6920,14 +6919,14 @@ pub struct LocationRelatedDataFailureProtocolIEs(
     pub Vec<LocationRelatedDataFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationRelatedDataFailureProtocolExtensions_EntryExtensionValue {
     #[asn(key = 9)]
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationRelatedDataFailureProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -6936,7 +6935,7 @@ pub struct LocationRelatedDataFailureProtocolExtensions_Entry {
     pub extension_value: LocationRelatedDataFailureProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6947,14 +6946,14 @@ pub struct LocationRelatedDataFailureProtocolExtensions(
     pub Vec<LocationRelatedDataFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationRelatedDataRequestProtocolIEs_EntryValue {
     #[asn(key = 95)]
     Id_LocationRelatedDataRequestType(LocationRelatedDataRequestType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationRelatedDataRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6963,7 +6962,7 @@ pub struct LocationRelatedDataRequestProtocolIEs_Entry {
     pub value: LocationRelatedDataRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6974,7 +6973,7 @@ pub struct LocationRelatedDataRequestProtocolIEs(
     pub Vec<LocationRelatedDataRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationRelatedDataRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 115)]
@@ -6985,7 +6984,7 @@ pub enum LocationRelatedDataRequestProtocolExtensions_EntryExtensionValue {
     Id_RequestedGANSSAssistanceData(RequestedGANSSAssistanceData),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationRelatedDataRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -6994,7 +6993,7 @@ pub struct LocationRelatedDataRequestProtocolExtensions_Entry {
     pub extension_value: LocationRelatedDataRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7005,14 +7004,14 @@ pub struct LocationRelatedDataRequestProtocolExtensions(
     pub Vec<LocationRelatedDataRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationRelatedDataResponseProtocolIEs_EntryValue {
     #[asn(key = 94)]
     Id_BroadcastAssistanceDataDecipheringKeys(BroadcastAssistanceDataDecipheringKeys),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationRelatedDataResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7021,7 +7020,7 @@ pub struct LocationRelatedDataResponseProtocolIEs_Entry {
     pub value: LocationRelatedDataResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7032,7 +7031,7 @@ pub struct LocationRelatedDataResponseProtocolIEs(
     pub Vec<LocationRelatedDataResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationRelatedDataResponseProtocolExtensions_EntryExtensionValue {
     #[asn(key = 186)]
@@ -7041,7 +7040,7 @@ pub enum LocationRelatedDataResponseProtocolExtensions_EntryExtensionValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationRelatedDataResponseProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -7050,7 +7049,7 @@ pub struct LocationRelatedDataResponseProtocolExtensions_Entry {
     pub extension_value: LocationRelatedDataResponseProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7061,7 +7060,7 @@ pub struct LocationRelatedDataResponseProtocolExtensions(
     pub Vec<LocationRelatedDataResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -7072,7 +7071,7 @@ pub enum LocationReportProtocolIEs_EntryValue {
     Id_RequestType(RequestType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7081,7 +7080,7 @@ pub struct LocationReportProtocolIEs_Entry {
     pub value: LocationReportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7090,7 +7089,7 @@ pub struct LocationReportProtocolIEs_Entry {
 )]
 pub struct LocationReportProtocolIEs(pub Vec<LocationReportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportProtocolExtensions_EntryExtensionValue {
     #[asn(key = 122)]
@@ -7109,7 +7108,7 @@ pub enum LocationReportProtocolExtensions_EntryExtensionValue {
     Id_VelocityEstimate(VelocityEstimate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -7118,7 +7117,7 @@ pub struct LocationReportProtocolExtensions_Entry {
     pub extension_value: LocationReportProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7127,14 +7126,14 @@ pub struct LocationReportProtocolExtensions_Entry {
 )]
 pub struct LocationReportProtocolExtensions(pub Vec<LocationReportProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportingControlProtocolIEs_EntryValue {
     #[asn(key = 57)]
     Id_RequestType(RequestType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingControlProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7143,7 +7142,7 @@ pub struct LocationReportingControlProtocolIEs_Entry {
     pub value: LocationReportingControlProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7152,7 +7151,7 @@ pub struct LocationReportingControlProtocolIEs_Entry {
 )]
 pub struct LocationReportingControlProtocolIEs(pub Vec<LocationReportingControlProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportingControlProtocolExtensions_EntryExtensionValue {
     #[asn(key = 114)]
@@ -7169,7 +7168,7 @@ pub enum LocationReportingControlProtocolExtensions_EntryExtensionValue {
     Id_VerticalAccuracyCode(VerticalAccuracyCode),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingControlProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -7178,7 +7177,7 @@ pub struct LocationReportingControlProtocolExtensions_Entry {
     pub extension_value: LocationReportingControlProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7189,11 +7188,11 @@ pub struct LocationReportingControlProtocolExtensions(
     pub Vec<LocationReportingControlProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingTransferInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7204,11 +7203,11 @@ pub struct LocationReportingTransferInformationIE_Extensions(
     pub Vec<LocationReportingTransferInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LoggedMDTIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7217,11 +7216,11 @@ pub struct LoggedMDTIE_Extensions_Entry {}
 )]
 pub struct LoggedMDTIE_Extensions(pub Vec<LoggedMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M4_Collection_ParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7232,19 +7231,19 @@ pub struct M4_Collection_ParametersIE_Extensions(
     pub Vec<M4_Collection_ParametersIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_43;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_44;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M6ReportIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7253,11 +7252,11 @@ pub struct M6ReportIE_Extensions_Entry {}
 )]
 pub struct M6ReportIE_Extensions(pub Vec<M6ReportIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M7ReportIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7266,7 +7265,7 @@ pub struct M7ReportIE_Extensions_Entry {}
 )]
 pub struct M7ReportIE_Extensions(pub Vec<M7ReportIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSCNDe_RegistrationRequestProtocolIEs_EntryValue {
     #[asn(key = 96)]
@@ -7275,7 +7274,7 @@ pub enum MBMSCNDe_RegistrationRequestProtocolIEs_EntryValue {
     Id_TMGI(TMGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSCNDe_RegistrationRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7284,7 +7283,7 @@ pub struct MBMSCNDe_RegistrationRequestProtocolIEs_Entry {
     pub value: MBMSCNDe_RegistrationRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7295,11 +7294,11 @@ pub struct MBMSCNDe_RegistrationRequestProtocolIEs(
     pub Vec<MBMSCNDe_RegistrationRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSCNDe_RegistrationRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7310,7 +7309,7 @@ pub struct MBMSCNDe_RegistrationRequestProtocolExtensions(
     pub Vec<MBMSCNDe_RegistrationRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSCNDe_RegistrationResponseProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7323,7 +7322,7 @@ pub enum MBMSCNDe_RegistrationResponseProtocolIEs_EntryValue {
     Id_TMGI(TMGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSCNDe_RegistrationResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7332,7 +7331,7 @@ pub struct MBMSCNDe_RegistrationResponseProtocolIEs_Entry {
     pub value: MBMSCNDe_RegistrationResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7343,14 +7342,14 @@ pub struct MBMSCNDe_RegistrationResponseProtocolIEs(
     pub Vec<MBMSCNDe_RegistrationResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSCNDe_RegistrationResponseProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSCNDe_RegistrationResponseProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -7359,7 +7358,7 @@ pub struct MBMSCNDe_RegistrationResponseProtocolExtensions_Entry {
     pub extension_value: MBMSCNDe_RegistrationResponseProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7370,11 +7369,11 @@ pub struct MBMSCNDe_RegistrationResponseProtocolExtensions(
     pub Vec<MBMSCNDe_RegistrationResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSIPMulticastAddressandAPNlistIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7385,14 +7384,14 @@ pub struct MBMSIPMulticastAddressandAPNlistIE_Extensions(
     pub Vec<MBMSIPMulticastAddressandAPNlistIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRABEstablishmentIndicationProtocolIEs_EntryValue {
     #[asn(key = 154)]
     Id_TransportLayerInformation(TransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABEstablishmentIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7401,7 +7400,7 @@ pub struct MBMSRABEstablishmentIndicationProtocolIEs_Entry {
     pub value: MBMSRABEstablishmentIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7412,11 +7411,11 @@ pub struct MBMSRABEstablishmentIndicationProtocolIEs(
     pub Vec<MBMSRABEstablishmentIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABEstablishmentIndicationProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7427,7 +7426,7 @@ pub struct MBMSRABEstablishmentIndicationProtocolExtensions(
     pub Vec<MBMSRABEstablishmentIndicationProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRABReleaseProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7436,7 +7435,7 @@ pub enum MBMSRABReleaseProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABReleaseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7445,7 +7444,7 @@ pub struct MBMSRABReleaseProtocolIEs_Entry {
     pub value: MBMSRABReleaseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7454,11 +7453,11 @@ pub struct MBMSRABReleaseProtocolIEs_Entry {
 )]
 pub struct MBMSRABReleaseProtocolIEs(pub Vec<MBMSRABReleaseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABReleaseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7467,7 +7466,7 @@ pub struct MBMSRABReleaseProtocolExtensions_Entry {}
 )]
 pub struct MBMSRABReleaseProtocolExtensions(pub Vec<MBMSRABReleaseProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRABReleaseFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7476,7 +7475,7 @@ pub enum MBMSRABReleaseFailureProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABReleaseFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7485,7 +7484,7 @@ pub struct MBMSRABReleaseFailureProtocolIEs_Entry {
     pub value: MBMSRABReleaseFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7494,11 +7493,11 @@ pub struct MBMSRABReleaseFailureProtocolIEs_Entry {
 )]
 pub struct MBMSRABReleaseFailureProtocolIEs(pub Vec<MBMSRABReleaseFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABReleaseFailureProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7509,14 +7508,14 @@ pub struct MBMSRABReleaseFailureProtocolExtensions(
     pub Vec<MBMSRABReleaseFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRABReleaseRequestProtocolIEs_EntryValue {
     #[asn(key = 4)]
     Id_Cause(Cause),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABReleaseRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7525,7 +7524,7 @@ pub struct MBMSRABReleaseRequestProtocolIEs_Entry {
     pub value: MBMSRABReleaseRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7534,11 +7533,11 @@ pub struct MBMSRABReleaseRequestProtocolIEs_Entry {
 )]
 pub struct MBMSRABReleaseRequestProtocolIEs(pub Vec<MBMSRABReleaseRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRABReleaseRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7549,7 +7548,7 @@ pub struct MBMSRABReleaseRequestProtocolExtensions(
     pub Vec<MBMSRABReleaseRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRegistrationFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7562,7 +7561,7 @@ pub enum MBMSRegistrationFailureProtocolIEs_EntryValue {
     Id_TMGI(TMGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRegistrationFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7571,7 +7570,7 @@ pub struct MBMSRegistrationFailureProtocolIEs_Entry {
     pub value: MBMSRegistrationFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7580,11 +7579,11 @@ pub struct MBMSRegistrationFailureProtocolIEs_Entry {
 )]
 pub struct MBMSRegistrationFailureProtocolIEs(pub Vec<MBMSRegistrationFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRegistrationFailureProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7595,7 +7594,7 @@ pub struct MBMSRegistrationFailureProtocolExtensions(
     pub Vec<MBMSRegistrationFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRegistrationRequestProtocolIEs_EntryValue {
     #[asn(key = 132)]
@@ -7610,7 +7609,7 @@ pub enum MBMSRegistrationRequestProtocolIEs_EntryValue {
     Id_TMGI(TMGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRegistrationRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7619,7 +7618,7 @@ pub struct MBMSRegistrationRequestProtocolIEs_Entry {
     pub value: MBMSRegistrationRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7628,14 +7627,14 @@ pub struct MBMSRegistrationRequestProtocolIEs_Entry {
 )]
 pub struct MBMSRegistrationRequestProtocolIEs(pub Vec<MBMSRegistrationRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRegistrationRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRegistrationRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -7644,7 +7643,7 @@ pub struct MBMSRegistrationRequestProtocolExtensions_Entry {
     pub extension_value: MBMSRegistrationRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7655,7 +7654,7 @@ pub struct MBMSRegistrationRequestProtocolExtensions(
     pub Vec<MBMSRegistrationRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSRegistrationResponseProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -7666,7 +7665,7 @@ pub enum MBMSRegistrationResponseProtocolIEs_EntryValue {
     Id_TMGI(TMGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRegistrationResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7675,7 +7674,7 @@ pub struct MBMSRegistrationResponseProtocolIEs_Entry {
     pub value: MBMSRegistrationResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7684,11 +7683,11 @@ pub struct MBMSRegistrationResponseProtocolIEs_Entry {
 )]
 pub struct MBMSRegistrationResponseProtocolIEs(pub Vec<MBMSRegistrationResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSRegistrationResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7699,7 +7698,7 @@ pub struct MBMSRegistrationResponseProtocolExtensions(
     pub Vec<MBMSRegistrationResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionStartProtocolIEs_EntryValue {
     #[asn(key = 135)]
@@ -7730,7 +7729,7 @@ pub enum MBMSSessionStartProtocolIEs_EntryValue {
     Id_TimeToMBMSDataTransfer(TimeToMBMSDataTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStartProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7739,7 +7738,7 @@ pub struct MBMSSessionStartProtocolIEs_Entry {
     pub value: MBMSSessionStartProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7748,7 +7747,7 @@ pub struct MBMSSessionStartProtocolIEs_Entry {
 )]
 pub struct MBMSSessionStartProtocolIEs(pub Vec<MBMSSessionStartProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionStartProtocolExtensions_EntryExtensionValue {
     #[asn(key = 169)]
@@ -7761,7 +7760,7 @@ pub enum MBMSSessionStartProtocolExtensions_EntryExtensionValue {
     Id_Session_Re_establishment_Indicator(Session_Re_establishment_Indicator),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStartProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -7770,7 +7769,7 @@ pub struct MBMSSessionStartProtocolExtensions_Entry {
     pub extension_value: MBMSSessionStartProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7779,7 +7778,7 @@ pub struct MBMSSessionStartProtocolExtensions_Entry {
 )]
 pub struct MBMSSessionStartProtocolExtensions(pub Vec<MBMSSessionStartProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionStartFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7788,7 +7787,7 @@ pub enum MBMSSessionStartFailureProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStartFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7797,7 +7796,7 @@ pub struct MBMSSessionStartFailureProtocolIEs_Entry {
     pub value: MBMSSessionStartFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7806,11 +7805,11 @@ pub struct MBMSSessionStartFailureProtocolIEs_Entry {
 )]
 pub struct MBMSSessionStartFailureProtocolIEs(pub Vec<MBMSSessionStartFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStartFailureProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7821,7 +7820,7 @@ pub struct MBMSSessionStartFailureProtocolExtensions(
     pub Vec<MBMSSessionStartFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionStartResponseProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7832,7 +7831,7 @@ pub enum MBMSSessionStartResponseProtocolIEs_EntryValue {
     Id_TransportLayerInformation(TransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStartResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7841,7 +7840,7 @@ pub struct MBMSSessionStartResponseProtocolIEs_Entry {
     pub value: MBMSSessionStartResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7850,11 +7849,11 @@ pub struct MBMSSessionStartResponseProtocolIEs_Entry {
 )]
 pub struct MBMSSessionStartResponseProtocolIEs(pub Vec<MBMSSessionStartResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStartResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7865,14 +7864,14 @@ pub struct MBMSSessionStartResponseProtocolExtensions(
     pub Vec<MBMSSessionStartResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionStopProtocolIEs_EntryValue {
     #[asn(key = 144)]
     Id_MBMSCNDe_Registration(MBMSCNDe_Registration),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStopProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7881,7 +7880,7 @@ pub struct MBMSSessionStopProtocolIEs_Entry {
     pub value: MBMSSessionStopProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7890,11 +7889,11 @@ pub struct MBMSSessionStopProtocolIEs_Entry {
 )]
 pub struct MBMSSessionStopProtocolIEs(pub Vec<MBMSSessionStopProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStopProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7903,7 +7902,7 @@ pub struct MBMSSessionStopProtocolExtensions_Entry {}
 )]
 pub struct MBMSSessionStopProtocolExtensions(pub Vec<MBMSSessionStopProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionStopResponseProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7912,7 +7911,7 @@ pub enum MBMSSessionStopResponseProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStopResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7921,7 +7920,7 @@ pub struct MBMSSessionStopResponseProtocolIEs_Entry {
     pub value: MBMSSessionStopResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7930,11 +7929,11 @@ pub struct MBMSSessionStopResponseProtocolIEs_Entry {
 )]
 pub struct MBMSSessionStopResponseProtocolIEs(pub Vec<MBMSSessionStopResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionStopResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7945,7 +7944,7 @@ pub struct MBMSSessionStopResponseProtocolExtensions(
     pub Vec<MBMSSessionStopResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionUpdateProtocolIEs_EntryValue {
     #[asn(key = 134)]
@@ -7954,7 +7953,7 @@ pub enum MBMSSessionUpdateProtocolIEs_EntryValue {
     Id_SessionUpdateID(SessionUpdateID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionUpdateProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7963,7 +7962,7 @@ pub struct MBMSSessionUpdateProtocolIEs_Entry {
     pub value: MBMSSessionUpdateProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7972,11 +7971,11 @@ pub struct MBMSSessionUpdateProtocolIEs_Entry {
 )]
 pub struct MBMSSessionUpdateProtocolIEs(pub Vec<MBMSSessionUpdateProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionUpdateProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7985,7 +7984,7 @@ pub struct MBMSSessionUpdateProtocolExtensions_Entry {}
 )]
 pub struct MBMSSessionUpdateProtocolExtensions(pub Vec<MBMSSessionUpdateProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionUpdateFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7996,7 +7995,7 @@ pub enum MBMSSessionUpdateFailureProtocolIEs_EntryValue {
     Id_SessionUpdateID(SessionUpdateID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionUpdateFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8005,7 +8004,7 @@ pub struct MBMSSessionUpdateFailureProtocolIEs_Entry {
     pub value: MBMSSessionUpdateFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8014,11 +8013,11 @@ pub struct MBMSSessionUpdateFailureProtocolIEs_Entry {
 )]
 pub struct MBMSSessionUpdateFailureProtocolIEs(pub Vec<MBMSSessionUpdateFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionUpdateFailureProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8029,7 +8028,7 @@ pub struct MBMSSessionUpdateFailureProtocolExtensions(
     pub Vec<MBMSSessionUpdateFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSessionUpdateResponseProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -8042,7 +8041,7 @@ pub enum MBMSSessionUpdateResponseProtocolIEs_EntryValue {
     Id_TransportLayerInformation(TransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionUpdateResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8051,7 +8050,7 @@ pub struct MBMSSessionUpdateResponseProtocolIEs_Entry {
     pub value: MBMSSessionUpdateResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8062,11 +8061,11 @@ pub struct MBMSSessionUpdateResponseProtocolIEs(
     pub Vec<MBMSSessionUpdateResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSessionUpdateResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8077,14 +8076,14 @@ pub struct MBMSSessionUpdateResponseProtocolExtensions(
     pub Vec<MBMSSessionUpdateResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSSynchronisationInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 236)]
     Id_IP_Source_Address(IPMulticastAddress),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSSynchronisationInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8093,7 +8092,7 @@ pub struct MBMSSynchronisationInformationIE_Extensions_Entry {
     pub extension_value: MBMSSynchronisationInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8104,7 +8103,7 @@ pub struct MBMSSynchronisationInformationIE_Extensions(
     pub Vec<MBMSSynchronisationInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSUELinkingRequestProtocolIEs_EntryValue {
     #[asn(key = 141)]
@@ -8113,7 +8112,7 @@ pub enum MBMSUELinkingRequestProtocolIEs_EntryValue {
     Id_LeftMBMSBearerServicesList(LeftMBMSBearerService_IEs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSUELinkingRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8122,7 +8121,7 @@ pub struct MBMSUELinkingRequestProtocolIEs_Entry {
     pub value: MBMSUELinkingRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8131,11 +8130,11 @@ pub struct MBMSUELinkingRequestProtocolIEs_Entry {
 )]
 pub struct MBMSUELinkingRequestProtocolIEs(pub Vec<MBMSUELinkingRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSUELinkingRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8146,7 +8145,7 @@ pub struct MBMSUELinkingRequestProtocolExtensions(
     pub Vec<MBMSUELinkingRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MBMSUELinkingResponseProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -8155,7 +8154,7 @@ pub enum MBMSUELinkingResponseProtocolIEs_EntryValue {
     Id_UnsuccessfulLinkingList(UnsuccessfulLinking_IEs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSUELinkingResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8164,7 +8163,7 @@ pub struct MBMSUELinkingResponseProtocolIEs_Entry {
     pub value: MBMSUELinkingResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8173,11 +8172,11 @@ pub struct MBMSUELinkingResponseProtocolIEs_Entry {
 )]
 pub struct MBMSUELinkingResponseProtocolIEs(pub Vec<MBMSUELinkingResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBMSUELinkingResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8188,14 +8187,14 @@ pub struct MBMSUELinkingResponseProtocolExtensions(
     pub Vec<MBMSUELinkingResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MDT_ConfigurationIE_Extensions_EntryExtensionValue {
     #[asn(key = 264)]
     Id_SignallingBasedMDTPLMNList(MDT_PLMN_List),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDT_ConfigurationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8204,7 +8203,7 @@ pub struct MDT_ConfigurationIE_Extensions_Entry {
     pub extension_value: MDT_ConfigurationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8213,15 +8212,15 @@ pub struct MDT_ConfigurationIE_Extensions_Entry {
 )]
 pub struct MDT_ConfigurationIE_Extensions(pub Vec<MDT_ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_45;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MessageStructure_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8230,7 +8229,7 @@ pub struct MessageStructure_EntryIE_Extensions_Entry {}
 )]
 pub struct MessageStructure_EntryIE_Extensions(pub Vec<MessageStructure_EntryIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct MessageStructure_Entry {
     pub ie_id: ProtocolIE_ID,
@@ -8240,14 +8239,14 @@ pub struct MessageStructure_Entry {
     pub ie_extensions: Option<MessageStructure_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NotEmptyRAListofIdleModeUEsIE_Extensions_EntryExtensionValue {
     #[asn(key = 180)]
     Id_LAofIdleModeUEs(LAListofIdleModeUEs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NotEmptyRAListofIdleModeUEsIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8256,7 +8255,7 @@ pub struct NotEmptyRAListofIdleModeUEsIE_Extensions_Entry {
     pub extension_value: NotEmptyRAListofIdleModeUEsIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8267,11 +8266,11 @@ pub struct NotEmptyRAListofIdleModeUEsIE_Extensions(
     pub Vec<NotEmptyRAListofIdleModeUEsIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Offload_RAB_ParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8280,7 +8279,7 @@ pub struct Offload_RAB_ParametersIE_Extensions_Entry {}
 )]
 pub struct Offload_RAB_ParametersIE_Extensions(pub Vec<Offload_RAB_ParametersIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum OutcomeValue {
     #[asn(key = 38)]
@@ -8295,7 +8294,7 @@ pub enum OutcomeValue {
     Id_UeRegistrationQuery(UeRegistrationQueryResponse),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum OverloadProtocolIEs_EntryValue {
     #[asn(key = 86)]
@@ -8304,7 +8303,7 @@ pub enum OverloadProtocolIEs_EntryValue {
     Id_NumberOfSteps(NumberOfSteps),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8313,7 +8312,7 @@ pub struct OverloadProtocolIEs_Entry {
     pub value: OverloadProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8322,7 +8321,7 @@ pub struct OverloadProtocolIEs_Entry {
 )]
 pub struct OverloadProtocolIEs(pub Vec<OverloadProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum OverloadProtocolExtensions_EntryExtensionValue {
     #[asn(key = 3)]
@@ -8335,7 +8334,7 @@ pub enum OverloadProtocolExtensions_EntryExtensionValue {
     Id_Priority_Class_Indicator(Priority_Class_Indicator),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -8344,7 +8343,7 @@ pub struct OverloadProtocolExtensions_Entry {
     pub extension_value: OverloadProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8353,11 +8352,11 @@ pub struct OverloadProtocolExtensions_Entry {
 )]
 pub struct OverloadProtocolExtensions(pub Vec<OverloadProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PLMNBasedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8366,11 +8365,11 @@ pub struct PLMNBasedIE_Extensions_Entry {}
 )]
 pub struct PLMNBasedIE_Extensions(pub Vec<PLMNBasedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PLMNs_in_shared_network_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8381,7 +8380,7 @@ pub struct PLMNs_in_shared_network_EntryIE_Extensions(
     pub Vec<PLMNs_in_shared_network_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PLMNs_in_shared_network_Entry {
     pub plm_nidentity: PLMNidentity,
@@ -8390,7 +8389,7 @@ pub struct PLMNs_in_shared_network_Entry {
     pub ie_extensions: Option<PLMNs_in_shared_network_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PagingProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -8409,7 +8408,7 @@ pub enum PagingProtocolIEs_EntryValue {
     Id_TemporaryUE_ID(TemporaryUE_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8418,7 +8417,7 @@ pub struct PagingProtocolIEs_Entry {
     pub value: PagingProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8427,7 +8426,7 @@ pub struct PagingProtocolIEs_Entry {
 )]
 pub struct PagingProtocolIEs(pub Vec<PagingProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PagingProtocolExtensions_EntryExtensionValue {
     #[asn(key = 229)]
@@ -8436,7 +8435,7 @@ pub enum PagingProtocolExtensions_EntryExtensionValue {
     Id_GlobalCN_ID(GlobalCN_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -8445,7 +8444,7 @@ pub struct PagingProtocolExtensions_Entry {
     pub extension_value: PagingProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8454,19 +8453,19 @@ pub struct PagingProtocolExtensions_Entry {
 )]
 pub struct PagingProtocolExtensions(pub Vec<PagingProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "8639999", extensible = true)]
 pub struct INTEGER_46(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "8639999", extensible = true)]
 pub struct INTEGER_47(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PeriodicLocationInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8475,7 +8474,7 @@ pub struct PeriodicLocationInfoIE_Extensions_Entry {}
 )]
 pub struct PeriodicLocationInfoIE_Extensions(pub Vec<PeriodicLocationInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PositionDataIE_Extensions_EntryExtensionValue {
     #[asn(key = 284)]
@@ -8484,7 +8483,7 @@ pub enum PositionDataIE_Extensions_EntryExtensionValue {
     Id_GANSS_PositioningDataSet(GANSS_PositioningDataSet),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PositionDataIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8493,7 +8492,7 @@ pub struct PositionDataIE_Extensions_Entry {
     pub extension_value: PositionDataIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8502,19 +8501,19 @@ pub struct PositionDataIE_Extensions_Entry {
 )]
 pub struct PositionDataIE_Extensions(pub Vec<PositionDataIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct INTEGER_48(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OBJECT-IDENTIFIER")]
 pub struct OBJECT_IDENTIFIER_49;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PrivateMessagePrivateIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8523,7 +8522,7 @@ pub struct PrivateMessagePrivateIEs_Entry {}
 )]
 pub struct PrivateMessagePrivateIEs(pub Vec<PrivateMessagePrivateIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_AssignmentRequestProtocolIEs_EntryValue {
     #[asn(key = 41)]
@@ -8532,7 +8531,7 @@ pub enum RAB_AssignmentRequestProtocolIEs_EntryValue {
     Id_RAB_SetupOrModifyList(RAB_SetupOrModifyList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_AssignmentRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8541,7 +8540,7 @@ pub struct RAB_AssignmentRequestProtocolIEs_Entry {
     pub value: RAB_AssignmentRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8550,7 +8549,7 @@ pub struct RAB_AssignmentRequestProtocolIEs_Entry {
 )]
 pub struct RAB_AssignmentRequestProtocolIEs(pub Vec<RAB_AssignmentRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_AssignmentRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 239)]
@@ -8559,7 +8558,7 @@ pub enum RAB_AssignmentRequestProtocolExtensions_EntryExtensionValue {
     Id_UE_AggregateMaximumBitRate(UE_AggregateMaximumBitRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_AssignmentRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -8568,7 +8567,7 @@ pub struct RAB_AssignmentRequestProtocolExtensions_Entry {
     pub extension_value: RAB_AssignmentRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8579,7 +8578,7 @@ pub struct RAB_AssignmentRequestProtocolExtensions(
     pub Vec<RAB_AssignmentRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_AssignmentResponseProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -8596,7 +8595,7 @@ pub enum RAB_AssignmentResponseProtocolIEs_EntryValue {
     Id_RAB_SetupOrModifiedList(RAB_SetupOrModifiedList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_AssignmentResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8605,7 +8604,7 @@ pub struct RAB_AssignmentResponseProtocolIEs_Entry {
     pub value: RAB_AssignmentResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8614,14 +8613,14 @@ pub struct RAB_AssignmentResponseProtocolIEs_Entry {
 )]
 pub struct RAB_AssignmentResponseProtocolIEs(pub Vec<RAB_AssignmentResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_AssignmentResponseProtocolExtensions_EntryExtensionValue {
     #[asn(key = 110)]
     Id_GERAN_Iumode_RAB_FailedList_RABAssgntResponse(GERAN_Iumode_RAB_FailedList_RABAssgntResponse),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_AssignmentResponseProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -8630,7 +8629,7 @@ pub struct RAB_AssignmentResponseProtocolExtensions_Entry {
     pub extension_value: RAB_AssignmentResponseProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8641,14 +8640,14 @@ pub struct RAB_AssignmentResponseProtocolExtensions(
     pub Vec<RAB_AssignmentResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ContextFailedtoTransferList_Entry_EntryValue {
     #[asn(key = 84)]
     Id_RAB_ContextFailedtoTransferItem(RABs_ContextFailedtoTransferItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ContextFailedtoTransferList_Entry_Entry {
     #[asn(key_field = true)]
@@ -8657,7 +8656,7 @@ pub struct RAB_ContextFailedtoTransferList_Entry_Entry {
     pub value: RAB_ContextFailedtoTransferList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8668,11 +8667,11 @@ pub struct RAB_ContextFailedtoTransferList_Entry(
     pub Vec<RAB_ContextFailedtoTransferList_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ContextItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8681,11 +8680,11 @@ pub struct RAB_ContextItemIE_Extensions_Entry {}
 )]
 pub struct RAB_ContextItemIE_Extensions(pub Vec<RAB_ContextItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ContextItem_RANAP_RelocInfIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8696,14 +8695,14 @@ pub struct RAB_ContextItem_RANAP_RelocInfIE_Extensions(
     pub Vec<RAB_ContextItem_RANAP_RelocInfIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ContextList_Entry_EntryValue {
     #[asn(key = 24)]
     Id_RAB_ContextItem(RAB_ContextItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ContextList_Entry_Entry {
     #[asn(key_field = true)]
@@ -8712,7 +8711,7 @@ pub struct RAB_ContextList_Entry_Entry {
     pub value: RAB_ContextList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8721,14 +8720,14 @@ pub struct RAB_ContextList_Entry_Entry {
 )]
 pub struct RAB_ContextList_Entry(pub Vec<RAB_ContextList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ContextList_RANAP_RelocInf_Entry_EntryValue {
     #[asn(key = 82)]
     Id_RAB_ContextItem_RANAP_RelocInf(RAB_ContextItem_RANAP_RelocInf),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ContextList_RANAP_RelocInf_Entry_Entry {
     #[asn(key_field = true)]
@@ -8737,7 +8736,7 @@ pub struct RAB_ContextList_RANAP_RelocInf_Entry_Entry {
     pub value: RAB_ContextList_RANAP_RelocInf_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8748,7 +8747,7 @@ pub struct RAB_ContextList_RANAP_RelocInf_Entry(
     pub Vec<RAB_ContextList_RANAP_RelocInf_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_DataForwardingItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 13)]
@@ -8757,7 +8756,7 @@ pub enum RAB_DataForwardingItemIE_Extensions_EntryExtensionValue {
     Id_TransportLayerAddress(TransportLayerAddress),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataForwardingItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8766,7 +8765,7 @@ pub struct RAB_DataForwardingItemIE_Extensions_Entry {
     pub extension_value: RAB_DataForwardingItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8775,11 +8774,11 @@ pub struct RAB_DataForwardingItemIE_Extensions_Entry {
 )]
 pub struct RAB_DataForwardingItemIE_Extensions(pub Vec<RAB_DataForwardingItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataForwardingItem_SRNS_CtxReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8790,14 +8789,14 @@ pub struct RAB_DataForwardingItem_SRNS_CtxReqIE_Extensions(
     pub Vec<RAB_DataForwardingItem_SRNS_CtxReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_DataForwardingList_Entry_EntryValue {
     #[asn(key = 26)]
     Id_RAB_DataForwardingItem(RAB_DataForwardingItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataForwardingList_Entry_Entry {
     #[asn(key_field = true)]
@@ -8806,7 +8805,7 @@ pub struct RAB_DataForwardingList_Entry_Entry {
     pub value: RAB_DataForwardingList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8815,14 +8814,14 @@ pub struct RAB_DataForwardingList_Entry_Entry {
 )]
 pub struct RAB_DataForwardingList_Entry(pub Vec<RAB_DataForwardingList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_DataForwardingList_SRNS_CtxReq_Entry_EntryValue {
     #[asn(key = 27)]
     Id_RAB_DataForwardingItem_SRNS_CtxReq(RAB_DataForwardingItem_SRNS_CtxReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataForwardingList_SRNS_CtxReq_Entry_Entry {
     #[asn(key_field = true)]
@@ -8831,7 +8830,7 @@ pub struct RAB_DataForwardingList_SRNS_CtxReq_Entry_Entry {
     pub value: RAB_DataForwardingList_SRNS_CtxReq_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8842,11 +8841,11 @@ pub struct RAB_DataForwardingList_SRNS_CtxReq_Entry(
     pub Vec<RAB_DataForwardingList_SRNS_CtxReq_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataVolumeReportItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8857,14 +8856,14 @@ pub struct RAB_DataVolumeReportItemIE_Extensions(
     pub Vec<RAB_DataVolumeReportItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_DataVolumeReportList_Entry_EntryValue {
     #[asn(key = 30)]
     Id_RAB_DataVolumeReportItem(RAB_DataVolumeReportItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataVolumeReportList_Entry_Entry {
     #[asn(key_field = true)]
@@ -8873,7 +8872,7 @@ pub struct RAB_DataVolumeReportList_Entry_Entry {
     pub value: RAB_DataVolumeReportList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8882,11 +8881,11 @@ pub struct RAB_DataVolumeReportList_Entry_Entry {
 )]
 pub struct RAB_DataVolumeReportList_Entry(pub Vec<RAB_DataVolumeReportList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataVolumeReportRequestItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8897,14 +8896,14 @@ pub struct RAB_DataVolumeReportRequestItemIE_Extensions(
     pub Vec<RAB_DataVolumeReportRequestItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_DataVolumeReportRequestList_Entry_EntryValue {
     #[asn(key = 32)]
     Id_RAB_DataVolumeReportRequestItem(RAB_DataVolumeReportRequestItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_DataVolumeReportRequestList_Entry_Entry {
     #[asn(key_field = true)]
@@ -8913,7 +8912,7 @@ pub struct RAB_DataVolumeReportRequestList_Entry_Entry {
     pub value: RAB_DataVolumeReportRequestList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8924,11 +8923,11 @@ pub struct RAB_DataVolumeReportRequestList_Entry(
     pub Vec<RAB_DataVolumeReportRequestList_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_FailedItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8937,11 +8936,11 @@ pub struct RAB_FailedItemIE_Extensions_Entry {}
 )]
 pub struct RAB_FailedItemIE_Extensions(pub Vec<RAB_FailedItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_FailedItem_EnhRelocInfoResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8952,14 +8951,14 @@ pub struct RAB_FailedItem_EnhRelocInfoResIE_Extensions(
     pub Vec<RAB_FailedItem_EnhRelocInfoResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_FailedList_Entry_EntryValue {
     #[asn(key = 34)]
     Id_RAB_FailedItem(RAB_FailedItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_FailedList_Entry_Entry {
     #[asn(key_field = true)]
@@ -8968,7 +8967,7 @@ pub struct RAB_FailedList_Entry_Entry {
     pub value: RAB_FailedList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8977,14 +8976,14 @@ pub struct RAB_FailedList_Entry_Entry {
 )]
 pub struct RAB_FailedList_Entry(pub Vec<RAB_FailedList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_FailedList_EnhRelocInfoRes_Entry_EntryValue {
     #[asn(key = 198)]
     Id_RAB_FailedItem_EnhRelocInfoRes(RAB_FailedItem_EnhRelocInfoRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_FailedList_EnhRelocInfoRes_Entry_Entry {
     #[asn(key_field = true)]
@@ -8993,7 +8992,7 @@ pub struct RAB_FailedList_EnhRelocInfoRes_Entry_Entry {
     pub value: RAB_FailedList_EnhRelocInfoRes_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9004,14 +9003,14 @@ pub struct RAB_FailedList_EnhRelocInfoRes_Entry(
     pub Vec<RAB_FailedList_EnhRelocInfoRes_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_FailedtoReportList_Entry_EntryValue {
     #[asn(key = 71)]
     Id_RAB_FailedtoReportItem(RABs_failed_to_reportItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_FailedtoReportList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9020,7 +9019,7 @@ pub struct RAB_FailedtoReportList_Entry_Entry {
     pub value: RAB_FailedtoReportList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9029,11 +9028,11 @@ pub struct RAB_FailedtoReportList_Entry_Entry {
 )]
 pub struct RAB_FailedtoReportList_Entry(pub Vec<RAB_FailedtoReportList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ModifyItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9042,14 +9041,14 @@ pub struct RAB_ModifyItemIE_Extensions_Entry {}
 )]
 pub struct RAB_ModifyItemIE_Extensions(pub Vec<RAB_ModifyItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ModifyList_Entry_EntryValue {
     #[asn(key = 92)]
     Id_RAB_ModifyItem(RAB_ModifyItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ModifyList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9058,7 +9057,7 @@ pub struct RAB_ModifyList_Entry_Entry {
     pub value: RAB_ModifyList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9067,14 +9066,14 @@ pub struct RAB_ModifyList_Entry_Entry {
 )]
 pub struct RAB_ModifyList_Entry(pub Vec<RAB_ModifyList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ModifyRequestProtocolIEs_EntryValue {
     #[asn(key = 91)]
     Id_RAB_ModifyList(RAB_ModifyList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ModifyRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9083,7 +9082,7 @@ pub struct RAB_ModifyRequestProtocolIEs_Entry {
     pub value: RAB_ModifyRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9092,11 +9091,11 @@ pub struct RAB_ModifyRequestProtocolIEs_Entry {
 )]
 pub struct RAB_ModifyRequestProtocolIEs(pub Vec<RAB_ModifyRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ModifyRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9105,7 +9104,7 @@ pub struct RAB_ModifyRequestProtocolExtensions_Entry {}
 )]
 pub struct RAB_ModifyRequestProtocolExtensions(pub Vec<RAB_ModifyRequestProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ParametersIE_Extensions_EntryExtensionValue {
     #[asn(key = 176)]
@@ -9120,7 +9119,7 @@ pub enum RAB_ParametersIE_Extensions_EntryExtensionValue {
     Id_SignallingIndication(SignallingIndication),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ParametersIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9129,7 +9128,7 @@ pub struct RAB_ParametersIE_Extensions_Entry {
     pub extension_value: RAB_ParametersIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9138,11 +9137,11 @@ pub struct RAB_ParametersIE_Extensions_Entry {
 )]
 pub struct RAB_ParametersIE_Extensions(pub Vec<RAB_ParametersIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_QueuedItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9151,14 +9150,14 @@ pub struct RAB_QueuedItemIE_Extensions_Entry {}
 )]
 pub struct RAB_QueuedItemIE_Extensions(pub Vec<RAB_QueuedItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_QueuedList_Entry_EntryValue {
     #[asn(key = 37)]
     Id_RAB_QueuedItem(RAB_QueuedItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_QueuedList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9167,7 +9166,7 @@ pub struct RAB_QueuedList_Entry_Entry {
     pub value: RAB_QueuedList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9176,11 +9175,11 @@ pub struct RAB_QueuedList_Entry_Entry {
 )]
 pub struct RAB_QueuedList_Entry(pub Vec<RAB_QueuedList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleaseItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9189,14 +9188,14 @@ pub struct RAB_ReleaseItemIE_Extensions_Entry {}
 )]
 pub struct RAB_ReleaseItemIE_Extensions(pub Vec<RAB_ReleaseItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ReleaseList_Entry_EntryValue {
     #[asn(key = 40)]
     Id_RAB_ReleaseItem(RAB_ReleaseItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleaseList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9205,7 +9204,7 @@ pub struct RAB_ReleaseList_Entry_Entry {
     pub value: RAB_ReleaseList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9214,14 +9213,14 @@ pub struct RAB_ReleaseList_Entry_Entry {
 )]
 pub struct RAB_ReleaseList_Entry(pub Vec<RAB_ReleaseList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ReleaseRequestProtocolIEs_EntryValue {
     #[asn(key = 41)]
     Id_RAB_ReleaseList(RAB_ReleaseList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleaseRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9230,7 +9229,7 @@ pub struct RAB_ReleaseRequestProtocolIEs_Entry {
     pub value: RAB_ReleaseRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9239,11 +9238,11 @@ pub struct RAB_ReleaseRequestProtocolIEs_Entry {
 )]
 pub struct RAB_ReleaseRequestProtocolIEs(pub Vec<RAB_ReleaseRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleaseRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9254,11 +9253,11 @@ pub struct RAB_ReleaseRequestProtocolExtensions(
     pub Vec<RAB_ReleaseRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleasedItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9267,11 +9266,11 @@ pub struct RAB_ReleasedItemIE_Extensions_Entry {}
 )]
 pub struct RAB_ReleasedItemIE_Extensions(pub Vec<RAB_ReleasedItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleasedItem_IuRelCompIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9282,14 +9281,14 @@ pub struct RAB_ReleasedItem_IuRelCompIE_Extensions(
     pub Vec<RAB_ReleasedItem_IuRelCompIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ReleasedList_Entry_EntryValue {
     #[asn(key = 42)]
     Id_RAB_ReleasedItem(RAB_ReleasedItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleasedList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9298,7 +9297,7 @@ pub struct RAB_ReleasedList_Entry_Entry {
     pub value: RAB_ReleasedList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9307,14 +9306,14 @@ pub struct RAB_ReleasedList_Entry_Entry {
 )]
 pub struct RAB_ReleasedList_Entry(pub Vec<RAB_ReleasedList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ReleasedList_IuRelComp_Entry_EntryValue {
     #[asn(key = 87)]
     Id_RAB_ReleasedItem_IuRelComp(RAB_ReleasedItem_IuRelComp),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ReleasedList_IuRelComp_Entry_Entry {
     #[asn(key_field = true)]
@@ -9323,7 +9322,7 @@ pub struct RAB_ReleasedList_IuRelComp_Entry_Entry {
     pub value: RAB_ReleasedList_IuRelComp_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9332,11 +9331,11 @@ pub struct RAB_ReleasedList_IuRelComp_Entry_Entry {
 )]
 pub struct RAB_ReleasedList_IuRelComp_Entry(pub Vec<RAB_ReleasedList_IuRelComp_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_RelocationReleaseItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9347,14 +9346,14 @@ pub struct RAB_RelocationReleaseItemIE_Extensions(
     pub Vec<RAB_RelocationReleaseItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_RelocationReleaseList_Entry_EntryValue {
     #[asn(key = 45)]
     Id_RAB_RelocationReleaseItem(RAB_RelocationReleaseItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_RelocationReleaseList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9363,7 +9362,7 @@ pub struct RAB_RelocationReleaseList_Entry_Entry {
     pub value: RAB_RelocationReleaseList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9372,7 +9371,7 @@ pub struct RAB_RelocationReleaseList_Entry_Entry {
 )]
 pub struct RAB_RelocationReleaseList_Entry(pub Vec<RAB_RelocationReleaseList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupItem_EnhRelocInfoReqIE_Extensions_EntryExtensionValue {
     #[asn(key = 231)]
@@ -9381,7 +9380,7 @@ pub enum RAB_SetupItem_EnhRelocInfoReqIE_Extensions_EntryExtensionValue {
     Id_PDP_TypeInformation_extension(PDP_TypeInformation_extension),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupItem_EnhRelocInfoReqIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9390,7 +9389,7 @@ pub struct RAB_SetupItem_EnhRelocInfoReqIE_Extensions_Entry {
     pub extension_value: RAB_SetupItem_EnhRelocInfoReqIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9401,11 +9400,11 @@ pub struct RAB_SetupItem_EnhRelocInfoReqIE_Extensions(
     pub Vec<RAB_SetupItem_EnhRelocInfoReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupItem_EnhRelocInfoResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9416,11 +9415,11 @@ pub struct RAB_SetupItem_EnhRelocInfoResIE_Extensions(
     pub Vec<RAB_SetupItem_EnhRelocInfoResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupItem_EnhancedRelocCompleteReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9431,14 +9430,14 @@ pub struct RAB_SetupItem_EnhancedRelocCompleteReqIE_Extensions(
     pub Vec<RAB_SetupItem_EnhancedRelocCompleteReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupItem_EnhancedRelocCompleteResIE_Extensions_EntryExtensionValue {
     #[asn(key = 240)]
     Id_Offload_RAB_Parameters(Offload_RAB_Parameters),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupItem_EnhancedRelocCompleteResIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9447,7 +9446,7 @@ pub struct RAB_SetupItem_EnhancedRelocCompleteResIE_Extensions_Entry {
     pub extension_value: RAB_SetupItem_EnhancedRelocCompleteResIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9458,7 +9457,7 @@ pub struct RAB_SetupItem_EnhancedRelocCompleteResIE_Extensions(
     pub Vec<RAB_SetupItem_EnhancedRelocCompleteResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupItem_RelocReqIE_Extensions_EntryExtensionValue {
     #[asn(key = 89)]
@@ -9473,7 +9472,7 @@ pub enum RAB_SetupItem_RelocReqIE_Extensions_EntryExtensionValue {
     Id_PDP_TypeInformation_extension(PDP_TypeInformation_extension),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupItem_RelocReqIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9482,7 +9481,7 @@ pub struct RAB_SetupItem_RelocReqIE_Extensions_Entry {
     pub extension_value: RAB_SetupItem_RelocReqIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9491,7 +9490,7 @@ pub struct RAB_SetupItem_RelocReqIE_Extensions_Entry {
 )]
 pub struct RAB_SetupItem_RelocReqIE_Extensions(pub Vec<RAB_SetupItem_RelocReqIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupItem_RelocReqAckIE_Extensions_EntryExtensionValue {
     #[asn(key = 90)]
@@ -9502,7 +9501,7 @@ pub enum RAB_SetupItem_RelocReqAckIE_Extensions_EntryExtensionValue {
     Id_TransportLayerAddress(TransportLayerAddress),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupItem_RelocReqAckIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9511,7 +9510,7 @@ pub struct RAB_SetupItem_RelocReqAckIE_Extensions_Entry {
     pub extension_value: RAB_SetupItem_RelocReqAckIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9522,14 +9521,14 @@ pub struct RAB_SetupItem_RelocReqAckIE_Extensions(
     pub Vec<RAB_SetupItem_RelocReqAckIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupList_EnhRelocInfoReq_Entry_EntryValue {
     #[asn(key = 193)]
     Id_RAB_SetupItem_EnhRelocInfoReq(RAB_SetupItem_EnhRelocInfoReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupList_EnhRelocInfoReq_Entry_Entry {
     #[asn(key_field = true)]
@@ -9538,7 +9537,7 @@ pub struct RAB_SetupList_EnhRelocInfoReq_Entry_Entry {
     pub value: RAB_SetupList_EnhRelocInfoReq_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9547,14 +9546,14 @@ pub struct RAB_SetupList_EnhRelocInfoReq_Entry_Entry {
 )]
 pub struct RAB_SetupList_EnhRelocInfoReq_Entry(pub Vec<RAB_SetupList_EnhRelocInfoReq_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupList_EnhRelocInfoRes_Entry_EntryValue {
     #[asn(key = 195)]
     Id_RAB_SetupItem_EnhRelocInfoRes(RAB_SetupItem_EnhRelocInfoRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupList_EnhRelocInfoRes_Entry_Entry {
     #[asn(key_field = true)]
@@ -9563,7 +9562,7 @@ pub struct RAB_SetupList_EnhRelocInfoRes_Entry_Entry {
     pub value: RAB_SetupList_EnhRelocInfoRes_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9572,14 +9571,14 @@ pub struct RAB_SetupList_EnhRelocInfoRes_Entry_Entry {
 )]
 pub struct RAB_SetupList_EnhRelocInfoRes_Entry(pub Vec<RAB_SetupList_EnhRelocInfoRes_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupList_EnhancedRelocCompleteReq_Entry_EntryValue {
     #[asn(key = 189)]
     Id_RAB_SetupItem_EnhancedRelocCompleteReq(RAB_SetupItem_EnhancedRelocCompleteReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupList_EnhancedRelocCompleteReq_Entry_Entry {
     #[asn(key_field = true)]
@@ -9588,7 +9587,7 @@ pub struct RAB_SetupList_EnhancedRelocCompleteReq_Entry_Entry {
     pub value: RAB_SetupList_EnhancedRelocCompleteReq_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9599,14 +9598,14 @@ pub struct RAB_SetupList_EnhancedRelocCompleteReq_Entry(
     pub Vec<RAB_SetupList_EnhancedRelocCompleteReq_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupList_EnhancedRelocCompleteRes_Entry_EntryValue {
     #[asn(key = 191)]
     Id_RAB_SetupItem_EnhancedRelocCompleteRes(RAB_SetupItem_EnhancedRelocCompleteRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupList_EnhancedRelocCompleteRes_Entry_Entry {
     #[asn(key_field = true)]
@@ -9615,7 +9614,7 @@ pub struct RAB_SetupList_EnhancedRelocCompleteRes_Entry_Entry {
     pub value: RAB_SetupList_EnhancedRelocCompleteRes_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9626,14 +9625,14 @@ pub struct RAB_SetupList_EnhancedRelocCompleteRes_Entry(
     pub Vec<RAB_SetupList_EnhancedRelocCompleteRes_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupList_RelocReq_Entry_EntryValue {
     #[asn(key = 47)]
     Id_RAB_SetupItem_RelocReq(RAB_SetupItem_RelocReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupList_RelocReq_Entry_Entry {
     #[asn(key_field = true)]
@@ -9642,7 +9641,7 @@ pub struct RAB_SetupList_RelocReq_Entry_Entry {
     pub value: RAB_SetupList_RelocReq_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9651,14 +9650,14 @@ pub struct RAB_SetupList_RelocReq_Entry_Entry {
 )]
 pub struct RAB_SetupList_RelocReq_Entry(pub Vec<RAB_SetupList_RelocReq_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupList_RelocReqAck_Entry_EntryValue {
     #[asn(key = 48)]
     Id_RAB_SetupItem_RelocReqAck(RAB_SetupItem_RelocReqAck),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupList_RelocReqAck_Entry_Entry {
     #[asn(key_field = true)]
@@ -9667,7 +9666,7 @@ pub struct RAB_SetupList_RelocReqAck_Entry_Entry {
     pub value: RAB_SetupList_RelocReqAck_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9676,14 +9675,14 @@ pub struct RAB_SetupList_RelocReqAck_Entry_Entry {
 )]
 pub struct RAB_SetupList_RelocReqAck_Entry(pub Vec<RAB_SetupList_RelocReqAck_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupOrModifiedItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 90)]
     Id_Ass_RAB_Parameters(Ass_RAB_Parameters),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupOrModifiedItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9692,7 +9691,7 @@ pub struct RAB_SetupOrModifiedItemIE_Extensions_Entry {
     pub extension_value: RAB_SetupOrModifiedItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9703,14 +9702,14 @@ pub struct RAB_SetupOrModifiedItemIE_Extensions(
     pub Vec<RAB_SetupOrModifiedItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupOrModifiedList_Entry_EntryValue {
     #[asn(key = 51)]
     Id_RAB_SetupOrModifiedItem(RAB_SetupOrModifiedItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupOrModifiedList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9719,7 +9718,7 @@ pub struct RAB_SetupOrModifiedList_Entry_Entry {
     pub value: RAB_SetupOrModifiedList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9728,7 +9727,7 @@ pub struct RAB_SetupOrModifiedList_Entry_Entry {
 )]
 pub struct RAB_SetupOrModifiedList_Entry(pub Vec<RAB_SetupOrModifiedList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupOrModifyItemFirstIE_Extensions_EntryExtensionValue {
     #[asn(key = 242)]
@@ -9739,7 +9738,7 @@ pub enum RAB_SetupOrModifyItemFirstIE_Extensions_EntryExtensionValue {
     Id_SIPTO_Correlation_ID(Correlation_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupOrModifyItemFirstIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9748,7 +9747,7 @@ pub struct RAB_SetupOrModifyItemFirstIE_Extensions_Entry {
     pub extension_value: RAB_SetupOrModifyItemFirstIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9759,7 +9758,7 @@ pub struct RAB_SetupOrModifyItemFirstIE_Extensions(
     pub Vec<RAB_SetupOrModifyItemFirstIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupOrModifyItemSecondIE_Extensions_EntryExtensionValue {
     #[asn(key = 89)]
@@ -9772,7 +9771,7 @@ pub enum RAB_SetupOrModifyItemSecondIE_Extensions_EntryExtensionValue {
     Id_PDP_TypeInformation_extension(PDP_TypeInformation_extension),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupOrModifyItemSecondIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9781,7 +9780,7 @@ pub struct RAB_SetupOrModifyItemSecondIE_Extensions_Entry {
     pub extension_value: RAB_SetupOrModifyItemSecondIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9792,21 +9791,21 @@ pub struct RAB_SetupOrModifyItemSecondIE_Extensions(
     pub Vec<RAB_SetupOrModifyItemSecondIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupOrModifyList_Entry_EntryFirstValue {
     #[asn(key = 53)]
     Id_RAB_SetupOrModifyItem(RAB_SetupOrModifyItemFirst),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_SetupOrModifyList_Entry_EntrySecondValue {
     #[asn(key = 53)]
     Id_RAB_SetupOrModifyItem(RAB_SetupOrModifyItemSecond),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_SetupOrModifyList_Entry_Entry {
     #[asn(key_field = true)]
@@ -9817,7 +9816,7 @@ pub struct RAB_SetupOrModifyList_Entry_Entry {
     pub second_value: RAB_SetupOrModifyList_Entry_EntrySecondValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9826,11 +9825,11 @@ pub struct RAB_SetupOrModifyList_Entry_Entry {
 )]
 pub struct RAB_SetupOrModifyList_Entry(pub Vec<RAB_SetupOrModifyList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ToBeReleasedItem_EnhancedRelocCompleteResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9841,14 +9840,14 @@ pub struct RAB_ToBeReleasedItem_EnhancedRelocCompleteResIE_Extensions(
     pub Vec<RAB_ToBeReleasedItem_EnhancedRelocCompleteResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_ToBeReleasedList_EnhancedRelocCompleteRes_Entry_EntryValue {
     #[asn(key = 209)]
     Id_RAB_ToBeReleasedItem_EnhancedRelocCompleteRes(RAB_ToBeReleasedItem_EnhancedRelocCompleteRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_ToBeReleasedList_EnhancedRelocCompleteRes_Entry_Entry {
     #[asn(key_field = true)]
@@ -9857,7 +9856,7 @@ pub struct RAB_ToBeReleasedList_EnhancedRelocCompleteRes_Entry_Entry {
     pub value: RAB_ToBeReleasedList_EnhancedRelocCompleteRes_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9868,14 +9867,14 @@ pub struct RAB_ToBeReleasedList_EnhancedRelocCompleteRes_Entry(
     pub Vec<RAB_ToBeReleasedList_EnhancedRelocCompleteRes_Entry_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RAB_TrCH_MappingItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 3)]
     Id_CN_DomainIndicator(CN_DomainIndicator),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAB_TrCH_MappingItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9884,7 +9883,7 @@ pub struct RAB_TrCH_MappingItemIE_Extensions_Entry {
     pub extension_value: RAB_TrCH_MappingItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9893,11 +9892,11 @@ pub struct RAB_TrCH_MappingItemIE_Extensions_Entry {
 )]
 pub struct RAB_TrCH_MappingItemIE_Extensions(pub Vec<RAB_TrCH_MappingItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RABDataVolumeReport_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9908,7 +9907,7 @@ pub struct RABDataVolumeReport_EntryIE_Extensions(
     pub Vec<RABDataVolumeReport_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct RABDataVolumeReport_Entry {
     pub dl_unsuccessfully_transmitted_data_volume: UnsuccessfullyTransmittedDataVolume,
@@ -9918,11 +9917,11 @@ pub struct RABDataVolumeReport_Entry {
     pub ie_extensions: Option<RABDataVolumeReport_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RABParametersList_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9933,7 +9932,7 @@ pub struct RABParametersList_EntryIE_Extensions(
     pub Vec<RABParametersList_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct RABParametersList_Entry {
     pub rab_id: RAB_ID,
@@ -9946,11 +9945,11 @@ pub struct RABParametersList_Entry {
     pub ie_extensions: Option<RABParametersList_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RABasedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9959,11 +9958,11 @@ pub struct RABasedIE_Extensions_Entry {}
 )]
 pub struct RABasedIE_Extensions(pub Vec<RABasedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RABs_ContextFailedtoTransferItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9974,11 +9973,11 @@ pub struct RABs_ContextFailedtoTransferItemIE_Extensions(
     pub Vec<RABs_ContextFailedtoTransferItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RABs_failed_to_reportItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9989,11 +9988,11 @@ pub struct RABs_failed_to_reportItemIE_Extensions(
     pub Vec<RABs_failed_to_reportItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10002,7 +10001,7 @@ pub struct RAIIE_Extensions_Entry {}
 )]
 pub struct RAIIE_Extensions(pub Vec<RAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_50(pub u8);
 impl ENUMERATED_50 {
@@ -10010,7 +10009,7 @@ impl ENUMERATED_50 {
     pub const FULLLIST: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANAP_EnhancedRelocationInformationRequestProtocolIEs_EntryValue {
     #[asn(key = 133)]
@@ -10035,7 +10034,7 @@ pub enum RANAP_EnhancedRelocationInformationRequestProtocolIEs_EntryValue {
     Id_UESBI_Iu(UESBI_Iu),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANAP_EnhancedRelocationInformationRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10044,7 +10043,7 @@ pub struct RANAP_EnhancedRelocationInformationRequestProtocolIEs_Entry {
     pub value: RANAP_EnhancedRelocationInformationRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10055,7 +10054,7 @@ pub struct RANAP_EnhancedRelocationInformationRequestProtocolIEs(
     pub Vec<RANAP_EnhancedRelocationInformationRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANAP_EnhancedRelocationInformationRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 261)]
@@ -10074,7 +10073,7 @@ pub enum RANAP_EnhancedRelocationInformationRequestProtocolExtensions_EntryExten
     Id_UE_AggregateMaximumBitRate(UE_AggregateMaximumBitRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANAP_EnhancedRelocationInformationRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10084,7 +10083,7 @@ pub struct RANAP_EnhancedRelocationInformationRequestProtocolExtensions_Entry {
         RANAP_EnhancedRelocationInformationRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10095,7 +10094,7 @@ pub struct RANAP_EnhancedRelocationInformationRequestProtocolExtensions(
     pub Vec<RANAP_EnhancedRelocationInformationRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANAP_EnhancedRelocationInformationResponseProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -10108,7 +10107,7 @@ pub enum RANAP_EnhancedRelocationInformationResponseProtocolIEs_EntryValue {
     Id_Target_ToSource_TransparentContainer(TargetRNC_ToSourceRNC_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANAP_EnhancedRelocationInformationResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10117,7 +10116,7 @@ pub struct RANAP_EnhancedRelocationInformationResponseProtocolIEs_Entry {
     pub value: RANAP_EnhancedRelocationInformationResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10128,11 +10127,11 @@ pub struct RANAP_EnhancedRelocationInformationResponseProtocolIEs(
     pub Vec<RANAP_EnhancedRelocationInformationResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANAP_EnhancedRelocationInformationResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10143,7 +10142,7 @@ pub struct RANAP_EnhancedRelocationInformationResponseProtocolExtensions(
     pub Vec<RANAP_EnhancedRelocationInformationResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANAP_RelocationInformationProtocolIEs_EntryValue {
     #[asn(key = 81)]
@@ -10152,7 +10151,7 @@ pub enum RANAP_RelocationInformationProtocolIEs_EntryValue {
     Id_RAB_ContextList_RANAP_RelocInf(RAB_ContextList_RANAP_RelocInf),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANAP_RelocationInformationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10161,7 +10160,7 @@ pub struct RANAP_RelocationInformationProtocolIEs_Entry {
     pub value: RANAP_RelocationInformationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10172,7 +10171,7 @@ pub struct RANAP_RelocationInformationProtocolIEs(
     pub Vec<RANAP_RelocationInformationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANAP_RelocationInformationProtocolExtensions_EntryExtensionValue {
     #[asn(key = 247)]
@@ -10181,7 +10180,7 @@ pub enum RANAP_RelocationInformationProtocolExtensions_EntryExtensionValue {
     Id_SourceRNC_PDCP_context_info(RRC_Container),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANAP_RelocationInformationProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10190,7 +10189,7 @@ pub struct RANAP_RelocationInformationProtocolExtensions_Entry {
     pub extension_value: RANAP_RelocationInformationProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10201,11 +10200,11 @@ pub struct RANAP_RelocationInformationProtocolExtensions(
     pub Vec<RANAP_RelocationInformationProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RIM_TransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10214,7 +10213,7 @@ pub struct RIM_TransferIE_Extensions_Entry {}
 )]
 pub struct RIM_TransferIE_Extensions(pub Vec<RIM_TransferIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct ENUMERATED_51(pub u8);
 impl ENUMERATED_51 {
@@ -10222,7 +10221,7 @@ impl ENUMERATED_51 {
     pub const DEACTIVATED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RNCTraceInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 256)]
@@ -10235,7 +10234,7 @@ pub enum RNCTraceInformationIE_Extensions_EntryExtensionValue {
     Id_TraceRecordingSessionReference(TraceRecordingSessionReference),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RNCTraceInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10244,7 +10243,7 @@ pub struct RNCTraceInformationIE_Extensions_Entry {
     pub extension_value: RNCTraceInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10253,11 +10252,11 @@ pub struct RNCTraceInformationIE_Extensions_Entry {
 )]
 pub struct RNCTraceInformationIE_Extensions(pub Vec<RNCTraceInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RNSAPRelocationParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10268,15 +10267,15 @@ pub struct RNSAPRelocationParametersIE_Extensions(
     pub Vec<RNSAPRelocationParametersIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BOOLEAN")]
 pub struct BOOLEAN_52(pub bool);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BOOLEAN")]
 pub struct BOOLEAN_53(pub bool);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -10285,7 +10284,7 @@ pub struct BOOLEAN_53(pub bool);
 )]
 pub struct BIT_STRING_54(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -10294,11 +10293,11 @@ pub struct BIT_STRING_54(pub BitVec<u8, Msb0>);
 )]
 pub struct OCTET_STRING_55(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RSRVCC_InformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10307,7 +10306,7 @@ pub struct RSRVCC_InformationIE_Extensions_Entry {}
 )]
 pub struct RSRVCC_InformationIE_Extensions(pub Vec<RSRVCC_InformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RedirectionIndication_EntryValue {
     #[asn(key = 280)]
@@ -10322,7 +10321,7 @@ pub enum RedirectionIndication_EntryValue {
     Id_RejectCauseValue(RejectCauseValue),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RedirectionIndication_Entry {
     #[asn(key_field = true)]
@@ -10331,14 +10330,14 @@ pub struct RedirectionIndication_Entry {
     pub value: RedirectionIndication_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationCancelProtocolIEs_EntryValue {
     #[asn(key = 4)]
     Id_Cause(Cause),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCancelProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10347,7 +10346,7 @@ pub struct RelocationCancelProtocolIEs_Entry {
     pub value: RelocationCancelProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10356,11 +10355,11 @@ pub struct RelocationCancelProtocolIEs_Entry {
 )]
 pub struct RelocationCancelProtocolIEs(pub Vec<RelocationCancelProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCancelProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10369,14 +10368,14 @@ pub struct RelocationCancelProtocolExtensions_Entry {}
 )]
 pub struct RelocationCancelProtocolExtensions(pub Vec<RelocationCancelProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationCancelAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 9)]
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCancelAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10385,7 +10384,7 @@ pub struct RelocationCancelAcknowledgeProtocolIEs_Entry {
     pub value: RelocationCancelAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10396,11 +10395,11 @@ pub struct RelocationCancelAcknowledgeProtocolIEs(
     pub Vec<RelocationCancelAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCancelAcknowledgeProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10411,7 +10410,7 @@ pub struct RelocationCancelAcknowledgeProtocolExtensions(
     pub Vec<RelocationCancelAcknowledgeProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationCommandProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -10426,7 +10425,7 @@ pub enum RelocationCommandProtocolIEs_EntryValue {
     Id_Target_ToSource_TransparentContainer(Target_ToSource_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10435,7 +10434,7 @@ pub struct RelocationCommandProtocolIEs_Entry {
     pub value: RelocationCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10444,7 +10443,7 @@ pub struct RelocationCommandProtocolIEs_Entry {
 )]
 pub struct RelocationCommandProtocolIEs(pub Vec<RelocationCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationCommandProtocolExtensions_EntryExtensionValue {
     #[asn(key = 99)]
@@ -10457,7 +10456,7 @@ pub enum RelocationCommandProtocolExtensions_EntryExtensionValue {
     Id_TargetBSS_ToSourceBSS_TransparentContainer(TargetBSS_ToSourceBSS_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCommandProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10466,7 +10465,7 @@ pub struct RelocationCommandProtocolExtensions_Entry {
     pub extension_value: RelocationCommandProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10475,11 +10474,11 @@ pub struct RelocationCommandProtocolExtensions_Entry {
 )]
 pub struct RelocationCommandProtocolExtensions(pub Vec<RelocationCommandProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCompleteProtocolIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10488,7 +10487,7 @@ pub struct RelocationCompleteProtocolIEs_Entry {}
 )]
 pub struct RelocationCompleteProtocolIEs(pub Vec<RelocationCompleteProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationCompleteProtocolExtensions_EntryExtensionValue {
     #[asn(key = 250)]
@@ -10499,7 +10498,7 @@ pub enum RelocationCompleteProtocolExtensions_EntryExtensionValue {
     Id_Tunnel_Information_for_BBF(TunnelInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationCompleteProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10508,7 +10507,7 @@ pub struct RelocationCompleteProtocolExtensions_Entry {
     pub extension_value: RelocationCompleteProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10519,11 +10518,11 @@ pub struct RelocationCompleteProtocolExtensions(
     pub Vec<RelocationCompleteProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationDetectProtocolIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10532,11 +10531,11 @@ pub struct RelocationDetectProtocolIEs_Entry {}
 )]
 pub struct RelocationDetectProtocolIEs(pub Vec<RelocationDetectProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationDetectProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10545,7 +10544,7 @@ pub struct RelocationDetectProtocolExtensions_Entry {}
 )]
 pub struct RelocationDetectProtocolExtensions(pub Vec<RelocationDetectProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -10554,7 +10553,7 @@ pub enum RelocationFailureProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10563,7 +10562,7 @@ pub struct RelocationFailureProtocolIEs_Entry {
     pub value: RelocationFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10572,7 +10571,7 @@ pub struct RelocationFailureProtocolIEs_Entry {
 )]
 pub struct RelocationFailureProtocolIEs(pub Vec<RelocationFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationFailureProtocolExtensions_EntryExtensionValue {
     #[asn(key = 108)]
@@ -10581,7 +10580,7 @@ pub enum RelocationFailureProtocolExtensions_EntryExtensionValue {
     Id_NewBSS_To_OldBSS_Information(NewBSS_To_OldBSS_Information),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationFailureProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10590,7 +10589,7 @@ pub struct RelocationFailureProtocolExtensions_Entry {
     pub extension_value: RelocationFailureProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10599,7 +10598,7 @@ pub struct RelocationFailureProtocolExtensions_Entry {
 )]
 pub struct RelocationFailureProtocolExtensions(pub Vec<RelocationFailureProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationPreparationFailureProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -10608,7 +10607,7 @@ pub enum RelocationPreparationFailureProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationPreparationFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10617,7 +10616,7 @@ pub struct RelocationPreparationFailureProtocolIEs_Entry {
     pub value: RelocationPreparationFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10628,14 +10627,14 @@ pub struct RelocationPreparationFailureProtocolIEs(
     pub Vec<RelocationPreparationFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationPreparationFailureProtocolExtensions_EntryExtensionValue {
     #[asn(key = 99)]
     Id_InterSystemInformation_TransparentContainer(InterSystemInformation_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationPreparationFailureProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10644,7 +10643,7 @@ pub struct RelocationPreparationFailureProtocolExtensions_Entry {
     pub extension_value: RelocationPreparationFailureProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10655,7 +10654,7 @@ pub struct RelocationPreparationFailureProtocolExtensions(
     pub Vec<RelocationPreparationFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationRequestProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -10676,7 +10675,7 @@ pub enum RelocationRequestProtocolIEs_EntryValue {
     Id_Source_ToTarget_TransparentContainer(SourceRNC_ToTargetRNC_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10685,7 +10684,7 @@ pub struct RelocationRequestProtocolIEs_Entry {
     pub value: RelocationRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10694,7 +10693,7 @@ pub struct RelocationRequestProtocolIEs_Entry {
 )]
 pub struct RelocationRequestProtocolIEs(pub Vec<RelocationRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 261)]
@@ -10725,7 +10724,7 @@ pub enum RelocationRequestProtocolExtensions_EntryExtensionValue {
     Id_UESBI_Iu(UESBI_Iu),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10734,7 +10733,7 @@ pub struct RelocationRequestProtocolExtensions_Entry {
     pub extension_value: RelocationRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10743,7 +10742,7 @@ pub struct RelocationRequestProtocolExtensions_Entry {
 )]
 pub struct RelocationRequestProtocolExtensions(pub Vec<RelocationRequestProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationRequestAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 5)]
@@ -10760,7 +10759,7 @@ pub enum RelocationRequestAcknowledgeProtocolIEs_EntryValue {
     Id_Target_ToSource_TransparentContainer(TargetRNC_ToSourceRNC_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationRequestAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10769,7 +10768,7 @@ pub struct RelocationRequestAcknowledgeProtocolIEs_Entry {
     pub value: RelocationRequestAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10780,7 +10779,7 @@ pub struct RelocationRequestAcknowledgeProtocolIEs(
     pub Vec<RelocationRequestAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationRequestAcknowledgeProtocolExtensions_EntryExtensionValue {
     #[asn(key = 203)]
@@ -10789,7 +10788,7 @@ pub enum RelocationRequestAcknowledgeProtocolExtensions_EntryExtensionValue {
     Id_NewBSS_To_OldBSS_Information(NewBSS_To_OldBSS_Information),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationRequestAcknowledgeProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10798,7 +10797,7 @@ pub struct RelocationRequestAcknowledgeProtocolExtensions_Entry {
     pub extension_value: RelocationRequestAcknowledgeProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10809,7 +10808,7 @@ pub struct RelocationRequestAcknowledgeProtocolExtensions(
     pub Vec<RelocationRequestAcknowledgeProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationRequiredProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -10830,7 +10829,7 @@ pub enum RelocationRequiredProtocolIEs_EntryValue {
     Id_TargetID(TargetID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationRequiredProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10839,7 +10838,7 @@ pub struct RelocationRequiredProtocolIEs_Entry {
     pub value: RelocationRequiredProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10848,7 +10847,7 @@ pub struct RelocationRequiredProtocolIEs_Entry {
 )]
 pub struct RelocationRequiredProtocolIEs(pub Vec<RelocationRequiredProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RelocationRequiredProtocolExtensions_EntryExtensionValue {
     #[asn(key = 203)]
@@ -10869,7 +10868,7 @@ pub enum RelocationRequiredProtocolExtensions_EntryExtensionValue {
     ),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RelocationRequiredProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -10878,7 +10877,7 @@ pub struct RelocationRequiredProtocolExtensions_Entry {
     pub extension_value: RelocationRequiredProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10889,11 +10888,11 @@ pub struct RelocationRequiredProtocolExtensions(
     pub Vec<RelocationRequiredProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_56(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Requested_RAB_Parameter_ValuesIE_Extensions_EntryExtensionValue {
     #[asn(key = 159)]
@@ -10912,7 +10911,7 @@ pub enum Requested_RAB_Parameter_ValuesIE_Extensions_EntryExtensionValue {
     Id_Requested_RAB_Parameter_SupportedMaxBitrateList(SupportedRAB_ParameterBitrateList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Requested_RAB_Parameter_ValuesIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10921,7 +10920,7 @@ pub struct Requested_RAB_Parameter_ValuesIE_Extensions_Entry {
     pub extension_value: Requested_RAB_Parameter_ValuesIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10932,7 +10931,7 @@ pub struct Requested_RAB_Parameter_ValuesIE_Extensions(
     pub Vec<Requested_RAB_Parameter_ValuesIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RerouteNASRequestProtocolIEs_EntryValue {
     #[asn(key = 287)]
@@ -10943,7 +10942,7 @@ pub enum RerouteNASRequestProtocolIEs_EntryValue {
     Id_UE_Usage_Type(UE_Usage_Type),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RerouteNASRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10952,7 +10951,7 @@ pub struct RerouteNASRequestProtocolIEs_Entry {
     pub value: RerouteNASRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10961,11 +10960,11 @@ pub struct RerouteNASRequestProtocolIEs_Entry {
 )]
 pub struct RerouteNASRequestProtocolIEs(pub Vec<RerouteNASRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RerouteNASRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10974,7 +10973,7 @@ pub struct RerouteNASRequestProtocolExtensions_Entry {}
 )]
 pub struct RerouteNASRequestProtocolExtensions(pub Vec<RerouteNASRequestProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -10985,7 +10984,7 @@ pub enum ResetProtocolIEs_EntryValue {
     Id_GlobalRNC_ID(GlobalRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10994,7 +10993,7 @@ pub struct ResetProtocolIEs_Entry {
     pub value: ResetProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11003,7 +11002,7 @@ pub struct ResetProtocolIEs_Entry {
 )]
 pub struct ResetProtocolIEs(pub Vec<ResetProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
@@ -11012,7 +11011,7 @@ pub enum ResetProtocolExtensions_EntryExtensionValue {
     Id_GlobalCN_ID(GlobalCN_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -11021,7 +11020,7 @@ pub struct ResetProtocolExtensions_Entry {
     pub extension_value: ResetProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11030,7 +11029,7 @@ pub struct ResetProtocolExtensions_Entry {
 )]
 pub struct ResetProtocolExtensions(pub Vec<ResetProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -11041,7 +11040,7 @@ pub enum ResetAcknowledgeProtocolIEs_EntryValue {
     Id_GlobalRNC_ID(GlobalRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11050,7 +11049,7 @@ pub struct ResetAcknowledgeProtocolIEs_Entry {
     pub value: ResetAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11059,7 +11058,7 @@ pub struct ResetAcknowledgeProtocolIEs_Entry {
 )]
 pub struct ResetAcknowledgeProtocolIEs(pub Vec<ResetAcknowledgeProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetAcknowledgeProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
@@ -11068,7 +11067,7 @@ pub enum ResetAcknowledgeProtocolExtensions_EntryExtensionValue {
     Id_GlobalCN_ID(GlobalCN_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetAcknowledgeProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -11077,7 +11076,7 @@ pub struct ResetAcknowledgeProtocolExtensions_Entry {
     pub extension_value: ResetAcknowledgeProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11086,7 +11085,7 @@ pub struct ResetAcknowledgeProtocolExtensions_Entry {
 )]
 pub struct ResetAcknowledgeProtocolExtensions(pub Vec<ResetAcknowledgeProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -11099,7 +11098,7 @@ pub enum ResetResourceProtocolIEs_EntryValue {
     Id_IuSigConIdList(ResetResourceList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11108,7 +11107,7 @@ pub struct ResetResourceProtocolIEs_Entry {
     pub value: ResetResourceProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11117,7 +11116,7 @@ pub struct ResetResourceProtocolIEs_Entry {
 )]
 pub struct ResetResourceProtocolIEs(pub Vec<ResetResourceProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
@@ -11126,7 +11125,7 @@ pub enum ResetResourceProtocolExtensions_EntryExtensionValue {
     Id_GlobalCN_ID(GlobalCN_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -11135,7 +11134,7 @@ pub struct ResetResourceProtocolExtensions_Entry {
     pub extension_value: ResetResourceProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11144,14 +11143,14 @@ pub struct ResetResourceProtocolExtensions_Entry {
 )]
 pub struct ResetResourceProtocolExtensions(pub Vec<ResetResourceProtocolExtensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceAckItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 282)]
     Id_IuSigConIdRangeEnd(IuSignallingConnectionIdentifier),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceAckItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11160,7 +11159,7 @@ pub struct ResetResourceAckItemIE_Extensions_Entry {
     pub extension_value: ResetResourceAckItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11169,14 +11168,14 @@ pub struct ResetResourceAckItemIE_Extensions_Entry {
 )]
 pub struct ResetResourceAckItemIE_Extensions(pub Vec<ResetResourceAckItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceAckList_Entry_EntryValue {
     #[asn(key = 78)]
     Id_IuSigConIdItem(ResetResourceAckItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceAckList_Entry_Entry {
     #[asn(key_field = true)]
@@ -11185,7 +11184,7 @@ pub struct ResetResourceAckList_Entry_Entry {
     pub value: ResetResourceAckList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11194,7 +11193,7 @@ pub struct ResetResourceAckList_Entry_Entry {
 )]
 pub struct ResetResourceAckList_Entry(pub Vec<ResetResourceAckList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -11207,7 +11206,7 @@ pub enum ResetResourceAcknowledgeProtocolIEs_EntryValue {
     Id_IuSigConIdList(ResetResourceAckList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11216,7 +11215,7 @@ pub struct ResetResourceAcknowledgeProtocolIEs_Entry {
     pub value: ResetResourceAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11225,7 +11224,7 @@ pub struct ResetResourceAcknowledgeProtocolIEs_Entry {
 )]
 pub struct ResetResourceAcknowledgeProtocolIEs(pub Vec<ResetResourceAcknowledgeProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceAcknowledgeProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
@@ -11234,7 +11233,7 @@ pub enum ResetResourceAcknowledgeProtocolExtensions_EntryExtensionValue {
     Id_GlobalCN_ID(GlobalCN_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceAcknowledgeProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -11243,7 +11242,7 @@ pub struct ResetResourceAcknowledgeProtocolExtensions_Entry {
     pub extension_value: ResetResourceAcknowledgeProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11254,14 +11253,14 @@ pub struct ResetResourceAcknowledgeProtocolExtensions(
     pub Vec<ResetResourceAcknowledgeProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 282)]
     Id_IuSigConIdRangeEnd(IuSignallingConnectionIdentifier),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11270,7 +11269,7 @@ pub struct ResetResourceItemIE_Extensions_Entry {
     pub extension_value: ResetResourceItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11279,14 +11278,14 @@ pub struct ResetResourceItemIE_Extensions_Entry {
 )]
 pub struct ResetResourceItemIE_Extensions(pub Vec<ResetResourceItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetResourceList_Entry_EntryValue {
     #[asn(key = 78)]
     Id_IuSigConIdItem(ResetResourceItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetResourceList_Entry_Entry {
     #[asn(key_field = true)]
@@ -11295,7 +11294,7 @@ pub struct ResetResourceList_Entry_Entry {
     pub value: ResetResourceList_Entry_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11304,19 +11303,19 @@ pub struct ResetResourceList_Entry_Entry {
 )]
 pub struct ResetResourceList_Entry(pub Vec<ResetResourceList_Entry_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "9")]
 pub struct INTEGER_57(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "8")]
 pub struct INTEGER_58(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResidualBitErrorRatioIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11325,11 +11324,11 @@ pub struct ResidualBitErrorRatioIE_Extensions_Entry {}
 )]
 pub struct ResidualBitErrorRatioIE_Extensions(pub Vec<ResidualBitErrorRatioIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11338,19 +11337,19 @@ pub struct SAIIE_Extensions_Entry {}
 )]
 pub struct SAIIE_Extensions(pub Vec<SAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "9")]
 pub struct INTEGER_59(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "6")]
 pub struct INTEGER_60(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SDU_ErrorRatioIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11359,11 +11358,11 @@ pub struct SDU_ErrorRatioIE_Extensions_Entry {}
 )]
 pub struct SDU_ErrorRatioIE_Extensions(pub Vec<SDU_ErrorRatioIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SDU_FormatInformationParameters_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11374,7 +11373,7 @@ pub struct SDU_FormatInformationParameters_EntryIE_Extensions(
     pub Vec<SDU_FormatInformationParameters_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct SDU_FormatInformationParameters_Entry {
     #[asn(optional_idx = 0)]
@@ -11385,11 +11384,11 @@ pub struct SDU_FormatInformationParameters_Entry {
     pub ie_extensions: Option<SDU_FormatInformationParameters_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SDU_Parameters_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11398,7 +11397,7 @@ pub struct SDU_Parameters_EntryIE_Extensions_Entry {}
 )]
 pub struct SDU_Parameters_EntryIE_Extensions(pub Vec<SDU_Parameters_EntryIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct SDU_Parameters_Entry {
     #[asn(optional_idx = 0)]
@@ -11411,11 +11410,11 @@ pub struct SDU_Parameters_Entry {
     pub ie_extensions: Option<SDU_Parameters_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SNA_Access_InformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11424,11 +11423,11 @@ pub struct SNA_Access_InformationIE_Extensions_Entry {}
 )]
 pub struct SNA_Access_InformationIE_Extensions(pub Vec<SNA_Access_InformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRB_TrCH_MappingItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11437,14 +11436,14 @@ pub struct SRB_TrCH_MappingItemIE_Extensions_Entry {}
 )]
 pub struct SRB_TrCH_MappingItemIE_Extensions(pub Vec<SRB_TrCH_MappingItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SRNS_ContextRequestProtocolIEs_EntryValue {
     #[asn(key = 29)]
     Id_RAB_DataForwardingList_SRNS_CtxReq(RAB_DataForwardingList_SRNS_CtxReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRNS_ContextRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11453,7 +11452,7 @@ pub struct SRNS_ContextRequestProtocolIEs_Entry {
     pub value: SRNS_ContextRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11462,14 +11461,14 @@ pub struct SRNS_ContextRequestProtocolIEs_Entry {
 )]
 pub struct SRNS_ContextRequestProtocolIEs(pub Vec<SRNS_ContextRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SRNS_ContextRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 167)]
     Id_RAT_Type(RAT_Type),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRNS_ContextRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -11478,7 +11477,7 @@ pub struct SRNS_ContextRequestProtocolExtensions_Entry {
     pub extension_value: SRNS_ContextRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11489,7 +11488,7 @@ pub struct SRNS_ContextRequestProtocolExtensions(
     pub Vec<SRNS_ContextRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SRNS_ContextResponseProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -11500,7 +11499,7 @@ pub enum SRNS_ContextResponseProtocolIEs_EntryValue {
     Id_RAB_ContextList(RAB_ContextList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRNS_ContextResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11509,7 +11508,7 @@ pub struct SRNS_ContextResponseProtocolIEs_Entry {
     pub value: SRNS_ContextResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11518,11 +11517,11 @@ pub struct SRNS_ContextResponseProtocolIEs_Entry {
 )]
 pub struct SRNS_ContextResponseProtocolIEs(pub Vec<SRNS_ContextResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRNS_ContextResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11533,14 +11532,14 @@ pub struct SRNS_ContextResponseProtocolExtensions(
     pub Vec<SRNS_ContextResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SRNS_DataForwardCommandProtocolIEs_EntryValue {
     #[asn(key = 28)]
     Id_RAB_DataForwardingList(RAB_DataForwardingList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRNS_DataForwardCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11549,7 +11548,7 @@ pub struct SRNS_DataForwardCommandProtocolIEs_Entry {
     pub value: SRNS_DataForwardCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11558,11 +11557,11 @@ pub struct SRNS_DataForwardCommandProtocolIEs_Entry {
 )]
 pub struct SRNS_DataForwardCommandProtocolIEs(pub Vec<SRNS_DataForwardCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRNS_DataForwardCommandProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11573,11 +11572,11 @@ pub struct SRNS_DataForwardCommandProtocolExtensions(
     pub Vec<SRNS_DataForwardCommandProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRVCC_CSKeysRequestProtocolIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11586,11 +11585,11 @@ pub struct SRVCC_CSKeysRequestProtocolIEs_Entry {}
 )]
 pub struct SRVCC_CSKeysRequestProtocolIEs(pub Vec<SRVCC_CSKeysRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRVCC_CSKeysRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11601,7 +11600,7 @@ pub struct SRVCC_CSKeysRequestProtocolExtensions(
     pub Vec<SRVCC_CSKeysRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SRVCC_CSKeysResponseProtocolIEs_EntryValue {
     #[asn(key = 9)]
@@ -11614,7 +11613,7 @@ pub enum SRVCC_CSKeysResponseProtocolIEs_EntryValue {
     Id_SRVCC_Information(SRVCC_Information),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRVCC_CSKeysResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11623,7 +11622,7 @@ pub struct SRVCC_CSKeysResponseProtocolIEs_Entry {
     pub value: SRVCC_CSKeysResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11632,11 +11631,11 @@ pub struct SRVCC_CSKeysResponseProtocolIEs_Entry {
 )]
 pub struct SRVCC_CSKeysResponseProtocolIEs(pub Vec<SRVCC_CSKeysResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRVCC_CSKeysResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11647,7 +11646,7 @@ pub struct SRVCC_CSKeysResponseProtocolExtensions(
     pub Vec<SRVCC_CSKeysResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -11656,11 +11655,11 @@ pub struct SRVCC_CSKeysResponseProtocolExtensions(
 )]
 pub struct BIT_STRING_61(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SRVCC_InformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11669,7 +11668,7 @@ pub struct SRVCC_InformationIE_Extensions_Entry {}
 )]
 pub struct SRVCC_InformationIE_Extensions(pub Vec<SRVCC_InformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SecurityModeCommandProtocolIEs_EntryValue {
     #[asn(key = 11)]
@@ -11680,7 +11679,7 @@ pub enum SecurityModeCommandProtocolIEs_EntryValue {
     Id_KeyStatus(KeyStatus),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityModeCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11689,7 +11688,7 @@ pub struct SecurityModeCommandProtocolIEs_Entry {
     pub value: SecurityModeCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11698,11 +11697,11 @@ pub struct SecurityModeCommandProtocolIEs_Entry {
 )]
 pub struct SecurityModeCommandProtocolIEs(pub Vec<SecurityModeCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityModeCommandProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11713,7 +11712,7 @@ pub struct SecurityModeCommandProtocolExtensions(
     pub Vec<SecurityModeCommandProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SecurityModeCompleteProtocolIEs_EntryValue {
     #[asn(key = 5)]
@@ -11724,7 +11723,7 @@ pub enum SecurityModeCompleteProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityModeCompleteProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11733,7 +11732,7 @@ pub struct SecurityModeCompleteProtocolIEs_Entry {
     pub value: SecurityModeCompleteProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11742,11 +11741,11 @@ pub struct SecurityModeCompleteProtocolIEs_Entry {
 )]
 pub struct SecurityModeCompleteProtocolIEs(pub Vec<SecurityModeCompleteProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityModeCompleteProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11757,7 +11756,7 @@ pub struct SecurityModeCompleteProtocolExtensions(
     pub Vec<SecurityModeCompleteProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SecurityModeRejectProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -11766,7 +11765,7 @@ pub enum SecurityModeRejectProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityModeRejectProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11775,7 +11774,7 @@ pub struct SecurityModeRejectProtocolIEs_Entry {
     pub value: SecurityModeRejectProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11784,11 +11783,11 @@ pub struct SecurityModeRejectProtocolIEs_Entry {
 )]
 pub struct SecurityModeRejectProtocolIEs(pub Vec<SecurityModeRejectProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityModeRejectProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11799,11 +11798,11 @@ pub struct SecurityModeRejectProtocolExtensions(
     pub Vec<SecurityModeRejectProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Shared_Network_InformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11814,14 +11813,14 @@ pub struct Shared_Network_InformationIE_Extensions(
     pub Vec<Shared_Network_InformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SourceRNC_IDIE_Extensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceRNC_IDIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11830,7 +11829,7 @@ pub struct SourceRNC_IDIE_Extensions_Entry {
     pub extension_value: SourceRNC_IDIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11839,7 +11838,7 @@ pub struct SourceRNC_IDIE_Extensions_Entry {
 )]
 pub struct SourceRNC_IDIE_Extensions(pub Vec<SourceRNC_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions_EntryExtensionValue {
     #[asn(key = 237)]
@@ -11874,7 +11873,7 @@ pub enum SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions_EntryExtensionV
     Id_d_RNTI_for_NoIuCSUP(D_RNTI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11884,7 +11883,7 @@ pub struct SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions_Entry {
         SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11895,11 +11894,11 @@ pub struct SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions(
     pub Vec<SourceRNC_ToTargetRNC_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceUTRANCellIDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11908,7 +11907,7 @@ pub struct SourceUTRANCellIDIE_Extensions_Entry {}
 )]
 pub struct SourceUTRANCellIDIE_Extensions(pub Vec<SourceUTRANCellIDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SuccessfulOutcomeValue {
     #[asn(key = 7)]
@@ -11953,11 +11952,11 @@ pub enum SuccessfulOutcomeValue {
     Id_enhancedRelocationComplete(EnhancedRelocationCompleteResponse),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11966,15 +11965,15 @@ pub struct TAIIE_Extensions_Entry {}
 )]
 pub struct TAIIE_Extensions(pub Vec<TAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct OCTET_STRING_62(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TMGIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11983,11 +11982,11 @@ pub struct TMGIIE_Extensions_Entry {}
 )]
 pub struct TMGIIE_Extensions(pub Vec<TMGIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TNLInformationEnhRelInfoReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11998,11 +11997,11 @@ pub struct TNLInformationEnhRelInfoReqIE_Extensions(
     pub Vec<TNLInformationEnhRelInfoReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TNLInformationEnhRelInfoResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12013,11 +12012,11 @@ pub struct TNLInformationEnhRelInfoResIE_Extensions(
     pub Vec<TNLInformationEnhRelInfoResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetENB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12026,14 +12025,14 @@ pub struct TargetENB_IDIE_Extensions_Entry {}
 )]
 pub struct TargetENB_IDIE_Extensions(pub Vec<TargetENB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TargetRNC_IDIE_Extensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetRNC_IDIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12042,7 +12041,7 @@ pub struct TargetRNC_IDIE_Extensions_Entry {
     pub extension_value: TargetRNC_IDIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12051,7 +12050,7 @@ pub struct TargetRNC_IDIE_Extensions_Entry {
 )]
 pub struct TargetRNC_IDIE_Extensions(pub Vec<TargetRNC_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions_EntryExtensionValue {
     #[asn(key = 295)]
@@ -12060,7 +12059,7 @@ pub enum TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions_EntryExtensionV
     ),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12070,7 +12069,7 @@ pub struct TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions_Entry {
         TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12081,7 +12080,7 @@ pub struct TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions(
     pub Vec<TargetRNC_ToSourceRNC_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TrCH_IDIE_Extensions_EntryExtensionValue {
     #[asn(key = 160)]
@@ -12090,7 +12089,7 @@ pub enum TrCH_IDIE_Extensions_EntryExtensionValue {
     Id_hS_DSCH_MAC_d_Flow_ID(HS_DSCH_MAC_d_Flow_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TrCH_IDIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12099,7 +12098,7 @@ pub struct TrCH_IDIE_Extensions_Entry {
     pub extension_value: TrCH_IDIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12108,11 +12107,11 @@ pub struct TrCH_IDIE_Extensions_Entry {
 )]
 pub struct TrCH_IDIE_Extensions(pub Vec<TrCH_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12121,11 +12120,11 @@ pub struct TraceInformationIE_Extensions_Entry {}
 )]
 pub struct TraceInformationIE_Extensions(pub Vec<TraceInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TracePropagationParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12136,11 +12135,11 @@ pub struct TracePropagationParametersIE_Extensions(
     pub Vec<TracePropagationParametersIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceRecordingSessionInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12151,11 +12150,11 @@ pub struct TraceRecordingSessionInformationIE_Extensions(
     pub Vec<TraceRecordingSessionInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TransportLayerInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12166,11 +12165,11 @@ pub struct TransportLayerInformationIE_Extensions(
     pub Vec<TransportLayerInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TunnelInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12179,7 +12178,7 @@ pub struct TunnelInformationIE_Extensions_Entry {}
 )]
 pub struct TunnelInformationIE_Extensions(pub Vec<TunnelInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -12188,11 +12187,11 @@ pub struct TunnelInformationIE_Extensions(pub Vec<TunnelInformationIE_Extensions
 )]
 pub struct OCTET_STRING_63(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_IsNotServedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12201,11 +12200,11 @@ pub struct UE_IsNotServedIE_Extensions_Entry {}
 )]
 pub struct UE_IsNotServedIE_Extensions(pub Vec<UE_IsNotServedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_IsServedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12214,11 +12213,11 @@ pub struct UE_IsServedIE_Extensions_Entry {}
 )]
 pub struct UE_IsServedIE_Extensions(pub Vec<UE_IsServedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UESBI_IuIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12227,14 +12226,14 @@ pub struct UESBI_IuIE_Extensions_Entry {}
 )]
 pub struct UESBI_IuIE_Extensions(pub Vec<UESBI_IuIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UESpecificInformationIndicationProtocolIEs_EntryValue {
     #[asn(key = 118)]
     Id_UESBI_Iu(UESBI_Iu),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UESpecificInformationIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12243,7 +12242,7 @@ pub struct UESpecificInformationIndicationProtocolIEs_Entry {
     pub value: UESpecificInformationIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12254,11 +12253,11 @@ pub struct UESpecificInformationIndicationProtocolIEs(
     pub Vec<UESpecificInformationIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UESpecificInformationIndicationProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12269,14 +12268,14 @@ pub struct UESpecificInformationIndicationProtocolExtensions(
     pub Vec<UESpecificInformationIndicationProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UPInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 269)]
     Id_TimingDifferenceULDL(TimingDifferenceULDL),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UPInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12285,7 +12284,7 @@ pub struct UPInformationIE_Extensions_Entry {
     pub extension_value: UPInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12294,11 +12293,11 @@ pub struct UPInformationIE_Extensions_Entry {
 )]
 pub struct UPInformationIE_Extensions(pub Vec<UPInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UTRAN_CellIDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12307,11 +12306,11 @@ pub struct UTRAN_CellIDIE_Extensions_Entry {}
 )]
 pub struct UTRAN_CellIDIE_Extensions(pub Vec<UTRAN_CellIDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRadioCapabilityMatchRequestProtocolIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12322,11 +12321,11 @@ pub struct UeRadioCapabilityMatchRequestProtocolIEs(
     pub Vec<UeRadioCapabilityMatchRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRadioCapabilityMatchRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12337,14 +12336,14 @@ pub struct UeRadioCapabilityMatchRequestProtocolExtensions(
     pub Vec<UeRadioCapabilityMatchRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UeRadioCapabilityMatchResponseProtocolIEs_EntryValue {
     #[asn(key = 258)]
     Id_VoiceSupportMatchIndicator(VoiceSupportMatchIndicator),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRadioCapabilityMatchResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12353,7 +12352,7 @@ pub struct UeRadioCapabilityMatchResponseProtocolIEs_Entry {
     pub value: UeRadioCapabilityMatchResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12364,11 +12363,11 @@ pub struct UeRadioCapabilityMatchResponseProtocolIEs(
     pub Vec<UeRadioCapabilityMatchResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRadioCapabilityMatchResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12379,7 +12378,7 @@ pub struct UeRadioCapabilityMatchResponseProtocolExtensions(
     pub Vec<UeRadioCapabilityMatchResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UeRegistrationQueryRequestProtocolIEs_EntryValue {
     #[asn(key = 79)]
@@ -12388,7 +12387,7 @@ pub enum UeRegistrationQueryRequestProtocolIEs_EntryValue {
     Id_PermanentNAS_UE_ID(PermanentNAS_UE_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRegistrationQueryRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12397,7 +12396,7 @@ pub struct UeRegistrationQueryRequestProtocolIEs_Entry {
     pub value: UeRegistrationQueryRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12408,11 +12407,11 @@ pub struct UeRegistrationQueryRequestProtocolIEs(
     pub Vec<UeRegistrationQueryRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRegistrationQueryRequestProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12423,14 +12422,14 @@ pub struct UeRegistrationQueryRequestProtocolExtensions(
     pub Vec<UeRegistrationQueryRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UeRegistrationQueryResponseProtocolIEs_EntryValue {
     #[asn(key = 281)]
     Id_UERegistrationQueryResult(UERegistrationQueryResult),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRegistrationQueryResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12439,7 +12438,7 @@ pub struct UeRegistrationQueryResponseProtocolIEs_Entry {
     pub value: UeRegistrationQueryResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12450,11 +12449,11 @@ pub struct UeRegistrationQueryResponseProtocolIEs(
     pub Vec<UeRegistrationQueryResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UeRegistrationQueryResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12465,11 +12464,11 @@ pub struct UeRegistrationQueryResponseProtocolExtensions(
     pub Vec<UeRegistrationQueryResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UnsuccessfulLinking_IEs_EntryIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12480,7 +12479,7 @@ pub struct UnsuccessfulLinking_IEs_EntryIE_Extensions(
     pub Vec<UnsuccessfulLinking_IEs_EntryIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UnsuccessfulLinking_IEs_Entry {
     pub tmgi: TMGI,
@@ -12489,7 +12488,7 @@ pub struct UnsuccessfulLinking_IEs_Entry {
     pub ie_extensions: Option<UnsuccessfulLinking_IEs_EntryIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UnsuccessfulOutcomeValue {
     #[asn(key = 31)]
@@ -12516,7 +12515,7 @@ pub enum UnsuccessfulOutcomeValue {
     Id_enhancedRelocationComplete(EnhancedRelocationCompleteFailure),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkInformationExchangeFailureProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -12531,7 +12530,7 @@ pub enum UplinkInformationExchangeFailureProtocolIEs_EntryValue {
     Id_InformationExchangeID(InformationExchangeID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkInformationExchangeFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12540,7 +12539,7 @@ pub struct UplinkInformationExchangeFailureProtocolIEs_Entry {
     pub value: UplinkInformationExchangeFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12551,11 +12550,11 @@ pub struct UplinkInformationExchangeFailureProtocolIEs(
     pub Vec<UplinkInformationExchangeFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkInformationExchangeFailureProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12566,7 +12565,7 @@ pub struct UplinkInformationExchangeFailureProtocolExtensions(
     pub Vec<UplinkInformationExchangeFailureProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkInformationExchangeRequestProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -12583,7 +12582,7 @@ pub enum UplinkInformationExchangeRequestProtocolIEs_EntryValue {
     Id_InformationTransferType(InformationTransferType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkInformationExchangeRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12592,7 +12591,7 @@ pub struct UplinkInformationExchangeRequestProtocolIEs_Entry {
     pub value: UplinkInformationExchangeRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12603,14 +12602,14 @@ pub struct UplinkInformationExchangeRequestProtocolIEs(
     pub Vec<UplinkInformationExchangeRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkInformationExchangeRequestProtocolExtensions_EntryExtensionValue {
     #[asn(key = 171)]
     Id_ExtendedRNC_ID(ExtendedRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkInformationExchangeRequestProtocolExtensions_Entry {
     #[asn(key_field = true)]
@@ -12619,7 +12618,7 @@ pub struct UplinkInformationExchangeRequestProtocolExtensions_Entry {
     pub extension_value: UplinkInformationExchangeRequestProtocolExtensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12630,7 +12629,7 @@ pub struct UplinkInformationExchangeRequestProtocolExtensions(
     pub Vec<UplinkInformationExchangeRequestProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkInformationExchangeResponseProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -12645,7 +12644,7 @@ pub enum UplinkInformationExchangeResponseProtocolIEs_EntryValue {
     Id_InformationRequested(InformationRequested),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkInformationExchangeResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12654,7 +12653,7 @@ pub struct UplinkInformationExchangeResponseProtocolIEs_Entry {
     pub value: UplinkInformationExchangeResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12665,11 +12664,11 @@ pub struct UplinkInformationExchangeResponseProtocolIEs(
     pub Vec<UplinkInformationExchangeResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkInformationExchangeResponseProtocolExtensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12680,11 +12679,11 @@ pub struct UplinkInformationExchangeResponseProtocolExtensions(
     pub Vec<UplinkInformationExchangeResponseProtocolExtensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserPlaneInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12693,7 +12692,7 @@ pub struct UserPlaneInformationIE_Extensions_Entry {}
 )]
 pub struct UserPlaneInformationIE_Extensions(pub Vec<UserPlaneInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct INTEGER_64(pub u8);
 

--- a/examples/tests/12-s1ap.rs
+++ b/examples/tests/12-s1ap.rs
@@ -1,9 +1,8 @@
 #![allow(dead_code, unreachable_patterns, non_camel_case_types)]
-use asn1_codecs_derive::AperCodec;
 use bitvec::order::Msb0;
 use bitvec::vec::BitVec;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12,13 +11,13 @@ use bitvec::vec::BitVec;
 )]
 pub struct ActivatedCellsList(pub Vec<ActivatedCellsList_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ActivatedCellsList_Item {
     pub cell_id: OCTET_STRING_2,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Additional_GUTI {
     pub gummei: GUMMEI,
@@ -27,7 +26,7 @@ pub struct Additional_GUTI {
     pub ie_extensions: Option<Additional_GUTIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct AdditionalCSFallbackIndicator(pub u8);
 impl AdditionalCSFallbackIndicator {
@@ -35,11 +34,11 @@ impl AdditionalCSFallbackIndicator {
     pub const RESTRICTION: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "32", sz_ub = "32")]
 pub struct AdditionalRRMPriorityIndex(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct AerialUEsubscriptionInformation(pub u8);
 impl AerialUEsubscriptionInformation {
@@ -47,7 +46,7 @@ impl AerialUEsubscriptionInformation {
     pub const NOT_ALLOWED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AllocationAndRetentionPriority {
     pub priority_level: PriorityLevel,
@@ -57,7 +56,7 @@ pub struct AllocationAndRetentionPriority {
     pub ie_extensions: Option<AllocationAndRetentionPriorityIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum AreaScopeOfMDT {
     #[asn(key = 0, extended = false)]
@@ -70,7 +69,7 @@ pub enum AreaScopeOfMDT {
     TAIBased(TAIBasedMDT),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = true)]
 pub enum AreaScopeOfQMC {
     #[asn(key = 0, extended = false)]
@@ -83,7 +82,7 @@ pub enum AreaScopeOfQMC {
     PLMNAreaBased(PLMNAreaBasedQMC),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AssistanceDataForCECapableUEs {
     pub cell_identifier_and_ce_level_for_ce_capable_u_es: CellIdentifierAndCELevelForCECapableUEs,
@@ -91,7 +90,7 @@ pub struct AssistanceDataForCECapableUEs {
     pub ie_extensions: Option<AssistanceDataForCECapableUEsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct AssistanceDataForPaging {
     #[asn(optional_idx = 0)]
@@ -104,7 +103,7 @@ pub struct AssistanceDataForPaging {
     pub ie_extensions: Option<AssistanceDataForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AssistanceDataForRecommendedCells {
     pub recommended_cells_for_paging: RecommendedCellsForPaging,
@@ -112,18 +111,18 @@ pub struct AssistanceDataForRecommendedCells {
     pub ie_extensions: Option<AssistanceDataForRecommendedCellsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "6")]
 pub struct BPLMNs(pub Vec<PLMNidentity>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct BearerType(pub u8);
 impl BearerType {
     pub const NON_IP: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Bearers_SubjectToEarlyStatusTransfer_Item {
     pub e_rab_id: E_RAB_ID,
@@ -132,7 +131,7 @@ pub struct Bearers_SubjectToEarlyStatusTransfer_Item {
     pub ie_extensions: Option<Bearers_SubjectToEarlyStatusTransfer_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -143,7 +142,7 @@ pub struct Bearers_SubjectToEarlyStatusTransferList(
     pub Vec<Bearers_SubjectToEarlyStatusTransferList_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct Bearers_SubjectToStatusTransfer_Item {
     pub e_rab_id: E_RAB_ID,
@@ -155,7 +154,7 @@ pub struct Bearers_SubjectToStatusTransfer_Item {
     pub ie_extensions: Option<Bearers_SubjectToStatusTransfer_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -164,22 +163,22 @@ pub struct Bearers_SubjectToStatusTransfer_Item {
 )]
 pub struct Bearers_SubjectToStatusTransferList(pub Vec<Bearers_SubjectToStatusTransferList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "10000000000")]
 pub struct BitRate(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct BluetoothMeasConfig(pub u8);
 impl BluetoothMeasConfig {
     pub const SETUP: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "4")]
 pub struct BluetoothMeasConfigNameList(pub Vec<BluetoothName>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct BluetoothMeasurementConfiguration {
     pub bluetooth_meas_config: BluetoothMeasConfig,
@@ -191,7 +190,7 @@ pub struct BluetoothMeasurementConfiguration {
     pub ie_extensions: Option<BluetoothMeasurementConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -200,7 +199,7 @@ pub struct BluetoothMeasurementConfiguration {
 )]
 pub struct BluetoothName(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum BroadcastCancelledAreaList {
     #[asn(key = 0, extended = false)]
@@ -211,7 +210,7 @@ pub enum BroadcastCancelledAreaList {
     EmergencyAreaID_Cancelled(EmergencyAreaID_Cancelled),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum BroadcastCompletedAreaList {
     #[asn(key = 0, extended = false)]
@@ -222,7 +221,7 @@ pub enum BroadcastCompletedAreaList {
     EmergencyAreaID_Broadcast(EmergencyAreaID_Broadcast),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct CE_ModeBRestricted(pub u8);
 impl CE_ModeBRestricted {
@@ -230,18 +229,18 @@ impl CE_ModeBRestricted {
     pub const NOT_RESTRICTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct CE_mode_B_SupportIndicator(pub u8);
 impl CE_mode_B_SupportIndicator {
     pub const SUPPORTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct CELevel(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct CGI {
     pub plm_nidentity: PLMNidentity,
@@ -253,11 +252,11 @@ pub struct CGI {
     pub ie_extensions: Option<CGIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct CI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct CNDomain(pub u8);
 impl CNDomain {
@@ -265,18 +264,18 @@ impl CNDomain {
     pub const CS: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct CNType(pub u8);
 impl CNType {
     pub const FIVE_GC_FORBIDDEN: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct CNTypeRestrictions(pub Vec<CNTypeRestrictions_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CNTypeRestrictions_Item {
     pub plmn_identity: PLMNidentity,
@@ -285,7 +284,7 @@ pub struct CNTypeRestrictions_Item {
     pub ie_extensions: Option<CNTypeRestrictions_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct COUNTValueExtended {
     pub pdcp_sn_extended: PDCP_SNExtended,
@@ -294,7 +293,7 @@ pub struct COUNTValueExtended {
     pub ie_extensions: Option<COUNTValueExtendedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct COUNTvalue {
     pub pdcp_sn: PDCP_SN,
@@ -303,7 +302,7 @@ pub struct COUNTvalue {
     pub ie_extensions: Option<COUNTvalueIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct COUNTvaluePDCP_SNlength18 {
     pub pdcp_s_nlength18: PDCP_SNlength18,
@@ -312,18 +311,18 @@ pub struct COUNTvaluePDCP_SNlength18 {
     pub ie_extensions: Option<COUNTvaluePDCP_SNlength18IE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct CSFallbackIndicator(pub u8);
 impl CSFallbackIndicator {
     pub const CS_FALLBACK_REQUIRED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "27", sz_ub = "27")]
 pub struct CSG_Id(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -332,7 +331,7 @@ pub struct CSG_Id(pub BitVec<u8, Msb0>);
 )]
 pub struct CSG_IdList(pub Vec<CSG_IdList_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CSG_IdList_Item {
     pub csg_id: CSG_Id,
@@ -340,7 +339,7 @@ pub struct CSG_IdList_Item {
     pub ie_extensions: Option<CSG_IdList_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct CSGMembershipInfo {
     pub csg_membership_status: CSGMembershipStatus,
@@ -353,7 +352,7 @@ pub struct CSGMembershipInfo {
     pub ie_extensions: Option<CSGMembershipInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct CSGMembershipStatus(pub u8);
 impl CSGMembershipStatus {
@@ -361,7 +360,7 @@ impl CSGMembershipStatus {
     pub const NOT_MEMBER: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -370,7 +369,7 @@ impl CSGMembershipStatus {
 )]
 pub struct CancelledCellinEAI(pub Vec<CancelledCellinEAI_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CancelledCellinEAI_Item {
     pub ecgi: EUTRAN_CGI,
@@ -379,7 +378,7 @@ pub struct CancelledCellinEAI_Item {
     pub ie_extensions: Option<CancelledCellinEAI_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -388,7 +387,7 @@ pub struct CancelledCellinEAI_Item {
 )]
 pub struct CancelledCellinTAI(pub Vec<CancelledCellinTAI_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CancelledCellinTAI_Item {
     pub ecgi: EUTRAN_CGI,
@@ -397,22 +396,22 @@ pub struct CancelledCellinTAI_Item {
     pub ie_extensions: Option<CancelledCellinTAI_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct CandidateCellList(pub Vec<IRAT_Cell_ID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct CandidatePCI {
     pub pci: INTEGER_5,
     pub earfcn: OCTET_STRING_6,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct CandidatePCIList(pub Vec<CandidatePCI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "4", extensible = true)]
 pub enum Cause {
     #[asn(key = 0, extended = false)]
@@ -427,7 +426,7 @@ pub enum Cause {
     Misc(CauseMisc),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct CauseMisc(pub u8);
 impl CauseMisc {
@@ -439,7 +438,7 @@ impl CauseMisc {
     pub const UNKNOWN_PLMN: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct CauseNas(pub u8);
 impl CauseNas {
@@ -449,7 +448,7 @@ impl CauseNas {
     pub const UNSPECIFIED: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "6")]
 pub struct CauseProtocol(pub u8);
 impl CauseProtocol {
@@ -462,7 +461,7 @@ impl CauseProtocol {
     pub const UNSPECIFIED: u8 = 6u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "35")]
 pub struct CauseRadioNetwork(pub u8);
 impl CauseRadioNetwork {
@@ -504,7 +503,7 @@ impl CauseRadioNetwork {
     pub const X2_HANDOVER_TRIGGERED: u8 = 35u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct CauseTransport(pub u8);
 impl CauseTransport {
@@ -512,14 +511,14 @@ impl CauseTransport {
     pub const UNSPECIFIED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Cdma2000HORequiredIndication(pub u8);
 impl Cdma2000HORequiredIndication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct Cdma2000HOStatus(pub u8);
 impl Cdma2000HOStatus {
@@ -527,23 +526,23 @@ impl Cdma2000HOStatus {
     pub const H_O_FAILURE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Cdma2000OneXMEID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Cdma2000OneXMSI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Cdma2000OneXPilot(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Cdma2000OneXRAND(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Cdma2000OneXSRVCCInfo {
     pub cdma2000_one_xmeid: Cdma2000OneXMEID,
@@ -553,11 +552,11 @@ pub struct Cdma2000OneXSRVCCInfo {
     pub ie_extensions: Option<Cdma2000OneXSRVCCInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Cdma2000PDU(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct Cdma2000RATType(pub u8);
 impl Cdma2000RATType {
@@ -565,11 +564,11 @@ impl Cdma2000RATType {
     pub const ONEX_RTT: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Cdma2000SectorID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct Cell_Size(pub u8);
 impl Cell_Size {
@@ -579,14 +578,14 @@ impl Cell_Size {
     pub const LARGE: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct CellAccessMode(pub u8);
 impl CellAccessMode {
     pub const HYBRID: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct CellActivationCause(pub u8);
 impl CellActivationCause {
@@ -595,7 +594,7 @@ impl CellActivationCause {
     pub const UNSPECIFIED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellActivationRequest {
     pub cells_to_activate_list: CellsToActivateList,
@@ -603,13 +602,13 @@ pub struct CellActivationRequest {
     pub minimum_activation_time: Option<INTEGER_7>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct CellActivationResponse {
     pub activated_cells_list: ActivatedCellsList,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellBasedMDT {
     pub cell_id_listfor_mdt: CellIdListforMDT,
@@ -617,7 +616,7 @@ pub struct CellBasedMDT {
     pub ie_extensions: Option<CellBasedMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellBasedQMC {
     pub cell_id_listfor_qmc: CellIdListforQMC,
@@ -625,7 +624,7 @@ pub struct CellBasedQMC {
     pub ie_extensions: Option<CellBasedQMCIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -634,7 +633,7 @@ pub struct CellBasedQMC {
 )]
 pub struct CellID_Broadcast(pub Vec<CellID_Broadcast_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellID_Broadcast_Item {
     pub ecgi: EUTRAN_CGI,
@@ -642,7 +641,7 @@ pub struct CellID_Broadcast_Item {
     pub ie_extensions: Option<CellID_Broadcast_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -651,7 +650,7 @@ pub struct CellID_Broadcast_Item {
 )]
 pub struct CellID_Cancelled(pub Vec<CellID_Cancelled_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellID_Cancelled_Item {
     pub ecgi: EUTRAN_CGI,
@@ -660,15 +659,15 @@ pub struct CellID_Cancelled_Item {
     pub ie_extensions: Option<CellID_Cancelled_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct CellIdListforMDT(pub Vec<EUTRAN_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct CellIdListforQMC(pub Vec<EUTRAN_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellIdentifierAndCELevelForCECapableUEs {
     pub global_cell_id: EUTRAN_CGI,
@@ -677,11 +676,11 @@ pub struct CellIdentifierAndCELevelForCECapableUEs {
     pub ie_extensions: Option<CellIdentifierAndCELevelForCECapableUEsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "28", sz_ub = "28")]
 pub struct CellIdentity(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct CellLoadReportingCause(pub u8);
 impl CellLoadReportingCause {
@@ -690,7 +689,7 @@ impl CellLoadReportingCause {
     pub const UNSPECIFIED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum CellLoadReportingResponse {
     #[asn(key = 0, extended = false)]
@@ -703,13 +702,13 @@ pub enum CellLoadReportingResponse {
     EHRPD(EHRPDSectorLoadReportingResponse),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct CellStateIndication {
     pub notification_cell_list: NotificationCellList,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct CellStateIndicationCause(pub u8);
 impl CellStateIndicationCause {
@@ -718,13 +717,13 @@ impl CellStateIndicationCause {
     pub const UNSPECIFIED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct CellTrafficTrace {
     pub protocol_i_es: CellTrafficTraceProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellType {
     pub cell_size: Cell_Size,
@@ -732,7 +731,7 @@ pub struct CellType {
     pub ie_extensions: Option<CellTypeIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -741,13 +740,13 @@ pub struct CellType {
 )]
 pub struct CellsToActivateList(pub Vec<CellsToActivateList_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct CellsToActivateList_Item {
     pub cell_id: OCTET_STRING_10,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -756,7 +755,7 @@ pub struct CellsToActivateList_Item {
 )]
 pub struct CompletedCellinEAI(pub Vec<CompletedCellinEAI_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CompletedCellinEAI_Item {
     pub ecgi: EUTRAN_CGI,
@@ -764,7 +763,7 @@ pub struct CompletedCellinEAI_Item {
     pub ie_extensions: Option<CompletedCellinEAI_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -773,7 +772,7 @@ pub struct CompletedCellinEAI_Item {
 )]
 pub struct CompletedCellinTAI(pub Vec<CompletedCellinTAI_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CompletedCellinTAI_Item {
     pub ecgi: EUTRAN_CGI,
@@ -781,18 +780,18 @@ pub struct CompletedCellinTAI_Item {
     pub ie_extensions: Option<CompletedCellinTAI_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct CompositeAvailableCapacityGroup(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "0")]
 pub struct ConcurrentWarningMessageIndicator(pub u8);
 impl ConcurrentWarningMessageIndicator {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ConnectedengNBItem {
     pub en_g_nb_id: En_gNB_ID,
@@ -801,7 +800,7 @@ pub struct ConnectedengNBItem {
     pub ie_extensions: Option<ConnectedengNBItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -810,13 +809,13 @@ pub struct ConnectedengNBItem {
 )]
 pub struct ConnectedengNBList(pub Vec<ConnectedengNBItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ConnectionEstablishmentIndication {
     pub protocol_i_es: ConnectionEstablishmentIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ContextatSource {
     pub source_ng_ran_node_id: Global_RAN_NODE_ID,
@@ -825,18 +824,18 @@ pub struct ContextatSource {
     pub ie_extensions: Option<ContextatSourceIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct Correlation_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Coverage_Level(pub u8);
 impl Coverage_Level {
     pub const EXTENDEDCOVERAGE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct Criticality(pub u8);
 impl Criticality {
@@ -845,7 +844,7 @@ impl Criticality {
     pub const NOTIFY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct CriticalityDiagnostics {
     #[asn(optional_idx = 0)]
@@ -860,7 +859,7 @@ pub struct CriticalityDiagnostics {
     pub ie_extensions: Option<CriticalityDiagnosticsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CriticalityDiagnostics_IE_Item {
     pub ie_criticality: Criticality,
@@ -870,7 +869,7 @@ pub struct CriticalityDiagnostics_IE_Item {
     pub ie_extensions: Option<CriticalityDiagnostics_IE_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -879,7 +878,7 @@ pub struct CriticalityDiagnostics_IE_Item {
 )]
 pub struct CriticalityDiagnostics_IE_List(pub Vec<CriticalityDiagnostics_IE_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DAPSRequestInfo {
     pub daps_indicator: ENUMERATED_11,
@@ -887,7 +886,7 @@ pub struct DAPSRequestInfo {
     pub ie_extensions: Option<DAPSRequestInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DAPSResponseInfo {
     pub dapsresponseindicator: ENUMERATED_12,
@@ -895,7 +894,7 @@ pub struct DAPSResponseInfo {
     pub ie_extensions: Option<DAPSResponseInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DAPSResponseInfoItem {
     pub e_rab_id: E_RAB_ID,
@@ -904,7 +903,7 @@ pub struct DAPSResponseInfoItem {
     pub ie_extensions: Option<DAPSResponseInfoItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -913,11 +912,11 @@ pub struct DAPSResponseInfoItem {
 )]
 pub struct DAPSResponseInfoList(pub Vec<DAPSResponseInfoList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct DCN_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DL_CP_SecurityInformation {
     pub dl_nas_mac: DL_NAS_MAC,
@@ -925,18 +924,18 @@ pub struct DL_CP_SecurityInformation {
     pub ie_extensions: Option<DL_CP_SecurityInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct DL_Forwarding(pub u8);
 impl DL_Forwarding {
     pub const D_L_FORWARDING_PROPOSED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct DL_NAS_MAC(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum DLCOUNT_PDCP_SNlength {
     #[asn(key = 0, extended = false)]
@@ -947,70 +946,70 @@ pub enum DLCOUNT_PDCP_SNlength {
     DLCOUNTValuePDCP_SNlength18(COUNTvaluePDCP_SNlength18),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct DLNASPDUDeliveryAckRequest(pub u8);
 impl DLNASPDUDeliveryAckRequest {
     pub const REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Data_Forwarding_Not_Possible(pub u8);
 impl Data_Forwarding_Not_Possible {
     pub const DATA_FORWARDING_NOT_POSSIBLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct DataCodingScheme(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "4095", extensible = true)]
 pub struct DataSize(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DeactivateTrace {
     pub protocol_i_es: DeactivateTraceProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Direct_Forwarding_Path_Availability(pub u8);
 impl Direct_Forwarding_Path_Availability {
     pub const DIRECT_PATH_AVAILABLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkNASTransport {
     pub protocol_i_es: DownlinkNASTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkNonUEAssociatedLPPaTransport {
     pub protocol_i_es: DownlinkNonUEAssociatedLPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkS1cdma2000tunnelling {
     pub protocol_i_es: DownlinkS1cdma2000tunnellingProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkUEAssociatedLPPaTransport {
     pub protocol_i_es: DownlinkUEAssociatedLPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15", extensible = true)]
 pub struct E_RAB_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct E_RABAdmittedItem {
     pub e_rab_id: E_RAB_ID,
@@ -1028,7 +1027,7 @@ pub struct E_RABAdmittedItem {
     pub ie_extensions: Option<E_RABAdmittedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1037,7 +1036,7 @@ pub struct E_RABAdmittedItem {
 )]
 pub struct E_RABAdmittedList(pub Vec<E_RABAdmittedList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct E_RABDataForwardingItem {
     pub e_rab_id: E_RAB_ID,
@@ -1053,7 +1052,7 @@ pub struct E_RABDataForwardingItem {
     pub ie_extensions: Option<E_RABDataForwardingItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABFailedToResumeItemResumeReq {
     pub e_rab_id: E_RAB_ID,
@@ -1062,7 +1061,7 @@ pub struct E_RABFailedToResumeItemResumeReq {
     pub ie_extensions: Option<E_RABFailedToResumeItemResumeReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABFailedToResumeItemResumeRes {
     pub e_rab_id: E_RAB_ID,
@@ -1071,7 +1070,7 @@ pub struct E_RABFailedToResumeItemResumeRes {
     pub ie_extensions: Option<E_RABFailedToResumeItemResumeResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1080,7 +1079,7 @@ pub struct E_RABFailedToResumeItemResumeRes {
 )]
 pub struct E_RABFailedToResumeListResumeReq(pub Vec<E_RABFailedToResumeListResumeReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1089,7 +1088,7 @@ pub struct E_RABFailedToResumeListResumeReq(pub Vec<E_RABFailedToResumeListResum
 )]
 pub struct E_RABFailedToResumeListResumeRes(pub Vec<E_RABFailedToResumeListResumeRes_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABFailedToSetupItemHOReqAck {
     pub e_rab_id: E_RAB_ID,
@@ -1098,7 +1097,7 @@ pub struct E_RABFailedToSetupItemHOReqAck {
     pub ie_extensions: Option<E_RABFailedToSetupItemHOReqAckIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1107,7 +1106,7 @@ pub struct E_RABFailedToSetupItemHOReqAck {
 )]
 pub struct E_RABFailedtoSetupListHOReqAck(pub Vec<E_RABFailedtoSetupListHOReqAck_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1116,7 +1115,7 @@ pub struct E_RABFailedtoSetupListHOReqAck(pub Vec<E_RABFailedtoSetupListHOReqAck
 )]
 pub struct E_RABInformationList(pub Vec<E_RABInformationList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct E_RABInformationListItem {
     pub e_rab_id: E_RAB_ID,
@@ -1126,7 +1125,7 @@ pub struct E_RABInformationListItem {
     pub ie_extensions: Option<E_RABInformationListItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABItem {
     pub e_rab_id: E_RAB_ID,
@@ -1135,7 +1134,7 @@ pub struct E_RABItem {
     pub ie_extensions: Option<E_RABItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct E_RABLevelQoSParameters {
     pub qci: QCI,
@@ -1146,7 +1145,7 @@ pub struct E_RABLevelQoSParameters {
     pub ie_extensions: Option<E_RABLevelQoSParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1155,19 +1154,19 @@ pub struct E_RABLevelQoSParameters {
 )]
 pub struct E_RABList(pub Vec<E_RABList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABModificationConfirm {
     pub protocol_i_es: E_RABModificationConfirmProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABModificationIndication {
     pub protocol_i_es: E_RABModificationIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABModifyItemBearerModConf {
     pub e_rab_id: E_RAB_ID,
@@ -1175,7 +1174,7 @@ pub struct E_RABModifyItemBearerModConf {
     pub ie_extensions: Option<E_RABModifyItemBearerModConfIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABModifyItemBearerModRes {
     pub e_rab_id: E_RAB_ID,
@@ -1183,7 +1182,7 @@ pub struct E_RABModifyItemBearerModRes {
     pub ie_extensions: Option<E_RABModifyItemBearerModResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1192,7 +1191,7 @@ pub struct E_RABModifyItemBearerModRes {
 )]
 pub struct E_RABModifyListBearerModConf(pub Vec<E_RABModifyListBearerModConf_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1201,19 +1200,19 @@ pub struct E_RABModifyListBearerModConf(pub Vec<E_RABModifyListBearerModConf_Ent
 )]
 pub struct E_RABModifyListBearerModRes(pub Vec<E_RABModifyListBearerModRes_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABModifyRequest {
     pub protocol_i_es: E_RABModifyRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABModifyResponse {
     pub protocol_i_es: E_RABModifyResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABNotToBeModifiedItemBearerModInd {
     pub e_rab_id: E_RAB_ID,
@@ -1223,7 +1222,7 @@ pub struct E_RABNotToBeModifiedItemBearerModInd {
     pub ie_extensions: Option<E_RABNotToBeModifiedItemBearerModIndIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1234,19 +1233,19 @@ pub struct E_RABNotToBeModifiedListBearerModInd(
     pub Vec<E_RABNotToBeModifiedListBearerModInd_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABReleaseCommand {
     pub protocol_i_es: E_RABReleaseCommandProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABReleaseIndication {
     pub protocol_i_es: E_RABReleaseIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABReleaseItemBearerRelComp {
     pub e_rab_id: E_RAB_ID,
@@ -1254,7 +1253,7 @@ pub struct E_RABReleaseItemBearerRelComp {
     pub ie_extensions: Option<E_RABReleaseItemBearerRelCompIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1263,13 +1262,13 @@ pub struct E_RABReleaseItemBearerRelComp {
 )]
 pub struct E_RABReleaseListBearerRelComp(pub Vec<E_RABReleaseListBearerRelComp_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABReleaseResponse {
     pub protocol_i_es: E_RABReleaseResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABSetupItemBearerSURes {
     pub e_rab_id: E_RAB_ID,
@@ -1279,7 +1278,7 @@ pub struct E_RABSetupItemBearerSURes {
     pub ie_extensions: Option<E_RABSetupItemBearerSUResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABSetupItemCtxtSURes {
     pub e_rab_id: E_RAB_ID,
@@ -1289,7 +1288,7 @@ pub struct E_RABSetupItemCtxtSURes {
     pub ie_extensions: Option<E_RABSetupItemCtxtSUResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1298,7 +1297,7 @@ pub struct E_RABSetupItemCtxtSURes {
 )]
 pub struct E_RABSetupListBearerSURes(pub Vec<E_RABSetupListBearerSURes_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1307,19 +1306,19 @@ pub struct E_RABSetupListBearerSURes(pub Vec<E_RABSetupListBearerSURes_Entry>);
 )]
 pub struct E_RABSetupListCtxtSURes(pub Vec<E_RABSetupListCtxtSURes_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABSetupRequest {
     pub protocol_i_es: E_RABSetupRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct E_RABSetupResponse {
     pub protocol_i_es: E_RABSetupResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1328,7 +1327,7 @@ pub struct E_RABSetupResponse {
 )]
 pub struct E_RABSubjecttoDataForwardingList(pub Vec<E_RABSubjecttoDataForwardingList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABToBeModifiedItemBearerModInd {
     pub e_rab_id: E_RAB_ID,
@@ -1338,7 +1337,7 @@ pub struct E_RABToBeModifiedItemBearerModInd {
     pub ie_extensions: Option<E_RABToBeModifiedItemBearerModIndIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABToBeModifiedItemBearerModReq {
     pub e_rab_id: E_RAB_ID,
@@ -1348,7 +1347,7 @@ pub struct E_RABToBeModifiedItemBearerModReq {
     pub ie_extensions: Option<E_RABToBeModifiedItemBearerModReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1357,7 +1356,7 @@ pub struct E_RABToBeModifiedItemBearerModReq {
 )]
 pub struct E_RABToBeModifiedListBearerModInd(pub Vec<E_RABToBeModifiedListBearerModInd_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1366,7 +1365,7 @@ pub struct E_RABToBeModifiedListBearerModInd(pub Vec<E_RABToBeModifiedListBearer
 )]
 pub struct E_RABToBeModifiedListBearerModReq(pub Vec<E_RABToBeModifiedListBearerModReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABToBeSetupItemBearerSUReq {
     pub e_rab_id: E_RAB_ID,
@@ -1378,7 +1377,7 @@ pub struct E_RABToBeSetupItemBearerSUReq {
     pub ie_extensions: Option<E_RABToBeSetupItemBearerSUReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct E_RABToBeSetupItemCtxtSUReq {
     pub e_rab_id: E_RAB_ID,
@@ -1391,7 +1390,7 @@ pub struct E_RABToBeSetupItemCtxtSUReq {
     pub ie_extensions: Option<E_RABToBeSetupItemCtxtSUReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABToBeSetupItemHOReq {
     pub e_rab_id: E_RAB_ID,
@@ -1402,7 +1401,7 @@ pub struct E_RABToBeSetupItemHOReq {
     pub ie_extensions: Option<E_RABToBeSetupItemHOReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1411,7 +1410,7 @@ pub struct E_RABToBeSetupItemHOReq {
 )]
 pub struct E_RABToBeSetupListBearerSUReq(pub Vec<E_RABToBeSetupListBearerSUReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1420,7 +1419,7 @@ pub struct E_RABToBeSetupListBearerSUReq(pub Vec<E_RABToBeSetupListBearerSUReq_E
 )]
 pub struct E_RABToBeSetupListCtxtSUReq(pub Vec<E_RABToBeSetupListCtxtSUReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1429,7 +1428,7 @@ pub struct E_RABToBeSetupListCtxtSUReq(pub Vec<E_RABToBeSetupListCtxtSUReq_Entry
 )]
 pub struct E_RABToBeSetupListHOReq(pub Vec<E_RABToBeSetupListHOReq_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABToBeSwitchedDLItem {
     pub e_rab_id: E_RAB_ID,
@@ -1439,7 +1438,7 @@ pub struct E_RABToBeSwitchedDLItem {
     pub ie_extensions: Option<E_RABToBeSwitchedDLItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1448,7 +1447,7 @@ pub struct E_RABToBeSwitchedDLItem {
 )]
 pub struct E_RABToBeSwitchedDLList(pub Vec<E_RABToBeSwitchedDLList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABToBeSwitchedULItem {
     pub e_rab_id: E_RAB_ID,
@@ -1458,7 +1457,7 @@ pub struct E_RABToBeSwitchedULItem {
     pub ie_extensions: Option<E_RABToBeSwitchedULItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1467,7 +1466,7 @@ pub struct E_RABToBeSwitchedULItem {
 )]
 pub struct E_RABToBeSwitchedULList(pub Vec<E_RABToBeSwitchedULList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct E_RABUsageReportItem {
     pub start_timestamp: OCTET_STRING_13,
@@ -1478,19 +1477,19 @@ pub struct E_RABUsageReportItem {
     pub ie_extensions: Option<E_RABUsageReportItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct E_RABUsageReportList(pub Vec<E_RABUsageReportList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct E_UTRAN_Trace_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "262143", extensible = true)]
 pub struct EARFCN(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1499,7 +1498,7 @@ pub struct EARFCN(pub u32);
 )]
 pub struct ECGI_List(pub Vec<EUTRAN_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1508,7 +1507,7 @@ pub struct ECGI_List(pub Vec<EUTRAN_CGI>);
 )]
 pub struct ECGIList(pub Vec<EUTRAN_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1517,14 +1516,14 @@ pub struct ECGIList(pub Vec<EUTRAN_CGI>);
 )]
 pub struct ECGIListForRestart(pub Vec<EUTRAN_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct EDT_Session(pub u8);
 impl EDT_Session {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -1533,36 +1532,36 @@ impl EDT_Session {
 )]
 pub struct EHRPD_Sector_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "100")]
 pub struct EHRPDCapacityValue(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct EHRPDCompositeAvailableCapacity {
     pub ehrpd_sector_capacity_class_value: EHRPDSectorCapacityClassValue,
     pub ehrpd_capacity_value: EHRPDCapacityValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct EHRPDMultiSectorLoadReportingResponseItem {
     pub ehrpd_sector_id: EHRPD_Sector_ID,
     pub ehrpd_sector_load_reporting_response: EHRPDSectorLoadReportingResponse,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "100", extensible = true)]
 pub struct EHRPDSectorCapacityClassValue(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct EHRPDSectorLoadReportingResponse {
     pub dl_ehrpd_composite_available_capacity: EHRPDCompositeAvailableCapacity,
     pub ul_ehrpd_composite_available_capacity: EHRPDCompositeAvailableCapacity,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct EN_DCSONConfigurationTransfer {
     pub transfertype: EN_DCSONTransferType,
@@ -1573,7 +1572,7 @@ pub struct EN_DCSONConfigurationTransfer {
     pub ie_extensions: Option<EN_DCSONConfigurationTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum EN_DCSONTransferType {
     #[asn(key = 0, extended = false)]
@@ -1582,7 +1581,7 @@ pub enum EN_DCSONTransferType {
     Reply(EN_DCTransferTypeReply),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EN_DCSONeNBIdentification {
     pub globale_nbid: Global_ENB_ID,
@@ -1591,7 +1590,7 @@ pub struct EN_DCSONeNBIdentification {
     pub ie_extensions: Option<EN_DCSONeNBIdentificationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EN_DCSONengNBIdentification {
     pub globaleng_nbid: Global_en_gNB_ID,
@@ -1600,7 +1599,7 @@ pub struct EN_DCSONengNBIdentification {
     pub ie_extensions: Option<EN_DCSONengNBIdentificationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EN_DCTransferTypeReply {
     pub sourceeng_nb: EN_DCSONengNBIdentification,
@@ -1609,7 +1608,7 @@ pub struct EN_DCTransferTypeReply {
     pub ie_extensions: Option<EN_DCTransferTypeReplyIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct EN_DCTransferTypeRequest {
     pub sourcee_nb: EN_DCSONeNBIdentification,
@@ -1624,7 +1623,7 @@ pub struct EN_DCTransferTypeRequest {
     pub ie_extensions: Option<EN_DCTransferTypeRequestIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ENB_EarlyStatusTransfer_TransparentContainer {
     pub bearers_subject_to_early_status_transfer_list: Bearers_SubjectToEarlyStatusTransferList,
@@ -1632,7 +1631,7 @@ pub struct ENB_EarlyStatusTransfer_TransparentContainer {
     pub ie_extensions: Option<ENB_EarlyStatusTransfer_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum ENB_ID {
     #[asn(key = 0, extended = false)]
@@ -1645,7 +1644,7 @@ pub enum ENB_ID {
     Long_macroENB_ID(BIT_STRING_20),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ENB_StatusTransfer_TransparentContainer {
     pub bearers_subject_to_status_transfer_list: Bearers_SubjectToStatusTransferList,
@@ -1653,63 +1652,63 @@ pub struct ENB_StatusTransfer_TransparentContainer {
     pub ie_extensions: Option<ENB_StatusTransfer_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "16777215")]
 pub struct ENB_UE_S1AP_ID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBCPRelocationIndication {
     pub protocol_i_es: ENBCPRelocationIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBConfigurationTransfer {
     pub protocol_i_es: ENBConfigurationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBConfigurationUpdate {
     pub protocol_i_es: ENBConfigurationUpdateProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBConfigurationUpdateAcknowledge {
     pub protocol_i_es: ENBConfigurationUpdateAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBConfigurationUpdateFailure {
     pub protocol_i_es: ENBConfigurationUpdateFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBDirectInformationTransfer {
     pub protocol_i_es: ENBDirectInformationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBEarlyStatusTransfer {
     pub protocol_i_es: ENBEarlyStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct ENBIndirectX2TransportLayerAddresses(pub Vec<TransportLayerAddress>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ENBStatusTransfer {
     pub protocol_i_es: ENBStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct ENBX2ExtTLA {
     #[asn(optional_idx = 0)]
@@ -1720,19 +1719,19 @@ pub struct ENBX2ExtTLA {
     pub ie_extensions: Option<ENBX2ExtTLAIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ENBX2ExtTLAs(pub Vec<ENBX2ExtTLA>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ENBX2GTPTLAs(pub Vec<TransportLayerAddress>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct ENBX2TLAs(pub Vec<TransportLayerAddress>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "PrintableString",
     sz_extensible = true,
@@ -1741,11 +1740,11 @@ pub struct ENBX2TLAs(pub Vec<TransportLayerAddress>);
 )]
 pub struct ENBname(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "15")]
 pub struct EPLMNs(pub Vec<PLMNidentity>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EUTRAN_CGI {
     pub plm_nidentity: PLMNidentity,
@@ -1754,28 +1753,28 @@ pub struct EUTRAN_CGI {
     pub ie_extensions: Option<EUTRAN_CGIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct EUTRANResponse {
     pub cell_id: OCTET_STRING_21,
     pub eutra_ncell_load_reporting_response: EUTRANcellLoadReportingResponse,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "2047")]
 pub struct EUTRANRoundTripDelayEstimationInfo(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct EUTRANcellLoadReportingResponse {
     pub composite_available_capacity_group: CompositeAvailableCapacityGroup,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct EmergencyAreaID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1784,7 +1783,7 @@ pub struct EmergencyAreaID(pub Vec<u8>);
 )]
 pub struct EmergencyAreaID_Broadcast(pub Vec<EmergencyAreaID_Broadcast_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EmergencyAreaID_Broadcast_Item {
     pub emergency_area_id: EmergencyAreaID,
@@ -1793,7 +1792,7 @@ pub struct EmergencyAreaID_Broadcast_Item {
     pub ie_extensions: Option<EmergencyAreaID_Broadcast_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1802,7 +1801,7 @@ pub struct EmergencyAreaID_Broadcast_Item {
 )]
 pub struct EmergencyAreaID_Cancelled(pub Vec<EmergencyAreaID_Cancelled_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EmergencyAreaID_Cancelled_Item {
     pub emergency_area_id: EmergencyAreaID,
@@ -1811,7 +1810,7 @@ pub struct EmergencyAreaID_Cancelled_Item {
     pub ie_extensions: Option<EmergencyAreaID_Cancelled_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1820,7 +1819,7 @@ pub struct EmergencyAreaID_Cancelled_Item {
 )]
 pub struct EmergencyAreaIDList(pub Vec<EmergencyAreaID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1829,22 +1828,22 @@ pub struct EmergencyAreaIDList(pub Vec<EmergencyAreaID>);
 )]
 pub struct EmergencyAreaIDListForRestart(pub Vec<EmergencyAreaID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct EmergencyIndicator(pub u8);
 impl EmergencyIndicator {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "22", sz_ub = "32")]
 pub struct En_gNB_ID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct EncryptionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct EndIndication(pub u8);
 impl EndIndication {
@@ -1852,33 +1851,33 @@ impl EndIndication {
     pub const FURTHER_DATA_EXISTS: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct EnhancedCoverageRestricted(pub u8);
 impl EnhancedCoverageRestricted {
     pub const RESTRICTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ErrorIndication {
     pub protocol_i_es: ErrorIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Ethernet_Type(pub u8);
 impl Ethernet_Type {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct EventTriggeredCellLoadReportingRequest {
     pub number_of_measurement_reporting_levels: NumberOfMeasurementReportingLevels,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EventTriggeredCellLoadReportingResponse {
     pub cell_load_reporting_response: CellLoadReportingResponse,
@@ -1886,7 +1885,7 @@ pub struct EventTriggeredCellLoadReportingResponse {
     pub overload_flag: Option<OverloadFlag>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct EventType(pub u8);
 impl EventType {
@@ -1895,11 +1894,11 @@ impl EventType {
     pub const STOP_CHANGE_OF_SERVE_CELL: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "30", extensible = true)]
 pub struct ExpectedActivityPeriod(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "6")]
 pub struct ExpectedHOInterval(pub u8);
 impl ExpectedHOInterval {
@@ -1912,11 +1911,11 @@ impl ExpectedHOInterval {
     pub const LONG_TIME: u8 = 6u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "30", extensible = true)]
 pub struct ExpectedIdlePeriod(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct ExpectedUEActivityBehaviour {
     #[asn(optional_idx = 0)]
@@ -1929,7 +1928,7 @@ pub struct ExpectedUEActivityBehaviour {
     pub ie_extensions: Option<ExpectedUEActivityBehaviourIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct ExpectedUEBehaviour {
     #[asn(optional_idx = 0)]
@@ -1940,11 +1939,11 @@ pub struct ExpectedUEBehaviour {
     pub ie_extensions: Option<ExpectedUEBehaviourIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "14", sz_ub = "14")]
 pub struct Extended_UEIdentityIndexValue(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "INTEGER",
     lb = "10000000001",
@@ -1953,22 +1952,22 @@ pub struct Extended_UEIdentityIndexValue(pub BitVec<u8, Msb0>);
 )]
 pub struct ExtendedBitRate(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "4096", ub = "65535")]
 pub struct ExtendedRNC_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "4096", ub = "131071")]
 pub struct ExtendedRepetitionPeriod(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum FailureEventReport {
     #[asn(key = 0, extended = false)]
     TooEarlyInterRATHOReportFromEUTRAN(TooEarlyInterRATHOReportReportFromEUTRAN),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct FailureEventReportingCause(pub u8);
 impl FailureEventReportingCause {
@@ -1977,11 +1976,11 @@ impl FailureEventReportingCause {
     pub const UNSPECIFIED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct FiveGSTAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct FiveGSTAI {
     pub plm_nidentity: PLMNidentity,
@@ -1990,11 +1989,11 @@ pub struct FiveGSTAI {
     pub ie_extensions: Option<FiveGSTAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255", extensible = true)]
 pub struct FiveQI(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct ForbiddenInterRATs(pub u8);
 impl ForbiddenInterRATs {
@@ -2004,7 +2003,7 @@ impl ForbiddenInterRATs {
     pub const CDMA2000: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2013,11 +2012,11 @@ impl ForbiddenInterRATs {
 )]
 pub struct ForbiddenLACs(pub Vec<LAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ForbiddenLAs(pub Vec<ForbiddenLAs_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ForbiddenLAs_Item {
     pub plmn_identity: PLMNidentity,
@@ -2026,7 +2025,7 @@ pub struct ForbiddenLAs_Item {
     pub ie_extensions: Option<ForbiddenLAs_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2035,11 +2034,11 @@ pub struct ForbiddenLAs_Item {
 )]
 pub struct ForbiddenTACs(pub Vec<TAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ForbiddenTAs(pub Vec<ForbiddenTAs_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ForbiddenTAs_Item {
     pub plmn_identity: PLMNidentity,
@@ -2048,7 +2047,7 @@ pub struct ForbiddenTAs_Item {
     pub ie_extensions: Option<ForbiddenTAs_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GBR_QosInformation {
     pub e_rab_maximum_bitrate_dl: BitRate,
@@ -2059,7 +2058,7 @@ pub struct GBR_QosInformation {
     pub ie_extensions: Option<GBR_QosInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GERAN_Cell_ID {
     pub lai: LAI,
@@ -2069,7 +2068,7 @@ pub struct GERAN_Cell_ID {
     pub ie_extensions: Option<GERAN_Cell_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GNB {
     pub global_g_nb_id: Global_GNB_ID,
@@ -2077,22 +2076,22 @@ pub struct GNB {
     pub ie_extensions: Option<GNBIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "22", sz_ub = "32")]
 pub struct GNB_ID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum GNB_Identity {
     #[asn(key = 0, extended = false)]
     GNB_ID(GNB_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct GTP_TEID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GUMMEI {
     pub plmn_identity: PLMNidentity,
@@ -2102,7 +2101,7 @@ pub struct GUMMEI {
     pub ie_extensions: Option<GUMMEIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2111,7 +2110,7 @@ pub struct GUMMEI {
 )]
 pub struct GUMMEIList(pub Vec<GUMMEI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct GUMMEIType(pub u8);
 impl GUMMEIType {
@@ -2119,14 +2118,14 @@ impl GUMMEIType {
     pub const MAPPED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct GWContextReleaseIndication(pub u8);
 impl GWContextReleaseIndication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Global_ENB_ID {
     pub plm_nidentity: PLMNidentity,
@@ -2135,7 +2134,7 @@ pub struct Global_ENB_ID {
     pub ie_extensions: Option<Global_ENB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Global_GNB_ID {
     pub plmn_identity: PLMNidentity,
@@ -2144,7 +2143,7 @@ pub struct Global_GNB_ID {
     pub ie_extensions: Option<Global_GNB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum Global_RAN_NODE_ID {
     #[asn(key = 0, extended = false)]
@@ -2153,7 +2152,7 @@ pub enum Global_RAN_NODE_ID {
     Ng_eNB(NG_eNB),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Global_en_gNB_ID {
     pub plm_nidentity: PLMNidentity,
@@ -2162,19 +2161,19 @@ pub struct Global_en_gNB_ID {
     pub ie_extensions: Option<Global_en_gNB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1048575")]
 pub struct HFN(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "131071")]
 pub struct HFNModified(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "16383")]
 pub struct HFNforPDCP_SNlength18(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct HOReport {
     pub ho_type: HoType,
@@ -2186,7 +2185,7 @@ pub struct HOReport {
     pub candidate_pci_list: Option<CandidatePCIList>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct HOReportingCause(pub u8);
 impl HOReportingCause {
@@ -2195,68 +2194,68 @@ impl HOReportingCause {
     pub const UNSPECIFIED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverCancel {
     pub protocol_i_es: HandoverCancelProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverCancelAcknowledge {
     pub protocol_i_es: HandoverCancelAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverCommand {
     pub protocol_i_es: HandoverCommandProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverFailure {
     pub protocol_i_es: HandoverFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct HandoverFlag(pub u8);
 impl HandoverFlag {
     pub const HANDOVER_PREPARATION: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverNotify {
     pub protocol_i_es: HandoverNotifyProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverPreparationFailure {
     pub protocol_i_es: HandoverPreparationFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverRequest {
     pub protocol_i_es: HandoverRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverRequestAcknowledge {
     pub protocol_i_es: HandoverRequestAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverRequired {
     pub protocol_i_es: HandoverRequiredProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct HandoverRestrictionList {
     pub serving_plmn: PLMNidentity,
@@ -2272,13 +2271,13 @@ pub struct HandoverRestrictionList {
     pub ie_extensions: Option<HandoverRestrictionListIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverSuccess {
     pub protocol_i_es: HandoverSuccessProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct HandoverType(pub u8);
 impl HandoverType {
@@ -2289,14 +2288,14 @@ impl HandoverType {
     pub const GERANTOLTE: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct HoReportType(pub u8);
 impl HoReportType {
     pub const UNNECESSARYHOTOANOTHERRAT: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct HoType(pub u8);
 impl HoType {
@@ -2304,7 +2303,7 @@ impl HoType {
     pub const LTETOGERAN: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct IAB_Authorized(pub u8);
 impl IAB_Authorized {
@@ -2312,32 +2311,32 @@ impl IAB_Authorized {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct IAB_Node_Indication(pub u8);
 impl IAB_Node_Indication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct IAB_Supported(pub u8);
 impl IAB_Supported {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "8")]
 pub struct IMSI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct IMSvoiceEPSfallbackfrom5G(pub u8);
 impl IMSvoiceEPSfallbackfrom5G {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum IRAT_Cell_ID {
     #[asn(key = 0, extended = false)]
@@ -2350,7 +2349,7 @@ pub enum IRAT_Cell_ID {
     EHRPD(EHRPD_Sector_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct ImmediateMDT {
     pub measurements_to_activate: MeasurementsToActivate,
@@ -2363,7 +2362,7 @@ pub struct ImmediateMDT {
     pub ie_extensions: Option<ImmediateMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InformationOnRecommendedCellsAndENBsForPaging {
     pub recommended_cells_for_paging: RecommendedCellsForPaging,
@@ -2372,31 +2371,31 @@ pub struct InformationOnRecommendedCellsAndENBsForPaging {
     pub ie_extensions: Option<InformationOnRecommendedCellsAndENBsForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialContextSetupFailure {
     pub protocol_i_es: InitialContextSetupFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialContextSetupRequest {
     pub protocol_i_es: InitialContextSetupRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialContextSetupResponse {
     pub protocol_i_es: InitialContextSetupResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialUEMessage {
     pub protocol_i_es: InitialUEMessageProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitiatingMessage {
     #[asn(key_field = true)]
@@ -2405,22 +2404,22 @@ pub struct InitiatingMessage {
     pub value: InitiatingMessageValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct IntegrityProtectionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "16", extensible = true)]
 pub struct IntendedNumberOfPagingAttempts(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum Inter_SystemInformationTransferType {
     #[asn(key = 0, extended = false)]
     RIMTransfer(RIMTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 8)]
 pub struct InterSystemMeasurementItem {
     pub freq_band_indicator_nr: INTEGER_25,
@@ -2444,11 +2443,11 @@ pub struct InterSystemMeasurementItem {
     pub ie_extensions: Option<InterSystemMeasurementItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct InterSystemMeasurementList(pub Vec<InterSystemMeasurementItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct InterSystemMeasurementParameters {
     pub measurement_duration: INTEGER_35,
@@ -2458,11 +2457,11 @@ pub struct InterSystemMeasurementParameters {
     pub ie_extensions: Option<InterSystemMeasurementParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct InterfacesToTrace(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct IntersystemMeasurementConfiguration {
     #[asn(optional_idx = 0)]
@@ -2476,38 +2475,38 @@ pub struct IntersystemMeasurementConfiguration {
     pub ie_extensions: Option<IntersystemMeasurementConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct IntersystemSONConfigurationTransfer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "0")]
 pub struct KillAllWarningMessages(pub u8);
 impl KillAllWarningMessages {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct KillRequest {
     pub protocol_i_es: KillRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct KillResponse {
     pub protocol_i_es: KillResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct L3_Information(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct LAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LAI {
     pub plm_nidentity: PLMNidentity,
@@ -2516,7 +2515,7 @@ pub struct LAI {
     pub ie_extensions: Option<LAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -2525,18 +2524,18 @@ pub struct LAI {
 )]
 pub struct LHN_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct LPPa_PDU(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct LTE_M_Indication(pub u8);
 impl LTE_M_Indication {
     pub const LTE_M: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum LastVisitedCell_Item {
     #[asn(key = 0, extended = false)]
@@ -2549,7 +2548,7 @@ pub enum LastVisitedCell_Item {
     NG_RAN_Cell(LastVisitedNGRANCellInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LastVisitedEUTRANCellInformation {
     pub global_cell_id: EUTRAN_CGI,
@@ -2559,22 +2558,22 @@ pub struct LastVisitedEUTRANCellInformation {
     pub ie_extensions: Option<LastVisitedEUTRANCellInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum LastVisitedGERANCellInformation {
     #[asn(key = 0, extended = false)]
     Undefined(NULL_39),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct LastVisitedNGRANCellInformation(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct LastVisitedUTRANCellInformation(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct Links_to_log(pub u8);
 impl Links_to_log {
@@ -2583,7 +2582,7 @@ impl Links_to_log {
     pub const BOTH_UPLINK_AND_DOWNLINK: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ListeningSubframePattern {
     pub pattern_period: ENUMERATED_40,
@@ -2592,25 +2591,25 @@ pub struct ListeningSubframePattern {
     pub ie_extensions: Option<ListeningSubframePatternIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct LocationReport {
     pub protocol_i_es: LocationReportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct LocationReportingControl {
     pub protocol_i_es: LocationReportingControlProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct LocationReportingFailureIndication {
     pub protocol_i_es: LocationReportingFailureIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct LoggedMBSFNMDT {
     pub logging_interval: LoggingInterval,
@@ -2621,7 +2620,7 @@ pub struct LoggedMBSFNMDT {
     pub ie_extensions: Option<LoggedMBSFNMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LoggedMDT {
     pub logging_interval: LoggingInterval,
@@ -2630,7 +2629,7 @@ pub struct LoggedMDT {
     pub ie_extensions: Option<LoggedMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "5")]
 pub struct LoggingDuration(pub u8);
 impl LoggingDuration {
@@ -2642,7 +2641,7 @@ impl LoggingDuration {
     pub const M120: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "7")]
 pub struct LoggingInterval(pub u8);
 impl LoggingInterval {
@@ -2656,11 +2655,11 @@ impl LoggingInterval {
     pub const MS6144: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct M_TMSI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M1PeriodicReporting {
     pub report_interval: ReportIntervalMDT,
@@ -2669,7 +2668,7 @@ pub struct M1PeriodicReporting {
     pub ie_extensions: Option<M1PeriodicReportingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct M1ReportingTrigger(pub u8);
 impl M1ReportingTrigger {
@@ -2677,7 +2676,7 @@ impl M1ReportingTrigger {
     pub const A2EVENTTRIGGERED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M1ThresholdEventA2 {
     pub measurement_threshold: MeasurementThresholdA2,
@@ -2685,7 +2684,7 @@ pub struct M1ThresholdEventA2 {
     pub ie_extensions: Option<M1ThresholdEventA2IE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M3Configuration {
     pub m3period: M3period,
@@ -2693,7 +2692,7 @@ pub struct M3Configuration {
     pub ie_extensions: Option<M3ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct M3period(pub u8);
 impl M3period {
@@ -2702,7 +2701,7 @@ impl M3period {
     pub const MS10000: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M4Configuration {
     pub m4period: M4period,
@@ -2711,7 +2710,7 @@ pub struct M4Configuration {
     pub ie_extensions: Option<M4ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct M4period(pub u8);
 impl M4period {
@@ -2722,7 +2721,7 @@ impl M4period {
     pub const MIN1: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M5Configuration {
     pub m5period: M5period,
@@ -2731,7 +2730,7 @@ pub struct M5Configuration {
     pub ie_extensions: Option<M5ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct M5period(pub u8);
 impl M5period {
@@ -2742,7 +2741,7 @@ impl M5period {
     pub const MIN1: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct M6Configuration {
     pub m6report_interval: M6report_Interval,
@@ -2753,7 +2752,7 @@ pub struct M6Configuration {
     pub ie_extensions: Option<M6ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "11")]
 pub struct M6delay_threshold(pub u8);
 impl M6delay_threshold {
@@ -2771,7 +2770,7 @@ impl M6delay_threshold {
     pub const MS750: u8 = 11u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct M6report_Interval(pub u8);
 impl M6report_Interval {
@@ -2781,7 +2780,7 @@ impl M6report_Interval {
     pub const MS10240: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M7Configuration {
     pub m7period: M7period,
@@ -2790,15 +2789,15 @@ pub struct M7Configuration {
     pub ie_extensions: Option<M7ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "60", extensible = true)]
 pub struct M7period(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct MBSFN_ResultToLog(pub Vec<MBSFN_ResultToLogInfo>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct MBSFN_ResultToLogInfo {
     #[asn(optional_idx = 0)]
@@ -2808,7 +2807,7 @@ pub struct MBSFN_ResultToLogInfo {
     pub ie_extensions: Option<MBSFN_ResultToLogInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct MDT_Activation(pub u8);
 impl MDT_Activation {
@@ -2817,7 +2816,7 @@ impl MDT_Activation {
     pub const LOGGED_MDT_ONLY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MDT_Configuration {
     pub mdt_activation: MDT_Activation,
@@ -2827,15 +2826,15 @@ pub struct MDT_Configuration {
     pub ie_extensions: Option<MDT_ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct MDT_ConfigurationNR(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct MDT_Location_Info(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum MDTMode {
     #[asn(key = 0, extended = false)]
@@ -2846,7 +2845,7 @@ pub enum MDTMode {
     MDTMode_Extension(MDTMode_Extension),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDTMode_Extension {
     #[asn(key_field = true)]
@@ -2855,65 +2854,65 @@ pub struct MDTMode_Extension {
     pub value: MDTMode_ExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct MDTPLMNList(pub Vec<PLMNidentity>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct MME_Code(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct MME_Group_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4294967295")]
 pub struct MME_UE_S1AP_ID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMECPRelocationIndication {
     pub protocol_i_es: MMECPRelocationIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMEConfigurationTransfer {
     pub protocol_i_es: MMEConfigurationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMEConfigurationUpdate {
     pub protocol_i_es: MMEConfigurationUpdateProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMEConfigurationUpdateAcknowledge {
     pub protocol_i_es: MMEConfigurationUpdateAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMEConfigurationUpdateFailure {
     pub protocol_i_es: MMEConfigurationUpdateFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMEDirectInformationTransfer {
     pub protocol_i_es: MMEDirectInformationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMEEarlyStatusTransfer {
     pub protocol_i_es: MMEEarlyStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum MMEPagingTarget {
     #[asn(key = 0, extended = false)]
@@ -2922,20 +2921,20 @@ pub enum MMEPagingTarget {
     TAI(TAI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct MMERelaySupportIndicator(pub u8);
 impl MMERelaySupportIndicator {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MMEStatusTransfer {
     pub protocol_i_es: MMEStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "PrintableString",
     sz_extensible = true,
@@ -2944,26 +2943,26 @@ pub struct MMEStatusTransfer {
 )]
 pub struct MMEname(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct MSClassmark2(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct MSClassmark3(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ManagementBasedMDTAllowed(pub u8);
 impl ManagementBasedMDTAllowed {
     pub const ALLOWED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "64", sz_ub = "64")]
 pub struct Masked_IMEISV(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum MeasurementThresholdA2 {
     #[asn(key = 0, extended = false)]
@@ -2972,25 +2971,25 @@ pub enum MeasurementThresholdA2 {
     Threshold_RSRQ(Threshold_RSRQ),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct MeasurementsToActivate(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct MessageIdentifier(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "32", sz_ub = "32")]
 pub struct MobilityInformation(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct MultiCellLoadReportingRequest {
     pub requested_cell_list: RequestedCellList,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -2999,7 +2998,7 @@ pub struct MultiCellLoadReportingRequest {
 )]
 pub struct MultiCellLoadReportingResponse(pub Vec<MultiCellLoadReportingResponse_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum MultiCellLoadReportingResponse_Item {
     #[asn(key = 0, extended = false)]
@@ -3012,7 +3011,7 @@ pub enum MultiCellLoadReportingResponse_Item {
     EHRPD(EHRPDMultiSectorLoadReportingResponseItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct MutingAvailabilityIndication(pub u8);
 impl MutingAvailabilityIndication {
@@ -3020,7 +3019,7 @@ impl MutingAvailabilityIndication {
     pub const UNAVAILABLE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct MutingPatternInformation {
     pub muting_pattern_period: ENUMERATED_45,
@@ -3030,31 +3029,31 @@ pub struct MutingPatternInformation {
     pub ie_extensions: Option<MutingPatternInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NAS_PDU(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NASDeliveryIndication {
     pub protocol_i_es: NASDeliveryIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NASNonDeliveryIndication {
     pub protocol_i_es: NASNonDeliveryIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NASSecurityParametersfromE_UTRAN(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NASSecurityParameterstoE_UTRAN(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct NB_IoT_DefaultPagingDRX(pub u8);
 impl NB_IoT_DefaultPagingDRX {
@@ -3064,7 +3063,7 @@ impl NB_IoT_DefaultPagingDRX {
     pub const V1024: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "13")]
 pub struct NB_IoT_Paging_eDRX_Cycle(pub u8);
 impl NB_IoT_Paging_eDRX_Cycle {
@@ -3084,7 +3083,7 @@ impl NB_IoT_Paging_eDRX_Cycle {
     pub const HF1024: u8 = 13u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct NB_IoT_Paging_eDRXInformation {
     pub nb_io_t_paging_e_drx_cycle: NB_IoT_Paging_eDRX_Cycle,
@@ -3094,7 +3093,7 @@ pub struct NB_IoT_Paging_eDRXInformation {
     pub ie_extensions: Option<NB_IoT_Paging_eDRXInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct NB_IoT_PagingDRX(pub u8);
 impl NB_IoT_PagingDRX {
@@ -3106,7 +3105,7 @@ impl NB_IoT_PagingDRX {
     pub const V1024: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "15")]
 pub struct NB_IoT_PagingTimeWindow(pub u8);
 impl NB_IoT_PagingTimeWindow {
@@ -3128,15 +3127,15 @@ impl NB_IoT_PagingTimeWindow {
     pub const S16: u8 = 15u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NB_IoT_RLF_Report_Container(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "12", sz_ub = "12")]
 pub struct NB_IoT_UEIdentityIndexValue(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NG_eNB {
     pub global_ng_e_nb_id: Global_ENB_ID,
@@ -3144,7 +3143,7 @@ pub struct NG_eNB {
     pub ie_extensions: Option<NG_eNBIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NR_CGI {
     pub plmn_identity: PLMNidentity,
@@ -3153,11 +3152,11 @@ pub struct NR_CGI {
     pub ie_extensions: Option<NR_CGIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "36", sz_ub = "36")]
 pub struct NRCellIdentity(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NRUESecurityCapabilities {
     pub n_rencryption_algorithms: NRencryptionAlgorithms,
@@ -3166,7 +3165,7 @@ pub struct NRUESecurityCapabilities {
     pub ie_extensions: Option<NRUESecurityCapabilitiesIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NRUESidelinkAggregateMaximumBitrate {
     pub u_eaggregate_maximum_bit_rate: BitRate,
@@ -3174,7 +3173,7 @@ pub struct NRUESidelinkAggregateMaximumBitrate {
     pub ie_extensions: Option<NRUESidelinkAggregateMaximumBitrateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct NRV2XServicesAuthorized {
     #[asn(optional_idx = 0)]
@@ -3185,29 +3184,29 @@ pub struct NRV2XServicesAuthorized {
     pub ie_extensions: Option<NRV2XServicesAuthorizedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct NRencryptionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct NRintegrityProtectionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct NRrestrictionin5GS(pub u8);
 impl NRrestrictionin5GS {
     pub const N_RRESTRICTEDIN5_GS: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct NRrestrictioninEPSasSecondaryRAT(pub u8);
 impl NRrestrictioninEPSasSecondaryRAT {
     pub const N_RRESTRICTEDIN_EP_SAS_SECONDARY_RAT: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct NextPagingAreaScope(pub u8);
 impl NextPagingAreaScope {
@@ -3215,7 +3214,7 @@ impl NextPagingAreaScope {
     pub const CHANGED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3224,14 +3223,14 @@ impl NextPagingAreaScope {
 )]
 pub struct NotificationCellList(pub Vec<NotificationCellList_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NotificationCellList_Item {
     pub cell_id: OCTET_STRING_47,
     pub notify_flag: NotifyFlag,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct NotifyFlag(pub u8);
 impl NotifyFlag {
@@ -3239,18 +3238,18 @@ impl NotifyFlag {
     pub const DEACTIVATED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct NotifySourceeNB(pub u8);
 impl NotifySourceeNB {
     pub const NOTIFY_SOURCE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct NumberOfBroadcasts(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct NumberOfMeasurementReportingLevels(pub u8);
 impl NumberOfMeasurementReportingLevels {
@@ -3261,15 +3260,15 @@ impl NumberOfMeasurementReportingLevels {
     pub const RL10: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct NumberofBroadcastRequest(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OldBSS_ToNewBSS_Information(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct OverloadAction(pub u8);
 impl OverloadAction {
@@ -3278,33 +3277,33 @@ impl OverloadAction {
     pub const PERMIT_EMERGENCY_SESSIONS_AND_MOBILE_TERMINATED_SERVICES_ONLY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct OverloadFlag(pub u8);
 impl OverloadFlag {
     pub const OVERLOAD: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum OverloadResponse {
     #[asn(key = 0, extended = false)]
     OverloadAction(OverloadAction),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct OverloadStart {
     pub protocol_i_es: OverloadStartProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct OverloadStop {
     pub protocol_i_es: OverloadStopProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PC5FlowBitRates {
     pub guaranteed_flow_bit_rate: BitRate,
@@ -3313,7 +3312,7 @@ pub struct PC5FlowBitRates {
     pub ie_extensions: Option<PC5FlowBitRatesIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct PC5QoSFlowItem {
     pub pqi: FiveQI,
@@ -3325,7 +3324,7 @@ pub struct PC5QoSFlowItem {
     pub ie_extensions: Option<PC5QoSFlowItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3334,7 +3333,7 @@ pub struct PC5QoSFlowItem {
 )]
 pub struct PC5QoSFlowList(pub Vec<PC5QoSFlowItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PC5QoSParameters {
     pub pc5_qo_s_flow_list: PC5QoSFlowList,
@@ -3344,19 +3343,19 @@ pub struct PC5QoSParameters {
     pub ie_extensions: Option<PC5QoSParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct PDCP_SN(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "32767")]
 pub struct PDCP_SNExtended(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "262143")]
 pub struct PDCP_SNlength18(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PLMNAreaBasedQMC {
     pub plmn_listfor_qmc: PLMNListforQMC,
@@ -3364,20 +3363,20 @@ pub struct PLMNAreaBasedQMC {
     pub ie_extensions: Option<PLMNAreaBasedQMCIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct PLMNListforQMC(pub Vec<PLMNidentity>);
 
 pub type PLMNidentity = TBCD_STRING;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct PS_ServiceNotAvailable(pub u8);
 impl PS_ServiceNotAvailable {
     pub const PS_SERVICE_NOT_AVAILABLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PSCellInformation {
     pub ncgi: NR_CGI,
@@ -3385,19 +3384,19 @@ pub struct PSCellInformation {
     pub ie_extensions: Option<PSCellInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PWSFailureIndication {
     pub protocol_i_es: PWSFailureIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PWSRestartIndication {
     pub protocol_i_es: PWSRestartIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3406,17 +3405,17 @@ pub struct PWSRestartIndication {
 )]
 pub struct PWSfailedECGIList(pub Vec<EUTRAN_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1000")]
 pub struct Packet_LossRate(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct Paging {
     pub protocol_i_es: PagingProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "13")]
 pub struct Paging_eDRX_Cycle(pub u8);
 impl Paging_eDRX_Cycle {
@@ -3436,7 +3435,7 @@ impl Paging_eDRX_Cycle {
     pub const HF256: u8 = 13u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct Paging_eDRXInformation {
     pub paging_e_drx_cycle: Paging_eDRX_Cycle,
@@ -3446,11 +3445,11 @@ pub struct Paging_eDRXInformation {
     pub ie_extensions: Option<Paging_eDRXInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "16", extensible = true)]
 pub struct PagingAttemptCount(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PagingAttemptInformation {
     pub paging_attempt_count: PagingAttemptCount,
@@ -3461,7 +3460,7 @@ pub struct PagingAttemptInformation {
     pub ie_extensions: Option<PagingAttemptInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct PagingDRX(pub u8);
 impl PagingDRX {
@@ -3471,7 +3470,7 @@ impl PagingDRX {
     pub const V256: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "7")]
 pub struct PagingPriority(pub u8);
 impl PagingPriority {
@@ -3485,7 +3484,7 @@ impl PagingPriority {
     pub const PRIOLEVEL8: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "20")]
 pub struct PagingProbabilityInformation(pub u8);
 impl PagingProbabilityInformation {
@@ -3512,7 +3511,7 @@ impl PagingProbabilityInformation {
     pub const P100: u8 = 20u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "15")]
 pub struct PagingTimeWindow(pub u8);
 impl PagingTimeWindow {
@@ -3534,25 +3533,25 @@ impl PagingTimeWindow {
     pub const S16: u8 = 15u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PathSwitchRequest {
     pub protocol_i_es: PathSwitchRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PathSwitchRequestAcknowledge {
     pub protocol_i_es: PathSwitchRequestAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PathSwitchRequestFailure {
     pub protocol_i_es: PathSwitchRequestFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct PedestrianUE(pub u8);
 impl PedestrianUE {
@@ -3560,18 +3559,18 @@ impl PedestrianUE {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct PendingDataIndication(pub u8);
 impl PendingDataIndication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct Port_Number(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct Pre_emptionCapability(pub u8);
 impl Pre_emptionCapability {
@@ -3579,7 +3578,7 @@ impl Pre_emptionCapability {
     pub const MAY_TRIGGER_PRE_EMPTION: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct Pre_emptionVulnerability(pub u8);
 impl Pre_emptionVulnerability {
@@ -3587,7 +3586,7 @@ impl Pre_emptionVulnerability {
     pub const PRE_EMPTABLE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct Presence(pub u8);
 impl Presence {
@@ -3596,11 +3595,11 @@ impl Presence {
     pub const MANDATORY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15")]
 pub struct PriorityLevel(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct PrivacyIndicator(pub u8);
 impl PrivacyIndicator {
@@ -3608,7 +3607,7 @@ impl PrivacyIndicator {
     pub const LOGGED_MDT: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum PrivateIE_ID {
     #[asn(key = 0, extended = false)]
@@ -3617,13 +3616,13 @@ pub enum PrivateIE_ID {
     Global(OBJECT_IDENTIFIER_49),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PrivateMessage {
     pub private_i_es: PrivateMessagePrivateIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct ProSeAuthorized {
     #[asn(optional_idx = 0)]
@@ -3634,7 +3633,7 @@ pub struct ProSeAuthorized {
     pub ie_extensions: Option<ProSeAuthorizedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ProSeDirectCommunication(pub u8);
 impl ProSeDirectCommunication {
@@ -3642,7 +3641,7 @@ impl ProSeDirectCommunication {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ProSeDirectDiscovery(pub u8);
 impl ProSeDirectDiscovery {
@@ -3650,7 +3649,7 @@ impl ProSeDirectDiscovery {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ProSeUEtoNetworkRelaying(pub u8);
 impl ProSeUEtoNetworkRelaying {
@@ -3658,42 +3657,42 @@ impl ProSeUEtoNetworkRelaying {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct ProcedureCode(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct ProtocolExtensionID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct ProtocolIE_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct QCI(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct RAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4294967295")]
 pub struct RAN_UE_NGAP_ID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct RAT_Type(pub u8);
 impl RAT_Type {
     pub const NBIOT: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct RIMInformation(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum RIMRoutingAddress {
     #[asn(key = 0, extended = false)]
@@ -3704,7 +3703,7 @@ pub enum RIMRoutingAddress {
     EHRPD_Sector_ID(OCTET_STRING_50),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct RIMTransfer {
     pub rim_information: RIMInformation,
@@ -3714,7 +3713,7 @@ pub struct RIMTransfer {
     pub ie_extensions: Option<RIMTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct RLFReportInformation {
     pub ue_rlf_report_container: UE_RLF_Report_Container,
@@ -3725,15 +3724,15 @@ pub struct RLFReportInformation {
     pub ie_extensions: Option<RLFReportInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct RNC_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct RRC_Container(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct RRC_Establishment_Cause(pub u8);
 impl RRC_Establishment_Cause {
@@ -3744,7 +3743,7 @@ impl RRC_Establishment_Cause {
     pub const MO_DATA: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "8")]
 pub struct Range(pub u8);
 impl Range {
@@ -3759,7 +3758,7 @@ impl Range {
     pub const M1000: u8 = 8u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -3768,7 +3767,7 @@ impl Range {
 )]
 pub struct ReceiveStatusOfULPDCPSDUsExtended(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -3777,7 +3776,7 @@ pub struct ReceiveStatusOfULPDCPSDUsExtended(pub BitVec<u8, Msb0>);
 )]
 pub struct ReceiveStatusOfULPDCPSDUsPDCP_SNlength18(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -3786,7 +3785,7 @@ pub struct ReceiveStatusOfULPDCPSDUsPDCP_SNlength18(pub BitVec<u8, Msb0>);
 )]
 pub struct ReceiveStatusofULPDCPSDUs(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct RecommendedCellItem {
     pub eutran_cgi: EUTRAN_CGI,
@@ -3796,11 +3795,11 @@ pub struct RecommendedCellItem {
     pub ie_extensions: Option<RecommendedCellItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct RecommendedCellList(pub Vec<RecommendedCellList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RecommendedCellsForPaging {
     pub recommended_cell_list: RecommendedCellList,
@@ -3808,7 +3807,7 @@ pub struct RecommendedCellsForPaging {
     pub ie_extensions: Option<RecommendedCellsForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RecommendedENBItem {
     pub mme_paging_target: MMEPagingTarget,
@@ -3816,11 +3815,11 @@ pub struct RecommendedENBItem {
     pub ie_extensions: Option<RecommendedENBItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct RecommendedENBList(pub Vec<RecommendedENBList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RecommendedENBsForPaging {
     pub recommended_enb_list: RecommendedENBList,
@@ -3828,22 +3827,22 @@ pub struct RecommendedENBsForPaging {
     pub ie_extensions: Option<RecommendedENBsForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct RelativeMMECapacity(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct RelayNode_Indicator(pub u8);
 impl RelayNode_Indicator {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct RepetitionPeriod(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "7")]
 pub struct ReportAmountMDT(pub u8);
 impl ReportAmountMDT {
@@ -3857,14 +3856,14 @@ impl ReportAmountMDT {
     pub const RINFINITY: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ReportArea(pub u8);
 impl ReportArea {
     pub const ECGI: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "12")]
 pub struct ReportIntervalMDT(pub u8);
 impl ReportIntervalMDT {
@@ -3883,7 +3882,7 @@ impl ReportIntervalMDT {
     pub const MIN60: u8 = 12u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3892,13 +3891,13 @@ impl ReportIntervalMDT {
 )]
 pub struct ReportingCellList(pub Vec<ReportingCellList_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ReportingCellList_Item {
     pub cell_id: IRAT_Cell_ID,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RequestType {
     pub event_type: EventType,
@@ -3907,14 +3906,14 @@ pub struct RequestType {
     pub ie_extensions: Option<RequestTypeIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct RequestTypeAdditionalInfo(pub u8);
 impl RequestTypeAdditionalInfo {
     pub const INCLUDE_PS_CELL: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3923,32 +3922,32 @@ impl RequestTypeAdditionalInfo {
 )]
 pub struct RequestedCellList(pub Vec<IRAT_Cell_ID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RerouteNASRequest {
     pub protocol_i_es: RerouteNASRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct Reset {
     pub protocol_i_es: ResetProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ResetAcknowledge {
     pub protocol_i_es: ResetAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ResetAll(pub u8);
 impl ResetAll {
     pub const RESET_ALL: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum ResetType {
     #[asn(key = 0, extended = false)]
@@ -3957,17 +3956,17 @@ pub enum ResetType {
     PartOfS1_Interface(UE_associatedLogicalS1_ConnectionListRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RetrieveUEInformation {
     pub protocol_i_es: RetrieveUEInformationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct Routing_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct S_TMSI {
     pub mmec: MME_Code,
@@ -3976,7 +3975,7 @@ pub struct S_TMSI {
     pub ie_extensions: Option<S_TMSIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum S1AP_PDU {
     #[asn(key = 0, extended = false)]
@@ -3987,25 +3986,25 @@ pub enum S1AP_PDU {
     UnsuccessfulOutcome(UnsuccessfulOutcome),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct S1SetupFailure {
     pub protocol_i_es: S1SetupFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct S1SetupRequest {
     pub protocol_i_es: S1SetupRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct S1SetupResponse {
     pub protocol_i_es: S1SetupResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SONConfigurationTransfer {
     pub targete_nb_id: TargeteNB_ID,
@@ -4015,7 +4014,7 @@ pub struct SONConfigurationTransfer {
     pub ie_extensions: Option<SONConfigurationTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum SONInformation {
     #[asn(key = 0, extended = false)]
@@ -4026,7 +4025,7 @@ pub enum SONInformation {
     SONInformation_Extension(SONInformation_Extension),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SONInformation_Extension {
     #[asn(key_field = true)]
@@ -4035,7 +4034,7 @@ pub struct SONInformation_Extension {
     pub value: SONInformation_ExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct SONInformationReply {
     #[asn(optional_idx = 0)]
@@ -4044,28 +4043,28 @@ pub struct SONInformationReply {
     pub ie_extensions: Option<SONInformationReplyIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum SONInformationReport {
     #[asn(key = 0, extended = false)]
     RLFReportInformation(RLFReportInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SONInformationRequest(pub u8);
 impl SONInformationRequest {
     pub const X2_TNL_CONFIGURATION_INFO: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SONtransferApplicationIdentity(pub u8);
 impl SONtransferApplicationIdentity {
     pub const CELL_LOAD_REPORTING: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum SONtransferCause {
     #[asn(key = 0, extended = false)]
@@ -4084,7 +4083,7 @@ pub enum SONtransferCause {
     FailureEventReporting(FailureEventReportingCause),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum SONtransferRequestContainer {
     #[asn(key = 0, extended = false)]
@@ -4103,7 +4102,7 @@ pub enum SONtransferRequestContainer {
     FailureEventReporting(FailureEventReport),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "0", extensible = true)]
 pub enum SONtransferResponseContainer {
     #[asn(key = 0, extended = false)]
@@ -4122,7 +4121,7 @@ pub enum SONtransferResponseContainer {
     FailureEventReporting(NULL_55),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SRVCCHOIndication(pub u8);
 impl SRVCCHOIndication {
@@ -4130,21 +4129,21 @@ impl SRVCCHOIndication {
     pub const C_SONLY: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SRVCCOperationNotPossible(pub u8);
 impl SRVCCOperationNotPossible {
     pub const NOT_POSSIBLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SRVCCOperationPossible(pub u8);
 impl SRVCCOperationPossible {
     pub const POSSIBLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct ScheduledCommunicationTime {
     #[asn(optional_idx = 0)]
@@ -4157,13 +4156,13 @@ pub struct ScheduledCommunicationTime {
     pub ie_extensions: Option<ScheduledCommunicationTimeIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct SecondaryRATDataUsageReport {
     pub protocol_i_es: SecondaryRATDataUsageReportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SecondaryRATDataUsageReportItem {
     pub e_rab_id: E_RAB_ID,
@@ -4173,7 +4172,7 @@ pub struct SecondaryRATDataUsageReportItem {
     pub ie_extensions: Option<SecondaryRATDataUsageReportItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4182,21 +4181,21 @@ pub struct SecondaryRATDataUsageReportItem {
 )]
 pub struct SecondaryRATDataUsageReportList(pub Vec<SecondaryRATDataUsageReportList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SecondaryRATDataUsageRequest(pub u8);
 impl SecondaryRATDataUsageRequest {
     pub const REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SecondaryRATType(pub u8);
 impl SecondaryRATType {
     pub const N_R: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SecurityContext {
     pub next_hop_chaining_count: INTEGER_59,
@@ -4205,7 +4204,7 @@ pub struct SecurityContext {
     pub ie_extensions: Option<SecurityContextIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -4214,15 +4213,15 @@ pub struct SecurityContext {
 )]
 pub struct SecurityKey(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct SerialNumber(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "0", sz_ub = "32")]
 pub struct ServedDCNs(pub Vec<ServedDCNsItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ServedDCNsItem {
     pub dcn_id: DCN_ID,
@@ -4231,11 +4230,11 @@ pub struct ServedDCNsItem {
     pub ie_extensions: Option<ServedDCNsItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct ServedGUMMEIs(pub Vec<ServedGUMMEIsItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ServedGUMMEIsItem {
     pub served_plm_ns: ServedPLMNs,
@@ -4245,7 +4244,7 @@ pub struct ServedGUMMEIsItem {
     pub ie_extensions: Option<ServedGUMMEIsItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4254,7 +4253,7 @@ pub struct ServedGUMMEIsItem {
 )]
 pub struct ServedGroupIDs(pub Vec<MME_Group_ID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4263,11 +4262,11 @@ pub struct ServedGroupIDs(pub Vec<MME_Group_ID>);
 )]
 pub struct ServedMMECs(pub Vec<MME_Code>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct ServedPLMNs(pub Vec<PLMNidentity>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ServiceType(pub u8);
 impl ServiceType {
@@ -4275,15 +4274,15 @@ impl ServiceType {
     pub const Q_MC_FOR_MTSI_SERVICE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Source_ToTarget_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct SourceBSS_ToTargetBSS_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SourceNgRanNode_ID {
     pub global_ran_node_id: Global_RAN_NODE_ID,
@@ -4292,11 +4291,11 @@ pub struct SourceNgRanNode_ID {
     pub ie_extensions: Option<SourceNgRanNode_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct SourceNgRanNode_ToTargetNgRanNode_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum SourceNodeID {
     #[asn(key = 0, extended = false)]
@@ -4305,11 +4304,11 @@ pub enum SourceNodeID {
     SourceNodeID_Extension(SourceNodeID_Extension),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceNodeID_Extension {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SourceOfUEActivityBehaviourInformation(pub u8);
 impl SourceOfUEActivityBehaviourInformation {
@@ -4317,11 +4316,11 @@ impl SourceOfUEActivityBehaviourInformation {
     pub const STATISTICS: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct SourceRNC_ToTargetRNC_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct SourceeNB_ID {
     pub global_enb_id: Global_ENB_ID,
@@ -4330,7 +4329,7 @@ pub struct SourceeNB_ID {
     pub ie_extensions: Option<SourceeNB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct SourceeNB_ToTargeteNB_TransparentContainer {
     pub rrc_container: RRC_Container,
@@ -4344,15 +4343,15 @@ pub struct SourceeNB_ToTargeteNB_TransparentContainer {
     pub ie_extensions: Option<SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "3", extensible = true)]
 pub struct StratumLevel(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "256")]
 pub struct SubscriberProfileIDforRFP(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 7)]
 pub struct Subscription_Based_UE_DifferentiationInfo {
     #[asn(optional_idx = 0)]
@@ -4371,7 +4370,7 @@ pub struct Subscription_Based_UE_DifferentiationInfo {
     pub ie_extensions: Option<Subscription_Based_UE_DifferentiationInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SuccessfulOutcome {
     #[asn(key_field = true)]
@@ -4380,7 +4379,7 @@ pub struct SuccessfulOutcome {
     pub value: SuccessfulOutcomeValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4389,7 +4388,7 @@ pub struct SuccessfulOutcome {
 )]
 pub struct SupportedTAs(pub Vec<SupportedTAs_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SupportedTAs_Item {
     pub tac: TAC,
@@ -4398,7 +4397,7 @@ pub struct SupportedTAs_Item {
     pub ie_extensions: Option<SupportedTAs_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct SynchronisationInformation {
     #[asn(optional_idx = 0)]
@@ -4411,7 +4410,7 @@ pub struct SynchronisationInformation {
     pub ie_extensions: Option<SynchronisationInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SynchronisationStatus(pub u8);
 impl SynchronisationStatus {
@@ -4419,7 +4418,7 @@ impl SynchronisationStatus {
     pub const ASYNCHRONOUS: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TABasedMDT {
     pub ta_listfor_mdt: TAListforMDT,
@@ -4427,7 +4426,7 @@ pub struct TABasedMDT {
     pub ie_extensions: Option<TABasedMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TABasedQMC {
     pub ta_listfor_qmc: TAListforQMC,
@@ -4435,11 +4434,11 @@ pub struct TABasedQMC {
     pub ie_extensions: Option<TABasedQMCIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct TAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAI {
     pub plm_nidentity: PLMNidentity,
@@ -4448,7 +4447,7 @@ pub struct TAI {
     pub ie_extensions: Option<TAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4457,7 +4456,7 @@ pub struct TAI {
 )]
 pub struct TAI_Broadcast(pub Vec<TAI_Broadcast_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAI_Broadcast_Item {
     pub tai: TAI,
@@ -4466,7 +4465,7 @@ pub struct TAI_Broadcast_Item {
     pub ie_extensions: Option<TAI_Broadcast_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4475,7 +4474,7 @@ pub struct TAI_Broadcast_Item {
 )]
 pub struct TAI_Cancelled(pub Vec<TAI_Cancelled_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAI_Cancelled_Item {
     pub tai: TAI,
@@ -4484,7 +4483,7 @@ pub struct TAI_Cancelled_Item {
     pub ie_extensions: Option<TAI_Cancelled_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIBasedMDT {
     pub tai_listfor_mdt: TAIListforMDT,
@@ -4492,7 +4491,7 @@ pub struct TAIBasedMDT {
     pub ie_extensions: Option<TAIBasedMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIBasedQMC {
     pub tai_listfor_qmc: TAIListforQMC,
@@ -4500,7 +4499,7 @@ pub struct TAIBasedQMC {
     pub ie_extensions: Option<TAIBasedQMCIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIItem {
     pub tai: TAI,
@@ -4508,7 +4507,7 @@ pub struct TAIItem {
     pub ie_extensions: Option<TAIItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4517,7 +4516,7 @@ pub struct TAIItem {
 )]
 pub struct TAIList(pub Vec<TAIList_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4526,15 +4525,15 @@ pub struct TAIList(pub Vec<TAIList_Entry>);
 )]
 pub struct TAIListForRestart(pub Vec<TAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct TAIListforMDT(pub Vec<TAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct TAIListforQMC(pub Vec<TAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4543,27 +4542,27 @@ pub struct TAIListforQMC(pub Vec<TAI>);
 )]
 pub struct TAIListforWarning(pub Vec<TAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct TAListforMDT(pub Vec<TAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct TAListforQMC(pub Vec<TAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct TBCD_STRING(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct Target_ToSource_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TargetBSS_ToSourceBSS_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum TargetID {
     #[asn(key = 0, extended = false)]
@@ -4576,7 +4575,7 @@ pub enum TargetID {
     TargetgNgRanNode_ID(TargetNgRanNode_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargetNgRanNode_ID {
     pub global_ran_node_id: Global_RAN_NODE_ID,
@@ -4585,11 +4584,11 @@ pub struct TargetNgRanNode_ID {
     pub ie_extensions: Option<TargetNgRanNode_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TargetNgRanNode_ToSourceNgRanNode_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct TargetRNC_ID {
     pub lai: LAI,
@@ -4602,11 +4601,11 @@ pub struct TargetRNC_ID {
     pub ie_extensions: Option<TargetRNC_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TargetRNC_ToSourceRNC_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargeteNB_ID {
     pub global_enb_id: Global_ENB_ID,
@@ -4615,7 +4614,7 @@ pub struct TargeteNB_ID {
     pub ie_extensions: Option<TargeteNB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargeteNB_ToSourceeNB_TransparentContainer {
     pub rrc_container: RRC_Container,
@@ -4623,27 +4622,27 @@ pub struct TargeteNB_ToSourceeNB_TransparentContainer {
     pub ie_extensions: Option<TargeteNB_ToSourceeNB_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "97")]
 pub struct Threshold_RSRP(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "34")]
 pub struct Threshold_RSRQ(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct Time_UE_StayedInCell(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "40950")]
 pub struct Time_UE_StayedInCell_EnhancedGranularity(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct TimeSinceSecondaryNodeRelease(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TimeSynchronisationInfo {
     pub stratum_level: StratumLevel,
@@ -4652,7 +4651,7 @@ pub struct TimeSynchronisationInfo {
     pub ie_extensions: Option<TimeSynchronisationInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct TimeToWait(pub u8);
 impl TimeToWait {
@@ -4664,7 +4663,7 @@ impl TimeToWait {
     pub const V60S: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TooEarlyInterRATHOReportReportFromEUTRAN {
     pub uerlf_report_container: OCTET_STRING_65,
@@ -4672,7 +4671,7 @@ pub struct TooEarlyInterRATHOReportReportFromEUTRAN {
     pub mobility_information: Option<MobilityInformation>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TraceActivation {
     pub e_utran_trace_id: E_UTRAN_Trace_ID,
@@ -4683,7 +4682,7 @@ pub struct TraceActivation {
     pub ie_extensions: Option<TraceActivationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct TraceDepth(pub u8);
 impl TraceDepth {
@@ -4695,34 +4694,34 @@ impl TraceDepth {
     pub const MAXIMUM_WITHOUT_VENDOR_SPECIFIC_EXTENSION: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct TraceFailureIndication {
     pub protocol_i_es: TraceFailureIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct TraceStart {
     pub protocol_i_es: TraceStartProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "99")]
 pub struct TrafficLoadReductionIndication(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct TransportInformation {
     pub transport_layer_address: TransportLayerAddress,
     pub ul_gtp_teid: GTP_TEID,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "1", sz_ub = "160")]
 pub struct TransportLayerAddress(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct TriggeringMessage(pub u8);
 impl TriggeringMessage {
@@ -4731,7 +4730,7 @@ impl TriggeringMessage {
     pub const UNSUCCESSFULL_OUTCOME: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TunnelInformation {
     pub transport_layer_address: TransportLayerAddress,
@@ -4741,7 +4740,7 @@ pub struct TunnelInformation {
     pub ie_extensions: Option<TunnelInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct TypeOfError(pub u8);
 impl TypeOfError {
@@ -4749,34 +4748,34 @@ impl TypeOfError {
     pub const MISSING: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct UE_Application_Layer_Measurement_Capability(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct UE_HistoryInformation(pub Vec<LastVisitedCell_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UE_HistoryInformationFromTheUE(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UE_RLF_Report_Container(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UE_RLF_Report_Container_for_extended_bands(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UE_RetentionInformation(pub u8);
 impl UE_RetentionInformation {
     pub const UES_RETAINED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UE_S1AP_ID_pair {
     pub mme_ue_s1ap_id: MME_UE_S1AP_ID,
@@ -4785,7 +4784,7 @@ pub struct UE_S1AP_ID_pair {
     pub ie_extensions: Option<UE_S1AP_ID_pairIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum UE_S1AP_IDs {
     #[asn(key = 0, extended = false)]
@@ -4794,11 +4793,11 @@ pub enum UE_S1AP_IDs {
     MME_UE_S1AP_ID(MME_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct UE_Usage_Type(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct UE_associatedLogicalS1_ConnectionItem {
     #[asn(optional_idx = 0)]
@@ -4809,7 +4808,7 @@ pub struct UE_associatedLogicalS1_ConnectionItem {
     pub ie_extensions: Option<UE_associatedLogicalS1_ConnectionItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4820,7 +4819,7 @@ pub struct UE_associatedLogicalS1_ConnectionListRes(
     pub Vec<UE_associatedLogicalS1_ConnectionListRes_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4831,7 +4830,7 @@ pub struct UE_associatedLogicalS1_ConnectionListResAck(
     pub Vec<UE_associatedLogicalS1_ConnectionListResAck_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UEAggregateMaximumBitrate {
     pub u_eaggregate_maximum_bit_rate_dl: BitRate,
@@ -4840,7 +4839,7 @@ pub struct UEAggregateMaximumBitrate {
     pub ie_extensions: Option<UEAggregateMaximumBitrateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UEAppLayerMeasConfig {
     pub container_for_app_layer_meas_config: OCTET_STRING_66,
@@ -4849,108 +4848,108 @@ pub struct UEAppLayerMeasConfig {
     pub ie_extensions: Option<UEAppLayerMeasConfigIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UECapabilityInfoIndication {
     pub protocol_i_es: UECapabilityInfoIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UECapabilityInfoRequest(pub u8);
 impl UECapabilityInfoRequest {
     pub const REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationConfirm {
     pub protocol_i_es: UEContextModificationConfirmProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationFailure {
     pub protocol_i_es: UEContextModificationFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationIndication {
     pub protocol_i_es: UEContextModificationIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationRequest {
     pub protocol_i_es: UEContextModificationRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationResponse {
     pub protocol_i_es: UEContextModificationResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextReleaseCommand {
     pub protocol_i_es: UEContextReleaseCommandProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextReleaseComplete {
     pub protocol_i_es: UEContextReleaseCompleteProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextReleaseRequest {
     pub protocol_i_es: UEContextReleaseRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextResumeFailure {
     pub protocol_i_es: UEContextResumeFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextResumeRequest {
     pub protocol_i_es: UEContextResumeRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextResumeResponse {
     pub protocol_i_es: UEContextResumeResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextSuspendRequest {
     pub protocol_i_es: UEContextSuspendRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextSuspendResponse {
     pub protocol_i_es: UEContextSuspendResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "10", sz_ub = "10")]
 pub struct UEIdentityIndexValue(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEInformationTransfer {
     pub protocol_i_es: UEInformationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = true)]
 pub enum UEPagingID {
     #[asn(key = 0, extended = false)]
@@ -4959,43 +4958,43 @@ pub enum UEPagingID {
     IMSI(IMSI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapability(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapabilityForPaging(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapabilityID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityIDMappingRequest {
     pub protocol_i_es: UERadioCapabilityIDMappingRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityIDMappingResponse {
     pub protocol_i_es: UERadioCapabilityIDMappingResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityMatchRequest {
     pub protocol_i_es: UERadioCapabilityMatchRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityMatchResponse {
     pub protocol_i_es: UERadioCapabilityMatchResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UESecurityCapabilities {
     pub encryption_algorithms: EncryptionAlgorithms,
@@ -5004,7 +5003,7 @@ pub struct UESecurityCapabilities {
     pub ie_extensions: Option<UESecurityCapabilitiesIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UESidelinkAggregateMaximumBitrate {
     pub ue_sidelink_aggregate_maximum_bit_rate: BitRate,
@@ -5012,14 +5011,14 @@ pub struct UESidelinkAggregateMaximumBitrate {
     pub ie_extensions: Option<UESidelinkAggregateMaximumBitrateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UEUserPlaneCIoTSupportIndicator(pub u8);
 impl UEUserPlaneCIoTSupportIndicator {
     pub const SUPPORTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UL_CP_SecurityInformation {
     pub ul_nas_mac: UL_NAS_MAC,
@@ -5028,26 +5027,26 @@ pub struct UL_CP_SecurityInformation {
     pub ie_extensions: Option<UL_CP_SecurityInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "5", sz_ub = "5")]
 pub struct UL_NAS_Count(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct UL_NAS_MAC(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "VisibleString")]
 pub struct URI_Address(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UnlicensedSpectrumRestriction(pub u8);
 impl UnlicensedSpectrumRestriction {
     pub const UNLICENSED_RESTRICTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UnsuccessfulOutcome {
     #[asn(key_field = true)]
@@ -5056,31 +5055,31 @@ pub struct UnsuccessfulOutcome {
     pub value: UnsuccessfulOutcomeValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkNASTransport {
     pub protocol_i_es: UplinkNASTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkNonUEAssociatedLPPaTransport {
     pub protocol_i_es: UplinkNonUEAssociatedLPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkS1cdma2000tunnelling {
     pub protocol_i_es: UplinkS1cdma2000tunnellingProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkUEAssociatedLPPaTransport {
     pub protocol_i_es: UplinkUEAssociatedLPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UserLocationInformation {
     pub eutran_cgi: EUTRAN_CGI,
@@ -5089,7 +5088,7 @@ pub struct UserLocationInformation {
     pub ie_extensions: Option<UserLocationInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct V2XServicesAuthorized {
     #[asn(optional_idx = 0)]
@@ -5100,7 +5099,7 @@ pub struct V2XServicesAuthorized {
     pub ie_extensions: Option<V2XServicesAuthorizedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct VehicleUE(pub u8);
 impl VehicleUE {
@@ -5108,7 +5107,7 @@ impl VehicleUE {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct VoiceSupportMatchIndicator(pub u8);
 impl VoiceSupportMatchIndicator {
@@ -5116,18 +5115,18 @@ impl VoiceSupportMatchIndicator {
     pub const NOT_SUPPORTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct WLANMeasConfig(pub u8);
 impl WLANMeasConfig {
     pub const SETUP: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "4")]
 pub struct WLANMeasConfigNameList(pub Vec<WLANName>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct WLANMeasurementConfiguration {
     pub wlan_meas_config: WLANMeasConfig,
@@ -5141,7 +5140,7 @@ pub struct WLANMeasurementConfiguration {
     pub ie_extensions: Option<WLANMeasurementConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -5150,7 +5149,7 @@ pub struct WLANMeasurementConfiguration {
 )]
 pub struct WLANName(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct WUS_Assistance_Information {
     pub paging_probability_information: PagingProbabilityInformation,
@@ -5158,7 +5157,7 @@ pub struct WUS_Assistance_Information {
     pub ie_extensions: Option<WUS_Assistance_InformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -5167,7 +5166,7 @@ pub struct WUS_Assistance_Information {
 )]
 pub struct WarningAreaCoordinates(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum WarningAreaList {
     #[asn(key = 0, extended = false)]
@@ -5178,7 +5177,7 @@ pub enum WarningAreaList {
     EmergencyAreaIDList(EmergencyAreaIDList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -5187,7 +5186,7 @@ pub enum WarningAreaList {
 )]
 pub struct WarningMessageContents(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -5196,23 +5195,23 @@ pub struct WarningMessageContents(pub Vec<u8>);
 )]
 pub struct WarningSecurityInfo(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct WarningType(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct WriteReplaceWarningRequest {
     pub protocol_i_es: WriteReplaceWarningRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct WriteReplaceWarningResponse {
     pub protocol_i_es: WriteReplaceWarningResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct X2TNLConfigurationInfo {
     pub enbx2_transport_layer_addresses: ENBX2TLAs,
@@ -5220,15 +5219,15 @@ pub struct X2TNLConfigurationInfo {
     pub ie_extensions: Option<X2TNLConfigurationInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_2(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Additional_GUTIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5237,11 +5236,11 @@ pub struct Additional_GUTIIE_Extensions_Entry {}
 )]
 pub struct Additional_GUTIIE_Extensions(pub Vec<Additional_GUTIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AllocationAndRetentionPriorityIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5252,15 +5251,15 @@ pub struct AllocationAndRetentionPriorityIE_Extensions(
     pub Vec<AllocationAndRetentionPriorityIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_3;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AssistanceDataForCECapableUEsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5271,11 +5270,11 @@ pub struct AssistanceDataForCECapableUEsIE_Extensions(
     pub Vec<AssistanceDataForCECapableUEsIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AssistanceDataForPagingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5286,11 +5285,11 @@ pub struct AssistanceDataForPagingIE_Extensions(
     pub Vec<AssistanceDataForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AssistanceDataForRecommendedCellsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5301,11 +5300,11 @@ pub struct AssistanceDataForRecommendedCellsIE_Extensions(
     pub Vec<AssistanceDataForRecommendedCellsIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Bearers_SubjectToEarlyStatusTransfer_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5316,14 +5315,14 @@ pub struct Bearers_SubjectToEarlyStatusTransfer_ItemIE_Extensions(
     pub Vec<Bearers_SubjectToEarlyStatusTransfer_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Bearers_SubjectToEarlyStatusTransferList_EntryValue {
     #[asn(key = 322)]
     Id_Bearers_SubjectToEarlyStatusTransfer_Item(Bearers_SubjectToEarlyStatusTransfer_Item),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Bearers_SubjectToEarlyStatusTransferList_Entry {
     #[asn(key_field = true)]
@@ -5332,7 +5331,7 @@ pub struct Bearers_SubjectToEarlyStatusTransferList_Entry {
     pub value: Bearers_SubjectToEarlyStatusTransferList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Bearers_SubjectToStatusTransfer_ItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 180)]
@@ -5349,7 +5348,7 @@ pub enum Bearers_SubjectToStatusTransfer_ItemIE_Extensions_EntryExtensionValue {
     Id_ULCOUNTValuePDCP_SNlength18(COUNTvaluePDCP_SNlength18),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Bearers_SubjectToStatusTransfer_ItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -5358,7 +5357,7 @@ pub struct Bearers_SubjectToStatusTransfer_ItemIE_Extensions_Entry {
     pub extension_value: Bearers_SubjectToStatusTransfer_ItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5369,14 +5368,14 @@ pub struct Bearers_SubjectToStatusTransfer_ItemIE_Extensions(
     pub Vec<Bearers_SubjectToStatusTransfer_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Bearers_SubjectToStatusTransferList_EntryValue {
     #[asn(key = 89)]
     Id_Bearers_SubjectToStatusTransfer_Item(Bearers_SubjectToStatusTransfer_Item),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Bearers_SubjectToStatusTransferList_Entry {
     #[asn(key_field = true)]
@@ -5385,18 +5384,18 @@ pub struct Bearers_SubjectToStatusTransferList_Entry {
     pub value: Bearers_SubjectToStatusTransferList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_4(pub u8);
 impl ENUMERATED_4 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct BluetoothMeasurementConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5407,11 +5406,11 @@ pub struct BluetoothMeasurementConfigurationIE_Extensions(
     pub Vec<BluetoothMeasurementConfigurationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CGIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5420,11 +5419,11 @@ pub struct CGIIE_Extensions_Entry {}
 )]
 pub struct CGIIE_Extensions(pub Vec<CGIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CNTypeRestrictions_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5435,11 +5434,11 @@ pub struct CNTypeRestrictions_ItemIE_Extensions(
     pub Vec<CNTypeRestrictions_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct COUNTValueExtendedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5448,11 +5447,11 @@ pub struct COUNTValueExtendedIE_Extensions_Entry {}
 )]
 pub struct COUNTValueExtendedIE_Extensions(pub Vec<COUNTValueExtendedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct COUNTvalueIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5461,11 +5460,11 @@ pub struct COUNTvalueIE_Extensions_Entry {}
 )]
 pub struct COUNTvalueIE_Extensions(pub Vec<COUNTvalueIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct COUNTvaluePDCP_SNlength18IE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5476,11 +5475,11 @@ pub struct COUNTvaluePDCP_SNlength18IE_Extensions(
     pub Vec<COUNTvaluePDCP_SNlength18IE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CSG_IdList_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5489,11 +5488,11 @@ pub struct CSG_IdList_ItemIE_Extensions_Entry {}
 )]
 pub struct CSG_IdList_ItemIE_Extensions(pub Vec<CSG_IdList_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CSGMembershipInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5502,11 +5501,11 @@ pub struct CSGMembershipInfoIE_Extensions_Entry {}
 )]
 pub struct CSGMembershipInfoIE_Extensions(pub Vec<CSGMembershipInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CancelledCellinEAI_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5517,11 +5516,11 @@ pub struct CancelledCellinEAI_ItemIE_Extensions(
     pub Vec<CancelledCellinEAI_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CancelledCellinTAI_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5532,19 +5531,19 @@ pub struct CancelledCellinTAI_ItemIE_Extensions(
     pub Vec<CancelledCellinTAI_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "503")]
 pub struct INTEGER_5(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_6(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Cdma2000OneXSRVCCInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5553,15 +5552,15 @@ pub struct Cdma2000OneXSRVCCInfoIE_Extensions_Entry {}
 )]
 pub struct Cdma2000OneXSRVCCInfoIE_Extensions(pub Vec<Cdma2000OneXSRVCCInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "60")]
 pub struct INTEGER_7(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellBasedMDTIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5570,11 +5569,11 @@ pub struct CellBasedMDTIE_Extensions_Entry {}
 )]
 pub struct CellBasedMDTIE_Extensions(pub Vec<CellBasedMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellBasedQMCIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5583,11 +5582,11 @@ pub struct CellBasedQMCIE_Extensions_Entry {}
 )]
 pub struct CellBasedQMCIE_Extensions(pub Vec<CellBasedQMCIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellID_Broadcast_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5596,11 +5595,11 @@ pub struct CellID_Broadcast_ItemIE_Extensions_Entry {}
 )]
 pub struct CellID_Broadcast_ItemIE_Extensions(pub Vec<CellID_Broadcast_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellID_Cancelled_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5609,11 +5608,11 @@ pub struct CellID_Cancelled_ItemIE_Extensions_Entry {}
 )]
 pub struct CellID_Cancelled_ItemIE_Extensions(pub Vec<CellID_Cancelled_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellIdentifierAndCELevelForCECapableUEsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5624,15 +5623,15 @@ pub struct CellIdentifierAndCELevelForCECapableUEsIE_Extensions(
     pub Vec<CellIdentifierAndCELevelForCECapableUEsIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_8(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_9(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CellTrafficTraceProtocolIEs_EntryValue {
     #[asn(key = 86)]
@@ -5649,7 +5648,7 @@ pub enum CellTrafficTraceProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellTrafficTraceProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5658,7 +5657,7 @@ pub struct CellTrafficTraceProtocolIEs_Entry {
     pub value: CellTrafficTraceProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5667,11 +5666,11 @@ pub struct CellTrafficTraceProtocolIEs_Entry {
 )]
 pub struct CellTrafficTraceProtocolIEs(pub Vec<CellTrafficTraceProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellTypeIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5680,15 +5679,15 @@ pub struct CellTypeIE_Extensions_Entry {}
 )]
 pub struct CellTypeIE_Extensions(pub Vec<CellTypeIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_10(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CompletedCellinEAI_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5699,11 +5698,11 @@ pub struct CompletedCellinEAI_ItemIE_Extensions(
     pub Vec<CompletedCellinEAI_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CompletedCellinTAI_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5714,11 +5713,11 @@ pub struct CompletedCellinTAI_ItemIE_Extensions(
     pub Vec<CompletedCellinTAI_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ConnectedengNBItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5727,7 +5726,7 @@ pub struct ConnectedengNBItemIE_Extensions_Entry {}
 )]
 pub struct ConnectedengNBItemIE_Extensions(pub Vec<ConnectedengNBItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ConnectionEstablishmentIndicationProtocolIEs_EntryValue {
     #[asn(key = 271)]
@@ -5752,7 +5751,7 @@ pub enum ConnectionEstablishmentIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ConnectionEstablishmentIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5761,7 +5760,7 @@ pub struct ConnectionEstablishmentIndicationProtocolIEs_Entry {
     pub value: ConnectionEstablishmentIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5772,11 +5771,11 @@ pub struct ConnectionEstablishmentIndicationProtocolIEs(
     pub Vec<ConnectionEstablishmentIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ContextatSourceIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5785,11 +5784,11 @@ pub struct ContextatSourceIE_Extensions_Entry {}
 )]
 pub struct ContextatSourceIE_Extensions(pub Vec<ContextatSourceIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CriticalityDiagnosticsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5798,11 +5797,11 @@ pub struct CriticalityDiagnosticsIE_Extensions_Entry {}
 )]
 pub struct CriticalityDiagnosticsIE_Extensions(pub Vec<CriticalityDiagnosticsIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CriticalityDiagnostics_IE_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5813,18 +5812,18 @@ pub struct CriticalityDiagnostics_IE_ItemIE_Extensions(
     pub Vec<CriticalityDiagnostics_IE_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_11(pub u8);
 impl ENUMERATED_11 {
     pub const D_APS_HO_REQUIRED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DAPSRequestInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5833,7 +5832,7 @@ pub struct DAPSRequestInfoIE_Extensions_Entry {}
 )]
 pub struct DAPSRequestInfoIE_Extensions(pub Vec<DAPSRequestInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_12(pub u8);
 impl ENUMERATED_12 {
@@ -5841,11 +5840,11 @@ impl ENUMERATED_12 {
     pub const D_APS_HO_NOT_ACCEPTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DAPSResponseInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5854,11 +5853,11 @@ pub struct DAPSResponseInfoIE_Extensions_Entry {}
 )]
 pub struct DAPSResponseInfoIE_Extensions(pub Vec<DAPSResponseInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DAPSResponseInfoItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5867,14 +5866,14 @@ pub struct DAPSResponseInfoItemIE_Extensions_Entry {}
 )]
 pub struct DAPSResponseInfoItemIE_Extensions(pub Vec<DAPSResponseInfoItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DAPSResponseInfoList_EntryValue {
     #[asn(key = 319)]
     Id_DAPSResponseInfoItem(DAPSResponseInfoItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DAPSResponseInfoList_Entry {
     #[asn(key_field = true)]
@@ -5883,11 +5882,11 @@ pub struct DAPSResponseInfoList_Entry {
     pub value: DAPSResponseInfoList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DL_CP_SecurityInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5898,7 +5897,7 @@ pub struct DL_CP_SecurityInformationIE_Extensions(
     pub Vec<DL_CP_SecurityInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DeactivateTraceProtocolIEs_EntryValue {
     #[asn(key = 86)]
@@ -5909,7 +5908,7 @@ pub enum DeactivateTraceProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DeactivateTraceProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5918,7 +5917,7 @@ pub struct DeactivateTraceProtocolIEs_Entry {
     pub value: DeactivateTraceProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5927,7 +5926,7 @@ pub struct DeactivateTraceProtocolIEs_Entry {
 )]
 pub struct DeactivateTraceProtocolIEs(pub Vec<DeactivateTraceProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkNASTransportProtocolIEs_EntryValue {
     #[asn(key = 299)]
@@ -5966,7 +5965,7 @@ pub enum DownlinkNASTransportProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkNASTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -5975,7 +5974,7 @@ pub struct DownlinkNASTransportProtocolIEs_Entry {
     pub value: DownlinkNASTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5984,7 +5983,7 @@ pub struct DownlinkNASTransportProtocolIEs_Entry {
 )]
 pub struct DownlinkNASTransportProtocolIEs(pub Vec<DownlinkNASTransportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkNonUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 147)]
@@ -5993,7 +5992,7 @@ pub enum DownlinkNonUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     Id_Routing_ID(Routing_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkNonUEAssociatedLPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6002,7 +6001,7 @@ pub struct DownlinkNonUEAssociatedLPPaTransportProtocolIEs_Entry {
     pub value: DownlinkNonUEAssociatedLPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6013,7 +6012,7 @@ pub struct DownlinkNonUEAssociatedLPPaTransportProtocolIEs(
     pub Vec<DownlinkNonUEAssociatedLPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkS1cdma2000tunnellingProtocolIEs_EntryValue {
     #[asn(key = 12)]
@@ -6030,7 +6029,7 @@ pub enum DownlinkS1cdma2000tunnellingProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkS1cdma2000tunnellingProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6039,7 +6038,7 @@ pub struct DownlinkS1cdma2000tunnellingProtocolIEs_Entry {
     pub value: DownlinkS1cdma2000tunnellingProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6050,7 +6049,7 @@ pub struct DownlinkS1cdma2000tunnellingProtocolIEs(
     pub Vec<DownlinkS1cdma2000tunnellingProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 147)]
@@ -6063,7 +6062,7 @@ pub enum DownlinkUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkUEAssociatedLPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6072,7 +6071,7 @@ pub struct DownlinkUEAssociatedLPPaTransportProtocolIEs_Entry {
     pub value: DownlinkUEAssociatedLPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6083,11 +6082,11 @@ pub struct DownlinkUEAssociatedLPPaTransportProtocolIEs(
     pub Vec<DownlinkUEAssociatedLPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABAdmittedItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6096,14 +6095,14 @@ pub struct E_RABAdmittedItemIE_Extensions_Entry {}
 )]
 pub struct E_RABAdmittedItemIE_Extensions(pub Vec<E_RABAdmittedItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABAdmittedList_EntryValue {
     #[asn(key = 20)]
     Id_E_RABAdmittedItem(E_RABAdmittedItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABAdmittedList_Entry {
     #[asn(key_field = true)]
@@ -6112,11 +6111,11 @@ pub struct E_RABAdmittedList_Entry {
     pub value: E_RABAdmittedList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABDataForwardingItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6127,11 +6126,11 @@ pub struct E_RABDataForwardingItemIE_Extensions(
     pub Vec<E_RABDataForwardingItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABFailedToResumeItemResumeReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6142,11 +6141,11 @@ pub struct E_RABFailedToResumeItemResumeReqIE_Extensions(
     pub Vec<E_RABFailedToResumeItemResumeReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABFailedToResumeItemResumeResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6157,14 +6156,14 @@ pub struct E_RABFailedToResumeItemResumeResIE_Extensions(
     pub Vec<E_RABFailedToResumeItemResumeResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABFailedToResumeListResumeReq_EntryValue {
     #[asn(key = 236)]
     Id_E_RABFailedToResumeItemResumeReq(E_RABFailedToResumeItemResumeReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABFailedToResumeListResumeReq_Entry {
     #[asn(key_field = true)]
@@ -6173,14 +6172,14 @@ pub struct E_RABFailedToResumeListResumeReq_Entry {
     pub value: E_RABFailedToResumeListResumeReq_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABFailedToResumeListResumeRes_EntryValue {
     #[asn(key = 238)]
     Id_E_RABFailedToResumeItemResumeRes(E_RABFailedToResumeItemResumeRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABFailedToResumeListResumeRes_Entry {
     #[asn(key_field = true)]
@@ -6189,11 +6188,11 @@ pub struct E_RABFailedToResumeListResumeRes_Entry {
     pub value: E_RABFailedToResumeListResumeRes_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABFailedToSetupItemHOReqAckIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6204,14 +6203,14 @@ pub struct E_RABFailedToSetupItemHOReqAckIE_Extensions(
     pub Vec<E_RABFailedToSetupItemHOReqAckIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABFailedtoSetupListHOReqAck_EntryValue {
     #[asn(key = 21)]
     Id_E_RABFailedtoSetupItemHOReqAck(E_RABFailedToSetupItemHOReqAck),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABFailedtoSetupListHOReqAck_Entry {
     #[asn(key_field = true)]
@@ -6220,14 +6219,14 @@ pub struct E_RABFailedtoSetupListHOReqAck_Entry {
     pub value: E_RABFailedtoSetupListHOReqAck_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABInformationList_EntryValue {
     #[asn(key = 78)]
     Id_E_RABInformationListItem(E_RABInformationListItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABInformationList_Entry {
     #[asn(key_field = true)]
@@ -6236,14 +6235,14 @@ pub struct E_RABInformationList_Entry {
     pub value: E_RABInformationList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABInformationListItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 317)]
     Id_DAPSRequestInfo(DAPSRequestInfo),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABInformationListItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6252,7 +6251,7 @@ pub struct E_RABInformationListItemIE_Extensions_Entry {
     pub extension_value: E_RABInformationListItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6263,11 +6262,11 @@ pub struct E_RABInformationListItemIE_Extensions(
     pub Vec<E_RABInformationListItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6276,7 +6275,7 @@ pub struct E_RABItemIE_Extensions_Entry {}
 )]
 pub struct E_RABItemIE_Extensions(pub Vec<E_RABItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABLevelQoSParametersIE_Extensions_EntryExtensionValue {
     #[asn(key = 273)]
@@ -6285,7 +6284,7 @@ pub enum E_RABLevelQoSParametersIE_Extensions_EntryExtensionValue {
     Id_UplinkPacketLossRate(Packet_LossRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABLevelQoSParametersIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6294,7 +6293,7 @@ pub struct E_RABLevelQoSParametersIE_Extensions_Entry {
     pub extension_value: E_RABLevelQoSParametersIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6305,14 +6304,14 @@ pub struct E_RABLevelQoSParametersIE_Extensions(
     pub Vec<E_RABLevelQoSParametersIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABList_EntryValue {
     #[asn(key = 35)]
     Id_E_RABItem(E_RABItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABList_Entry {
     #[asn(key_field = true)]
@@ -6321,7 +6320,7 @@ pub struct E_RABList_Entry {
     pub value: E_RABList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABModificationConfirmProtocolIEs_EntryValue {
     #[asn(key = 146)]
@@ -6340,7 +6339,7 @@ pub enum E_RABModificationConfirmProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModificationConfirmProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6349,7 +6348,7 @@ pub struct E_RABModificationConfirmProtocolIEs_Entry {
     pub value: E_RABModificationConfirmProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6358,7 +6357,7 @@ pub struct E_RABModificationConfirmProtocolIEs_Entry {
 )]
 pub struct E_RABModificationConfirmProtocolIEs(pub Vec<E_RABModificationConfirmProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABModificationIndicationProtocolIEs_EntryValue {
     #[asn(key = 226)]
@@ -6379,7 +6378,7 @@ pub enum E_RABModificationIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModificationIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6388,7 +6387,7 @@ pub struct E_RABModificationIndicationProtocolIEs_Entry {
     pub value: E_RABModificationIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6399,11 +6398,11 @@ pub struct E_RABModificationIndicationProtocolIEs(
     pub Vec<E_RABModificationIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModifyItemBearerModConfIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6414,11 +6413,11 @@ pub struct E_RABModifyItemBearerModConfIE_Extensions(
     pub Vec<E_RABModifyItemBearerModConfIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModifyItemBearerModResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6429,14 +6428,14 @@ pub struct E_RABModifyItemBearerModResIE_Extensions(
     pub Vec<E_RABModifyItemBearerModResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABModifyListBearerModConf_EntryValue {
     #[asn(key = 204)]
     Id_E_RABModifyItemBearerModConf(E_RABModifyItemBearerModConf),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModifyListBearerModConf_Entry {
     #[asn(key_field = true)]
@@ -6445,14 +6444,14 @@ pub struct E_RABModifyListBearerModConf_Entry {
     pub value: E_RABModifyListBearerModConf_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABModifyListBearerModRes_EntryValue {
     #[asn(key = 37)]
     Id_E_RABModifyItemBearerModRes(E_RABModifyItemBearerModRes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModifyListBearerModRes_Entry {
     #[asn(key_field = true)]
@@ -6461,7 +6460,7 @@ pub struct E_RABModifyListBearerModRes_Entry {
     pub value: E_RABModifyListBearerModRes_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABModifyRequestProtocolIEs_EntryValue {
     #[asn(key = 30)]
@@ -6476,7 +6475,7 @@ pub enum E_RABModifyRequestProtocolIEs_EntryValue {
     Id_uEaggregateMaximumBitrate(UEAggregateMaximumBitrate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModifyRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6485,7 +6484,7 @@ pub struct E_RABModifyRequestProtocolIEs_Entry {
     pub value: E_RABModifyRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6494,7 +6493,7 @@ pub struct E_RABModifyRequestProtocolIEs_Entry {
 )]
 pub struct E_RABModifyRequestProtocolIEs(pub Vec<E_RABModifyRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABModifyResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -6511,7 +6510,7 @@ pub enum E_RABModifyResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABModifyResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6520,7 +6519,7 @@ pub struct E_RABModifyResponseProtocolIEs_Entry {
     pub value: E_RABModifyResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6529,11 +6528,11 @@ pub struct E_RABModifyResponseProtocolIEs_Entry {
 )]
 pub struct E_RABModifyResponseProtocolIEs(pub Vec<E_RABModifyResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABNotToBeModifiedItemBearerModIndIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6544,14 +6543,14 @@ pub struct E_RABNotToBeModifiedItemBearerModIndIE_Extensions(
     pub Vec<E_RABNotToBeModifiedItemBearerModIndIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABNotToBeModifiedListBearerModInd_EntryValue {
     #[asn(key = 202)]
     Id_E_RABNotToBeModifiedItemBearerModInd(E_RABNotToBeModifiedItemBearerModInd),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABNotToBeModifiedListBearerModInd_Entry {
     #[asn(key_field = true)]
@@ -6560,7 +6559,7 @@ pub struct E_RABNotToBeModifiedListBearerModInd_Entry {
     pub value: E_RABNotToBeModifiedListBearerModInd_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABReleaseCommandProtocolIEs_EntryValue {
     #[asn(key = 33)]
@@ -6575,7 +6574,7 @@ pub enum E_RABReleaseCommandProtocolIEs_EntryValue {
     Id_uEaggregateMaximumBitrate(UEAggregateMaximumBitrate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABReleaseCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6584,7 +6583,7 @@ pub struct E_RABReleaseCommandProtocolIEs_Entry {
     pub value: E_RABReleaseCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6593,7 +6592,7 @@ pub struct E_RABReleaseCommandProtocolIEs_Entry {
 )]
 pub struct E_RABReleaseCommandProtocolIEs(pub Vec<E_RABReleaseCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABReleaseIndicationProtocolIEs_EntryValue {
     #[asn(key = 110)]
@@ -6608,7 +6607,7 @@ pub enum E_RABReleaseIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABReleaseIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6617,7 +6616,7 @@ pub struct E_RABReleaseIndicationProtocolIEs_Entry {
     pub value: E_RABReleaseIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6626,11 +6625,11 @@ pub struct E_RABReleaseIndicationProtocolIEs_Entry {
 )]
 pub struct E_RABReleaseIndicationProtocolIEs(pub Vec<E_RABReleaseIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABReleaseItemBearerRelCompIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6641,14 +6640,14 @@ pub struct E_RABReleaseItemBearerRelCompIE_Extensions(
     pub Vec<E_RABReleaseItemBearerRelCompIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABReleaseListBearerRelComp_EntryValue {
     #[asn(key = 15)]
     Id_E_RABReleaseItemBearerRelComp(E_RABReleaseItemBearerRelComp),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABReleaseListBearerRelComp_Entry {
     #[asn(key_field = true)]
@@ -6657,7 +6656,7 @@ pub struct E_RABReleaseListBearerRelComp_Entry {
     pub value: E_RABReleaseListBearerRelComp_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABReleaseResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -6676,7 +6675,7 @@ pub enum E_RABReleaseResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABReleaseResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6685,7 +6684,7 @@ pub struct E_RABReleaseResponseProtocolIEs_Entry {
     pub value: E_RABReleaseResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6694,11 +6693,11 @@ pub struct E_RABReleaseResponseProtocolIEs_Entry {
 )]
 pub struct E_RABReleaseResponseProtocolIEs(pub Vec<E_RABReleaseResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABSetupItemBearerSUResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6709,11 +6708,11 @@ pub struct E_RABSetupItemBearerSUResIE_Extensions(
     pub Vec<E_RABSetupItemBearerSUResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABSetupItemCtxtSUResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6724,14 +6723,14 @@ pub struct E_RABSetupItemCtxtSUResIE_Extensions(
     pub Vec<E_RABSetupItemCtxtSUResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABSetupListBearerSURes_EntryValue {
     #[asn(key = 39)]
     Id_E_RABSetupItemBearerSURes(E_RABSetupItemBearerSURes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABSetupListBearerSURes_Entry {
     #[asn(key_field = true)]
@@ -6740,14 +6739,14 @@ pub struct E_RABSetupListBearerSURes_Entry {
     pub value: E_RABSetupListBearerSURes_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABSetupListCtxtSURes_EntryValue {
     #[asn(key = 50)]
     Id_E_RABSetupItemCtxtSURes(E_RABSetupItemCtxtSURes),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABSetupListCtxtSURes_Entry {
     #[asn(key_field = true)]
@@ -6756,7 +6755,7 @@ pub struct E_RABSetupListCtxtSURes_Entry {
     pub value: E_RABSetupListCtxtSURes_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABSetupRequestProtocolIEs_EntryValue {
     #[asn(key = 16)]
@@ -6769,7 +6768,7 @@ pub enum E_RABSetupRequestProtocolIEs_EntryValue {
     Id_uEaggregateMaximumBitrate(UEAggregateMaximumBitrate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABSetupRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6778,7 +6777,7 @@ pub struct E_RABSetupRequestProtocolIEs_Entry {
     pub value: E_RABSetupRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6787,7 +6786,7 @@ pub struct E_RABSetupRequestProtocolIEs_Entry {
 )]
 pub struct E_RABSetupRequestProtocolIEs(pub Vec<E_RABSetupRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABSetupResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -6802,7 +6801,7 @@ pub enum E_RABSetupResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABSetupResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6811,7 +6810,7 @@ pub struct E_RABSetupResponseProtocolIEs_Entry {
     pub value: E_RABSetupResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6820,14 +6819,14 @@ pub struct E_RABSetupResponseProtocolIEs_Entry {
 )]
 pub struct E_RABSetupResponseProtocolIEs(pub Vec<E_RABSetupResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABSubjecttoDataForwardingList_EntryValue {
     #[asn(key = 14)]
     Id_E_RABDataForwardingItem(E_RABDataForwardingItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABSubjecttoDataForwardingList_Entry {
     #[asn(key_field = true)]
@@ -6836,11 +6835,11 @@ pub struct E_RABSubjecttoDataForwardingList_Entry {
     pub value: E_RABSubjecttoDataForwardingList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeModifiedItemBearerModIndIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6851,14 +6850,14 @@ pub struct E_RABToBeModifiedItemBearerModIndIE_Extensions(
     pub Vec<E_RABToBeModifiedItemBearerModIndIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeModifiedItemBearerModReqIE_Extensions_EntryExtensionValue {
     #[asn(key = 185)]
     Id_TransportInformation(TransportInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeModifiedItemBearerModReqIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6867,7 +6866,7 @@ pub struct E_RABToBeModifiedItemBearerModReqIE_Extensions_Entry {
     pub extension_value: E_RABToBeModifiedItemBearerModReqIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6878,14 +6877,14 @@ pub struct E_RABToBeModifiedItemBearerModReqIE_Extensions(
     pub Vec<E_RABToBeModifiedItemBearerModReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeModifiedListBearerModInd_EntryValue {
     #[asn(key = 200)]
     Id_E_RABToBeModifiedItemBearerModInd(E_RABToBeModifiedItemBearerModInd),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeModifiedListBearerModInd_Entry {
     #[asn(key_field = true)]
@@ -6894,14 +6893,14 @@ pub struct E_RABToBeModifiedListBearerModInd_Entry {
     pub value: E_RABToBeModifiedListBearerModInd_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeModifiedListBearerModReq_EntryValue {
     #[asn(key = 36)]
     Id_E_RABToBeModifiedItemBearerModReq(E_RABToBeModifiedItemBearerModReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeModifiedListBearerModReq_Entry {
     #[asn(key_field = true)]
@@ -6910,7 +6909,7 @@ pub struct E_RABToBeModifiedListBearerModReq_Entry {
     pub value: E_RABToBeModifiedListBearerModReq_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSetupItemBearerSUReqIE_Extensions_EntryExtensionValue {
     #[asn(key = 233)]
@@ -6923,7 +6922,7 @@ pub enum E_RABToBeSetupItemBearerSUReqIE_Extensions_EntryExtensionValue {
     Id_SIPTO_Correlation_ID(Correlation_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSetupItemBearerSUReqIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6932,7 +6931,7 @@ pub struct E_RABToBeSetupItemBearerSUReqIE_Extensions_Entry {
     pub extension_value: E_RABToBeSetupItemBearerSUReqIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6943,7 +6942,7 @@ pub struct E_RABToBeSetupItemBearerSUReqIE_Extensions(
     pub Vec<E_RABToBeSetupItemBearerSUReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSetupItemCtxtSUReqIE_Extensions_EntryExtensionValue {
     #[asn(key = 233)]
@@ -6956,7 +6955,7 @@ pub enum E_RABToBeSetupItemCtxtSUReqIE_Extensions_EntryExtensionValue {
     Id_SIPTO_Correlation_ID(Correlation_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSetupItemCtxtSUReqIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6965,7 +6964,7 @@ pub struct E_RABToBeSetupItemCtxtSUReqIE_Extensions_Entry {
     pub extension_value: E_RABToBeSetupItemCtxtSUReqIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6976,7 +6975,7 @@ pub struct E_RABToBeSetupItemCtxtSUReqIE_Extensions(
     pub Vec<E_RABToBeSetupItemCtxtSUReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSetupItemHOReqIE_Extensions_EntryExtensionValue {
     #[asn(key = 233)]
@@ -6987,7 +6986,7 @@ pub enum E_RABToBeSetupItemHOReqIE_Extensions_EntryExtensionValue {
     Id_Ethernet_Type(Ethernet_Type),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSetupItemHOReqIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6996,7 +6995,7 @@ pub struct E_RABToBeSetupItemHOReqIE_Extensions_Entry {
     pub extension_value: E_RABToBeSetupItemHOReqIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7007,14 +7006,14 @@ pub struct E_RABToBeSetupItemHOReqIE_Extensions(
     pub Vec<E_RABToBeSetupItemHOReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSetupListBearerSUReq_EntryValue {
     #[asn(key = 17)]
     Id_E_RABToBeSetupItemBearerSUReq(E_RABToBeSetupItemBearerSUReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSetupListBearerSUReq_Entry {
     #[asn(key_field = true)]
@@ -7023,14 +7022,14 @@ pub struct E_RABToBeSetupListBearerSUReq_Entry {
     pub value: E_RABToBeSetupListBearerSUReq_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSetupListCtxtSUReq_EntryValue {
     #[asn(key = 52)]
     Id_E_RABToBeSetupItemCtxtSUReq(E_RABToBeSetupItemCtxtSUReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSetupListCtxtSUReq_Entry {
     #[asn(key_field = true)]
@@ -7039,14 +7038,14 @@ pub struct E_RABToBeSetupListCtxtSUReq_Entry {
     pub value: E_RABToBeSetupListCtxtSUReq_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSetupListHOReq_EntryValue {
     #[asn(key = 27)]
     Id_E_RABToBeSetupItemHOReq(E_RABToBeSetupItemHOReq),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSetupListHOReq_Entry {
     #[asn(key_field = true)]
@@ -7055,11 +7054,11 @@ pub struct E_RABToBeSetupListHOReq_Entry {
     pub value: E_RABToBeSetupListHOReq_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSwitchedDLItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7070,14 +7069,14 @@ pub struct E_RABToBeSwitchedDLItemIE_Extensions(
     pub Vec<E_RABToBeSwitchedDLItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSwitchedDLList_EntryValue {
     #[asn(key = 23)]
     Id_E_RABToBeSwitchedDLItem(E_RABToBeSwitchedDLItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSwitchedDLList_Entry {
     #[asn(key_field = true)]
@@ -7086,11 +7085,11 @@ pub struct E_RABToBeSwitchedDLList_Entry {
     pub value: E_RABToBeSwitchedDLList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSwitchedULItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7101,14 +7100,14 @@ pub struct E_RABToBeSwitchedULItemIE_Extensions(
     pub Vec<E_RABToBeSwitchedULItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABToBeSwitchedULList_EntryValue {
     #[asn(key = 94)]
     Id_E_RABToBeSwitchedULItem(E_RABToBeSwitchedULItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABToBeSwitchedULList_Entry {
     #[asn(key_field = true)]
@@ -7117,27 +7116,27 @@ pub struct E_RABToBeSwitchedULList_Entry {
     pub value: E_RABToBeSwitchedULList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct OCTET_STRING_13(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct OCTET_STRING_14(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "18446744073709551615")]
 pub struct INTEGER_15(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "18446744073709551615")]
 pub struct INTEGER_16(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABUsageReportItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7146,14 +7145,14 @@ pub struct E_RABUsageReportItemIE_Extensions_Entry {}
 )]
 pub struct E_RABUsageReportItemIE_Extensions(pub Vec<E_RABUsageReportItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum E_RABUsageReportList_EntryValue {
     #[asn(key = 267)]
     Id_E_RABUsageReportItem(E_RABUsageReportItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABUsageReportList_Entry {
     #[asn(key_field = true)]
@@ -7162,11 +7161,11 @@ pub struct E_RABUsageReportList_Entry {
     pub value: E_RABUsageReportList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EN_DCSONConfigurationTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7177,11 +7176,11 @@ pub struct EN_DCSONConfigurationTransferIE_Extensions(
     pub Vec<EN_DCSONConfigurationTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EN_DCSONeNBIdentificationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7192,11 +7191,11 @@ pub struct EN_DCSONeNBIdentificationIE_Extensions(
     pub Vec<EN_DCSONeNBIdentificationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EN_DCSONengNBIdentificationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7207,11 +7206,11 @@ pub struct EN_DCSONengNBIdentificationIE_Extensions(
     pub Vec<EN_DCSONengNBIdentificationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EN_DCTransferTypeReplyIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7220,11 +7219,11 @@ pub struct EN_DCTransferTypeReplyIE_Extensions_Entry {}
 )]
 pub struct EN_DCTransferTypeReplyIE_Extensions(pub Vec<EN_DCTransferTypeReplyIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EN_DCTransferTypeRequestIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7235,11 +7234,11 @@ pub struct EN_DCTransferTypeRequestIE_Extensions(
     pub Vec<EN_DCTransferTypeRequestIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENB_EarlyStatusTransfer_TransparentContainerIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7250,27 +7249,27 @@ pub struct ENB_EarlyStatusTransfer_TransparentContainerIE_Extensions(
     pub Vec<ENB_EarlyStatusTransfer_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "20", sz_ub = "20")]
 pub struct BIT_STRING_17(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "28", sz_ub = "28")]
 pub struct BIT_STRING_18(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "18", sz_ub = "18")]
 pub struct BIT_STRING_19(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "21", sz_ub = "21")]
 pub struct BIT_STRING_20(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENB_StatusTransfer_TransparentContainerIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7281,7 +7280,7 @@ pub struct ENB_StatusTransfer_TransparentContainerIE_Extensions(
     pub Vec<ENB_StatusTransfer_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBCPRelocationIndicationProtocolIEs_EntryValue {
     #[asn(key = 100)]
@@ -7296,7 +7295,7 @@ pub enum ENBCPRelocationIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBCPRelocationIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7305,7 +7304,7 @@ pub struct ENBCPRelocationIndicationProtocolIEs_Entry {
     pub value: ENBCPRelocationIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7316,7 +7315,7 @@ pub struct ENBCPRelocationIndicationProtocolIEs(
     pub Vec<ENBCPRelocationIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBConfigurationTransferProtocolIEs_EntryValue {
     #[asn(key = 294)]
@@ -7327,7 +7326,7 @@ pub enum ENBConfigurationTransferProtocolIEs_EntryValue {
     Id_SONConfigurationTransferECT(SONConfigurationTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBConfigurationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7336,7 +7335,7 @@ pub struct ENBConfigurationTransferProtocolIEs_Entry {
     pub value: ENBConfigurationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7345,7 +7344,7 @@ pub struct ENBConfigurationTransferProtocolIEs_Entry {
 )]
 pub struct ENBConfigurationTransferProtocolIEs(pub Vec<ENBConfigurationTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBConfigurationUpdateProtocolIEs_EntryValue {
     #[asn(key = 128)]
@@ -7364,7 +7363,7 @@ pub enum ENBConfigurationUpdateProtocolIEs_EntryValue {
     Id_eNBname(ENBname),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBConfigurationUpdateProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7373,7 +7372,7 @@ pub struct ENBConfigurationUpdateProtocolIEs_Entry {
     pub value: ENBConfigurationUpdateProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7382,14 +7381,14 @@ pub struct ENBConfigurationUpdateProtocolIEs_Entry {
 )]
 pub struct ENBConfigurationUpdateProtocolIEs(pub Vec<ENBConfigurationUpdateProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBConfigurationUpdateAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 58)]
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7398,7 +7397,7 @@ pub struct ENBConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     pub value: ENBConfigurationUpdateAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7409,7 +7408,7 @@ pub struct ENBConfigurationUpdateAcknowledgeProtocolIEs(
     pub Vec<ENBConfigurationUpdateAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBConfigurationUpdateFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -7420,7 +7419,7 @@ pub enum ENBConfigurationUpdateFailureProtocolIEs_EntryValue {
     Id_TimeToWait(TimeToWait),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBConfigurationUpdateFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7429,7 +7428,7 @@ pub struct ENBConfigurationUpdateFailureProtocolIEs_Entry {
     pub value: ENBConfigurationUpdateFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7440,14 +7439,14 @@ pub struct ENBConfigurationUpdateFailureProtocolIEs(
     pub Vec<ENBConfigurationUpdateFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBDirectInformationTransferProtocolIEs_EntryValue {
     #[asn(key = 121)]
     Id_Inter_SystemInformationTransferTypeEDT(Inter_SystemInformationTransferType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBDirectInformationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7456,7 +7455,7 @@ pub struct ENBDirectInformationTransferProtocolIEs_Entry {
     pub value: ENBDirectInformationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7467,7 +7466,7 @@ pub struct ENBDirectInformationTransferProtocolIEs(
     pub Vec<ENBDirectInformationTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBEarlyStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -7478,7 +7477,7 @@ pub enum ENBEarlyStatusTransferProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBEarlyStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7487,7 +7486,7 @@ pub struct ENBEarlyStatusTransferProtocolIEs_Entry {
     pub value: ENBEarlyStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7496,7 +7495,7 @@ pub struct ENBEarlyStatusTransferProtocolIEs_Entry {
 )]
 pub struct ENBEarlyStatusTransferProtocolIEs(pub Vec<ENBEarlyStatusTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ENBStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -7507,7 +7506,7 @@ pub enum ENBStatusTransferProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7516,7 +7515,7 @@ pub struct ENBStatusTransferProtocolIEs_Entry {
     pub value: ENBStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7525,11 +7524,11 @@ pub struct ENBStatusTransferProtocolIEs_Entry {
 )]
 pub struct ENBStatusTransferProtocolIEs(pub Vec<ENBStatusTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENBX2ExtTLAIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7538,11 +7537,11 @@ pub struct ENBX2ExtTLAIE_Extensions_Entry {}
 )]
 pub struct ENBX2ExtTLAIE_Extensions(pub Vec<ENBX2ExtTLAIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EUTRAN_CGIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7551,15 +7550,15 @@ pub struct EUTRAN_CGIIE_Extensions_Entry {}
 )]
 pub struct EUTRAN_CGIIE_Extensions(pub Vec<EUTRAN_CGIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_21(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EmergencyAreaID_Broadcast_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7570,11 +7569,11 @@ pub struct EmergencyAreaID_Broadcast_ItemIE_Extensions(
     pub Vec<EmergencyAreaID_Broadcast_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EmergencyAreaID_Cancelled_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7585,7 +7584,7 @@ pub struct EmergencyAreaID_Cancelled_ItemIE_Extensions(
     pub Vec<EmergencyAreaID_Cancelled_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ErrorIndicationProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -7600,7 +7599,7 @@ pub enum ErrorIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ErrorIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7609,7 +7608,7 @@ pub struct ErrorIndicationProtocolIEs_Entry {
     pub value: ErrorIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7618,11 +7617,11 @@ pub struct ErrorIndicationProtocolIEs_Entry {
 )]
 pub struct ErrorIndicationProtocolIEs(pub Vec<ErrorIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ExpectedUEActivityBehaviourIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7633,11 +7632,11 @@ pub struct ExpectedUEActivityBehaviourIE_Extensions(
     pub Vec<ExpectedUEActivityBehaviourIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ExpectedUEBehaviourIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7646,11 +7645,11 @@ pub struct ExpectedUEBehaviourIE_Extensions_Entry {}
 )]
 pub struct ExpectedUEBehaviourIE_Extensions(pub Vec<ExpectedUEBehaviourIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct FiveGSTAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7659,11 +7658,11 @@ pub struct FiveGSTAIIE_Extensions_Entry {}
 )]
 pub struct FiveGSTAIIE_Extensions(pub Vec<FiveGSTAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ForbiddenLAs_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7672,11 +7671,11 @@ pub struct ForbiddenLAs_ItemIE_Extensions_Entry {}
 )]
 pub struct ForbiddenLAs_ItemIE_Extensions(pub Vec<ForbiddenLAs_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ForbiddenTAs_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7685,7 +7684,7 @@ pub struct ForbiddenTAs_ItemIE_Extensions_Entry {}
 )]
 pub struct ForbiddenTAs_ItemIE_Extensions(pub Vec<ForbiddenTAs_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum GBR_QosInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 257)]
@@ -7698,7 +7697,7 @@ pub enum GBR_QosInformationIE_Extensions_EntryExtensionValue {
     Id_extended_e_RAB_MaximumBitrateUL(ExtendedBitRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GBR_QosInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -7707,7 +7706,7 @@ pub struct GBR_QosInformationIE_Extensions_Entry {
     pub extension_value: GBR_QosInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7716,11 +7715,11 @@ pub struct GBR_QosInformationIE_Extensions_Entry {
 )]
 pub struct GBR_QosInformationIE_Extensions(pub Vec<GBR_QosInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GERAN_Cell_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7729,11 +7728,11 @@ pub struct GERAN_Cell_IDIE_Extensions_Entry {}
 )]
 pub struct GERAN_Cell_IDIE_Extensions(pub Vec<GERAN_Cell_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GNBIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7742,11 +7741,11 @@ pub struct GNBIE_Extensions_Entry {}
 )]
 pub struct GNBIE_Extensions(pub Vec<GNBIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GUMMEIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7755,11 +7754,11 @@ pub struct GUMMEIIE_Extensions_Entry {}
 )]
 pub struct GUMMEIIE_Extensions(pub Vec<GUMMEIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Global_ENB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7768,11 +7767,11 @@ pub struct Global_ENB_IDIE_Extensions_Entry {}
 )]
 pub struct Global_ENB_IDIE_Extensions(pub Vec<Global_ENB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Global_GNB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7781,11 +7780,11 @@ pub struct Global_GNB_IDIE_Extensions_Entry {}
 )]
 pub struct Global_GNB_IDIE_Extensions(pub Vec<Global_GNB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Global_en_gNB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7794,7 +7793,7 @@ pub struct Global_en_gNB_IDIE_Extensions_Entry {}
 )]
 pub struct Global_en_gNB_IDIE_Extensions(pub Vec<Global_en_gNB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverCancelProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -7805,7 +7804,7 @@ pub enum HandoverCancelProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverCancelProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7814,7 +7813,7 @@ pub struct HandoverCancelProtocolIEs_Entry {
     pub value: HandoverCancelProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7823,7 +7822,7 @@ pub struct HandoverCancelProtocolIEs_Entry {
 )]
 pub struct HandoverCancelProtocolIEs(pub Vec<HandoverCancelProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverCancelAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -7834,7 +7833,7 @@ pub enum HandoverCancelAcknowledgeProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverCancelAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7843,7 +7842,7 @@ pub struct HandoverCancelAcknowledgeProtocolIEs_Entry {
     pub value: HandoverCancelAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7854,7 +7853,7 @@ pub struct HandoverCancelAcknowledgeProtocolIEs(
     pub Vec<HandoverCancelAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverCommandProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -7877,7 +7876,7 @@ pub enum HandoverCommandProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7886,7 +7885,7 @@ pub struct HandoverCommandProtocolIEs_Entry {
     pub value: HandoverCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7895,7 +7894,7 @@ pub struct HandoverCommandProtocolIEs_Entry {
 )]
 pub struct HandoverCommandProtocolIEs(pub Vec<HandoverCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -7906,7 +7905,7 @@ pub enum HandoverFailureProtocolIEs_EntryValue {
     Id_MME_UE_S1AP_ID(MME_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7915,7 +7914,7 @@ pub struct HandoverFailureProtocolIEs_Entry {
     pub value: HandoverFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7924,7 +7923,7 @@ pub struct HandoverFailureProtocolIEs_Entry {
 )]
 pub struct HandoverFailureProtocolIEs(pub Vec<HandoverFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverNotifyProtocolIEs_EntryValue {
     #[asn(key = 100)]
@@ -7945,7 +7944,7 @@ pub enum HandoverNotifyProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverNotifyProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7954,7 +7953,7 @@ pub struct HandoverNotifyProtocolIEs_Entry {
     pub value: HandoverNotifyProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7963,7 +7962,7 @@ pub struct HandoverNotifyProtocolIEs_Entry {
 )]
 pub struct HandoverNotifyProtocolIEs(pub Vec<HandoverNotifyProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverPreparationFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -7976,7 +7975,7 @@ pub enum HandoverPreparationFailureProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverPreparationFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7985,7 +7984,7 @@ pub struct HandoverPreparationFailureProtocolIEs_Entry {
     pub value: HandoverPreparationFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7996,7 +7995,7 @@ pub struct HandoverPreparationFailureProtocolIEs(
     pub Vec<HandoverPreparationFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRequestProtocolIEs_EntryValue {
     #[asn(key = 299)]
@@ -8075,7 +8074,7 @@ pub enum HandoverRequestProtocolIEs_EntryValue {
     Id_uEaggregateMaximumBitrate(UEAggregateMaximumBitrate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8084,7 +8083,7 @@ pub struct HandoverRequestProtocolIEs_Entry {
     pub value: HandoverRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8093,7 +8092,7 @@ pub struct HandoverRequestProtocolIEs_Entry {
 )]
 pub struct HandoverRequestProtocolIEs(pub Vec<HandoverRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRequestAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 242)]
@@ -8116,7 +8115,7 @@ pub enum HandoverRequestAcknowledgeProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequestAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8125,7 +8124,7 @@ pub struct HandoverRequestAcknowledgeProtocolIEs_Entry {
     pub value: HandoverRequestAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8136,7 +8135,7 @@ pub struct HandoverRequestAcknowledgeProtocolIEs(
     pub Vec<HandoverRequestAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRequiredProtocolIEs_EntryValue {
     #[asn(key = 127)]
@@ -8169,7 +8168,7 @@ pub enum HandoverRequiredProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequiredProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8178,7 +8177,7 @@ pub struct HandoverRequiredProtocolIEs_Entry {
     pub value: HandoverRequiredProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8187,7 +8186,7 @@ pub struct HandoverRequiredProtocolIEs_Entry {
 )]
 pub struct HandoverRequiredProtocolIEs(pub Vec<HandoverRequiredProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRestrictionListIE_Extensions_EntryExtensionValue {
     #[asn(key = 282)]
@@ -8202,7 +8201,7 @@ pub enum HandoverRestrictionListIE_Extensions_EntryExtensionValue {
     Id_UnlicensedSpectrumRestriction(UnlicensedSpectrumRestriction),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRestrictionListIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8211,7 +8210,7 @@ pub struct HandoverRestrictionListIE_Extensions_Entry {
     pub extension_value: HandoverRestrictionListIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8222,7 +8221,7 @@ pub struct HandoverRestrictionListIE_Extensions(
     pub Vec<HandoverRestrictionListIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverSuccessProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -8231,7 +8230,7 @@ pub enum HandoverSuccessProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverSuccessProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8240,7 +8239,7 @@ pub struct HandoverSuccessProtocolIEs_Entry {
     pub value: HandoverSuccessProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8249,19 +8248,19 @@ pub struct HandoverSuccessProtocolIEs_Entry {
 )]
 pub struct HandoverSuccessProtocolIEs(pub Vec<HandoverSuccessProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_22(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_23(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_24(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ImmediateMDTIE_Extensions_EntryExtensionValue {
     #[asn(key = 284)]
@@ -8282,7 +8281,7 @@ pub enum ImmediateMDTIE_Extensions_EntryExtensionValue {
     Id_WLANMeasurementConfiguration(WLANMeasurementConfiguration),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ImmediateMDTIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8291,7 +8290,7 @@ pub struct ImmediateMDTIE_Extensions_Entry {
     pub extension_value: ImmediateMDTIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8300,11 +8299,11 @@ pub struct ImmediateMDTIE_Extensions_Entry {
 )]
 pub struct ImmediateMDTIE_Extensions(pub Vec<ImmediateMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InformationOnRecommendedCellsAndENBsForPagingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8315,7 +8314,7 @@ pub struct InformationOnRecommendedCellsAndENBsForPagingIE_Extensions(
     pub Vec<InformationOnRecommendedCellsAndENBsForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialContextSetupFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -8328,7 +8327,7 @@ pub enum InitialContextSetupFailureProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialContextSetupFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8337,7 +8336,7 @@ pub struct InitialContextSetupFailureProtocolIEs_Entry {
     pub value: InitialContextSetupFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8348,7 +8347,7 @@ pub struct InitialContextSetupFailureProtocolIEs(
     pub Vec<InitialContextSetupFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialContextSetupRequestProtocolIEs_EntryValue {
     #[asn(key = 187)]
@@ -8427,7 +8426,7 @@ pub enum InitialContextSetupRequestProtocolIEs_EntryValue {
     Id_uEaggregateMaximumBitrate(UEAggregateMaximumBitrate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialContextSetupRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8436,7 +8435,7 @@ pub struct InitialContextSetupRequestProtocolIEs_Entry {
     pub value: InitialContextSetupRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8447,7 +8446,7 @@ pub struct InitialContextSetupRequestProtocolIEs(
     pub Vec<InitialContextSetupRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialContextSetupResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -8462,7 +8461,7 @@ pub enum InitialContextSetupResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialContextSetupResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8471,7 +8470,7 @@ pub struct InitialContextSetupResponseProtocolIEs_Entry {
     pub value: InitialContextSetupResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8482,7 +8481,7 @@ pub struct InitialContextSetupResponseProtocolIEs(
     pub Vec<InitialContextSetupResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialUEMessageProtocolIEs_EntryValue {
     #[asn(key = 242)]
@@ -8533,7 +8532,7 @@ pub enum InitialUEMessageProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialUEMessageProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8542,7 +8541,7 @@ pub struct InitialUEMessageProtocolIEs_Entry {
     pub value: InitialUEMessageProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8551,7 +8550,7 @@ pub struct InitialUEMessageProtocolIEs_Entry {
 )]
 pub struct InitialUEMessageProtocolIEs(pub Vec<InitialUEMessageProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitiatingMessageValue {
     #[asn(key = 42)]
@@ -8690,15 +8689,15 @@ pub enum InitiatingMessageValue {
     Id_uplinkUEAssociatedLPPaTransport(UplinkUEAssociatedLPPaTransport),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "1024")]
 pub struct INTEGER_25(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "32")]
 pub struct INTEGER_26(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct ENUMERATED_27(pub u8);
 impl ENUMERATED_27 {
@@ -8709,39 +8708,39 @@ impl ENUMERATED_27 {
     pub const K_HZ240: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "16")]
 pub struct INTEGER_28(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_29(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_30(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_31(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_32(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_33(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_34(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InterSystemMeasurementItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8752,15 +8751,15 @@ pub struct InterSystemMeasurementItemIE_Extensions(
     pub Vec<InterSystemMeasurementItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "100")]
 pub struct INTEGER_35(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InterSystemMeasurementParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8771,23 +8770,23 @@ pub struct InterSystemMeasurementParametersIE_Extensions(
     pub Vec<InterSystemMeasurementParametersIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_36(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_37(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct INTEGER_38(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemMeasurementConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8798,7 +8797,7 @@ pub struct IntersystemMeasurementConfigurationIE_Extensions(
     pub Vec<IntersystemMeasurementConfigurationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum KillRequestProtocolIEs_EntryValue {
     #[asn(key = 191)]
@@ -8811,7 +8810,7 @@ pub enum KillRequestProtocolIEs_EntryValue {
     Id_WarningAreaList(WarningAreaList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct KillRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8820,7 +8819,7 @@ pub struct KillRequestProtocolIEs_Entry {
     pub value: KillRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8829,7 +8828,7 @@ pub struct KillRequestProtocolIEs_Entry {
 )]
 pub struct KillRequestProtocolIEs(pub Vec<KillRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum KillResponseProtocolIEs_EntryValue {
     #[asn(key = 141)]
@@ -8842,7 +8841,7 @@ pub enum KillResponseProtocolIEs_EntryValue {
     Id_SerialNumber(SerialNumber),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct KillResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8851,7 +8850,7 @@ pub struct KillResponseProtocolIEs_Entry {
     pub value: KillResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8860,11 +8859,11 @@ pub struct KillResponseProtocolIEs_Entry {
 )]
 pub struct KillResponseProtocolIEs(pub Vec<KillResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8873,7 +8872,7 @@ pub struct LAIIE_Extensions_Entry {}
 )]
 pub struct LAIIE_Extensions(pub Vec<LAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LastVisitedEUTRANCellInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 168)]
@@ -8882,7 +8881,7 @@ pub enum LastVisitedEUTRANCellInformationIE_Extensions_EntryExtensionValue {
     Id_Time_UE_StayedInCell_EnhancedGranularity(Time_UE_StayedInCell_EnhancedGranularity),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LastVisitedEUTRANCellInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8891,7 +8890,7 @@ pub struct LastVisitedEUTRANCellInformationIE_Extensions_Entry {
     pub extension_value: LastVisitedEUTRANCellInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8902,11 +8901,11 @@ pub struct LastVisitedEUTRANCellInformationIE_Extensions(
     pub Vec<LastVisitedEUTRANCellInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_39;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct ENUMERATED_40(pub u8);
 impl ENUMERATED_40 {
@@ -8916,15 +8915,15 @@ impl ENUMERATED_40 {
     pub const MS10240: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "10239", extensible = true)]
 pub struct INTEGER_41(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ListeningSubframePatternIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8935,7 +8934,7 @@ pub struct ListeningSubframePatternIE_Extensions(
     pub Vec<ListeningSubframePatternIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportProtocolIEs_EntryValue {
     #[asn(key = 100)]
@@ -8952,7 +8951,7 @@ pub enum LocationReportProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8961,7 +8960,7 @@ pub struct LocationReportProtocolIEs_Entry {
     pub value: LocationReportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8970,7 +8969,7 @@ pub struct LocationReportProtocolIEs_Entry {
 )]
 pub struct LocationReportProtocolIEs(pub Vec<LocationReportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportingControlProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -8981,7 +8980,7 @@ pub enum LocationReportingControlProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingControlProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8990,7 +8989,7 @@ pub struct LocationReportingControlProtocolIEs_Entry {
     pub value: LocationReportingControlProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8999,7 +8998,7 @@ pub struct LocationReportingControlProtocolIEs_Entry {
 )]
 pub struct LocationReportingControlProtocolIEs(pub Vec<LocationReportingControlProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportingFailureIndicationProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -9010,7 +9009,7 @@ pub enum LocationReportingFailureIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingFailureIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9019,7 +9018,7 @@ pub struct LocationReportingFailureIndicationProtocolIEs_Entry {
     pub value: LocationReportingFailureIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9030,11 +9029,11 @@ pub struct LocationReportingFailureIndicationProtocolIEs(
     pub Vec<LocationReportingFailureIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LoggedMBSFNMDTIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9043,7 +9042,7 @@ pub struct LoggedMBSFNMDTIE_Extensions_Entry {}
 )]
 pub struct LoggedMBSFNMDTIE_Extensions(pub Vec<LoggedMBSFNMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LoggedMDTIE_Extensions_EntryExtensionValue {
     #[asn(key = 284)]
@@ -9052,7 +9051,7 @@ pub enum LoggedMDTIE_Extensions_EntryExtensionValue {
     Id_WLANMeasurementConfiguration(WLANMeasurementConfiguration),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LoggedMDTIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9061,7 +9060,7 @@ pub struct LoggedMDTIE_Extensions_Entry {
     pub extension_value: LoggedMDTIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9070,11 +9069,11 @@ pub struct LoggedMDTIE_Extensions_Entry {
 )]
 pub struct LoggedMDTIE_Extensions(pub Vec<LoggedMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M1PeriodicReportingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9083,11 +9082,11 @@ pub struct M1PeriodicReportingIE_Extensions_Entry {}
 )]
 pub struct M1PeriodicReportingIE_Extensions(pub Vec<M1PeriodicReportingIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M1ThresholdEventA2IE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9096,11 +9095,11 @@ pub struct M1ThresholdEventA2IE_Extensions_Entry {}
 )]
 pub struct M1ThresholdEventA2IE_Extensions(pub Vec<M1ThresholdEventA2IE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M3ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9109,11 +9108,11 @@ pub struct M3ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M3ConfigurationIE_Extensions(pub Vec<M3ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M4ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9122,11 +9121,11 @@ pub struct M4ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M4ConfigurationIE_Extensions(pub Vec<M4ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M5ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9135,11 +9134,11 @@ pub struct M5ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M5ConfigurationIE_Extensions(pub Vec<M5ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M6ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9148,11 +9147,11 @@ pub struct M6ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M6ConfigurationIE_Extensions(pub Vec<M6ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M7ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9161,15 +9160,15 @@ pub struct M7ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M7ConfigurationIE_Extensions(pub Vec<M7ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct INTEGER_42(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MBSFN_ResultToLogInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9178,14 +9177,14 @@ pub struct MBSFN_ResultToLogInfoIE_Extensions_Entry {}
 )]
 pub struct MBSFN_ResultToLogInfoIE_Extensions(pub Vec<MBSFN_ResultToLogInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MDT_ConfigurationIE_Extensions_EntryExtensionValue {
     #[asn(key = 178)]
     Id_SignallingBasedMDTPLMNList(MDTPLMNList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDT_ConfigurationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9194,7 +9193,7 @@ pub struct MDT_ConfigurationIE_Extensions_Entry {
     pub extension_value: MDT_ConfigurationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9203,14 +9202,14 @@ pub struct MDT_ConfigurationIE_Extensions_Entry {
 )]
 pub struct MDT_ConfigurationIE_Extensions(pub Vec<MDT_ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MDTMode_ExtensionValue {
     #[asn(key = 197)]
     Id_LoggedMBSFNMDT(LoggedMBSFNMDT),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMECPRelocationIndicationProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -9219,7 +9218,7 @@ pub enum MMECPRelocationIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMECPRelocationIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9228,7 +9227,7 @@ pub struct MMECPRelocationIndicationProtocolIEs_Entry {
     pub value: MMECPRelocationIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9239,7 +9238,7 @@ pub struct MMECPRelocationIndicationProtocolIEs(
     pub Vec<MMECPRelocationIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMEConfigurationTransferProtocolIEs_EntryValue {
     #[asn(key = 295)]
@@ -9250,7 +9249,7 @@ pub enum MMEConfigurationTransferProtocolIEs_EntryValue {
     Id_SONConfigurationTransferMCT(SONConfigurationTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMEConfigurationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9259,7 +9258,7 @@ pub struct MMEConfigurationTransferProtocolIEs_Entry {
     pub value: MMEConfigurationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9268,7 +9267,7 @@ pub struct MMEConfigurationTransferProtocolIEs_Entry {
 )]
 pub struct MMEConfigurationTransferProtocolIEs(pub Vec<MMEConfigurationTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMEConfigurationUpdateProtocolIEs_EntryValue {
     #[asn(key = 61)]
@@ -9281,7 +9280,7 @@ pub enum MMEConfigurationUpdateProtocolIEs_EntryValue {
     Id_ServedGUMMEIs(ServedGUMMEIs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMEConfigurationUpdateProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9290,7 +9289,7 @@ pub struct MMEConfigurationUpdateProtocolIEs_Entry {
     pub value: MMEConfigurationUpdateProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9299,14 +9298,14 @@ pub struct MMEConfigurationUpdateProtocolIEs_Entry {
 )]
 pub struct MMEConfigurationUpdateProtocolIEs(pub Vec<MMEConfigurationUpdateProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMEConfigurationUpdateAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 58)]
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMEConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9315,7 +9314,7 @@ pub struct MMEConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     pub value: MMEConfigurationUpdateAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9326,7 +9325,7 @@ pub struct MMEConfigurationUpdateAcknowledgeProtocolIEs(
     pub Vec<MMEConfigurationUpdateAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMEConfigurationUpdateFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -9337,7 +9336,7 @@ pub enum MMEConfigurationUpdateFailureProtocolIEs_EntryValue {
     Id_TimeToWait(TimeToWait),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMEConfigurationUpdateFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9346,7 +9345,7 @@ pub struct MMEConfigurationUpdateFailureProtocolIEs_Entry {
     pub value: MMEConfigurationUpdateFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9357,14 +9356,14 @@ pub struct MMEConfigurationUpdateFailureProtocolIEs(
     pub Vec<MMEConfigurationUpdateFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMEDirectInformationTransferProtocolIEs_EntryValue {
     #[asn(key = 122)]
     Id_Inter_SystemInformationTransferTypeMDT(Inter_SystemInformationTransferType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMEDirectInformationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9373,7 +9372,7 @@ pub struct MMEDirectInformationTransferProtocolIEs_Entry {
     pub value: MMEDirectInformationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9384,7 +9383,7 @@ pub struct MMEDirectInformationTransferProtocolIEs(
     pub Vec<MMEDirectInformationTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMEEarlyStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -9395,7 +9394,7 @@ pub enum MMEEarlyStatusTransferProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMEEarlyStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9404,7 +9403,7 @@ pub struct MMEEarlyStatusTransferProtocolIEs_Entry {
     pub value: MMEEarlyStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9413,7 +9412,7 @@ pub struct MMEEarlyStatusTransferProtocolIEs_Entry {
 )]
 pub struct MMEEarlyStatusTransferProtocolIEs(pub Vec<MMEEarlyStatusTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MMEStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -9424,7 +9423,7 @@ pub enum MMEStatusTransferProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MMEStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9433,7 +9432,7 @@ pub struct MMEStatusTransferProtocolIEs_Entry {
     pub value: MMEStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9442,15 +9441,15 @@ pub struct MMEStatusTransferProtocolIEs_Entry {
 )]
 pub struct MMEStatusTransferProtocolIEs(pub Vec<MMEStatusTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_43(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_44(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct ENUMERATED_45(pub u8);
 impl ENUMERATED_45 {
@@ -9461,15 +9460,15 @@ impl ENUMERATED_45 {
     pub const MS10240: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "10239", extensible = true)]
 pub struct INTEGER_46(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MutingPatternInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9480,7 +9479,7 @@ pub struct MutingPatternInformationIE_Extensions(
     pub Vec<MutingPatternInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NASDeliveryIndicationProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -9489,7 +9488,7 @@ pub enum NASDeliveryIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NASDeliveryIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9498,7 +9497,7 @@ pub struct NASDeliveryIndicationProtocolIEs_Entry {
     pub value: NASDeliveryIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9507,7 +9506,7 @@ pub struct NASDeliveryIndicationProtocolIEs_Entry {
 )]
 pub struct NASDeliveryIndicationProtocolIEs(pub Vec<NASDeliveryIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NASNonDeliveryIndicationProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -9520,7 +9519,7 @@ pub enum NASNonDeliveryIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NASNonDeliveryIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9529,7 +9528,7 @@ pub struct NASNonDeliveryIndicationProtocolIEs_Entry {
     pub value: NASNonDeliveryIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9538,11 +9537,11 @@ pub struct NASNonDeliveryIndicationProtocolIEs_Entry {
 )]
 pub struct NASNonDeliveryIndicationProtocolIEs(pub Vec<NASNonDeliveryIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NB_IoT_Paging_eDRXInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9553,11 +9552,11 @@ pub struct NB_IoT_Paging_eDRXInformationIE_Extensions(
     pub Vec<NB_IoT_Paging_eDRXInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NG_eNBIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9566,11 +9565,11 @@ pub struct NG_eNBIE_Extensions_Entry {}
 )]
 pub struct NG_eNBIE_Extensions(pub Vec<NG_eNBIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NR_CGIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9579,11 +9578,11 @@ pub struct NR_CGIIE_Extensions_Entry {}
 )]
 pub struct NR_CGIIE_Extensions(pub Vec<NR_CGIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NRUESecurityCapabilitiesIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9594,11 +9593,11 @@ pub struct NRUESecurityCapabilitiesIE_Extensions(
     pub Vec<NRUESecurityCapabilitiesIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NRUESidelinkAggregateMaximumBitrateIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9609,11 +9608,11 @@ pub struct NRUESidelinkAggregateMaximumBitrateIE_Extensions(
     pub Vec<NRUESidelinkAggregateMaximumBitrateIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NRV2XServicesAuthorizedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9624,11 +9623,11 @@ pub struct NRV2XServicesAuthorizedIE_Extensions(
     pub Vec<NRV2XServicesAuthorizedIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_47(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum OverloadStartProtocolIEs_EntryValue {
     #[asn(key = 154)]
@@ -9639,7 +9638,7 @@ pub enum OverloadStartProtocolIEs_EntryValue {
     Id_TrafficLoadReductionIndication(TrafficLoadReductionIndication),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadStartProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9648,7 +9647,7 @@ pub struct OverloadStartProtocolIEs_Entry {
     pub value: OverloadStartProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9657,14 +9656,14 @@ pub struct OverloadStartProtocolIEs_Entry {
 )]
 pub struct OverloadStartProtocolIEs(pub Vec<OverloadStartProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum OverloadStopProtocolIEs_EntryValue {
     #[asn(key = 154)]
     Id_GUMMEIList(GUMMEIList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadStopProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9673,7 +9672,7 @@ pub struct OverloadStopProtocolIEs_Entry {
     pub value: OverloadStopProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9682,11 +9681,11 @@ pub struct OverloadStopProtocolIEs_Entry {
 )]
 pub struct OverloadStopProtocolIEs(pub Vec<OverloadStopProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PC5FlowBitRatesIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9695,11 +9694,11 @@ pub struct PC5FlowBitRatesIE_Extensions_Entry {}
 )]
 pub struct PC5FlowBitRatesIE_Extensions(pub Vec<PC5FlowBitRatesIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PC5QoSFlowItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9708,11 +9707,11 @@ pub struct PC5QoSFlowItemIE_Extensions_Entry {}
 )]
 pub struct PC5QoSFlowItemIE_Extensions(pub Vec<PC5QoSFlowItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PC5QoSParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9721,11 +9720,11 @@ pub struct PC5QoSParametersIE_Extensions_Entry {}
 )]
 pub struct PC5QoSParametersIE_Extensions(pub Vec<PC5QoSParametersIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PLMNAreaBasedQMCIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9734,11 +9733,11 @@ pub struct PLMNAreaBasedQMCIE_Extensions_Entry {}
 )]
 pub struct PLMNAreaBasedQMCIE_Extensions(pub Vec<PLMNAreaBasedQMCIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PSCellInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9747,7 +9746,7 @@ pub struct PSCellInformationIE_Extensions_Entry {}
 )]
 pub struct PSCellInformationIE_Extensions(pub Vec<PSCellInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PWSFailureIndicationProtocolIEs_EntryValue {
     #[asn(key = 59)]
@@ -9756,7 +9755,7 @@ pub enum PWSFailureIndicationProtocolIEs_EntryValue {
     Id_PWSfailedECGIList(PWSfailedECGIList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PWSFailureIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9765,7 +9764,7 @@ pub struct PWSFailureIndicationProtocolIEs_Entry {
     pub value: PWSFailureIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9774,7 +9773,7 @@ pub struct PWSFailureIndicationProtocolIEs_Entry {
 )]
 pub struct PWSFailureIndicationProtocolIEs(pub Vec<PWSFailureIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PWSRestartIndicationProtocolIEs_EntryValue {
     #[asn(key = 182)]
@@ -9787,7 +9786,7 @@ pub enum PWSRestartIndicationProtocolIEs_EntryValue {
     Id_TAIListForRestart(TAIListForRestart),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PWSRestartIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9796,7 +9795,7 @@ pub struct PWSRestartIndicationProtocolIEs_Entry {
     pub value: PWSRestartIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9805,7 +9804,7 @@ pub struct PWSRestartIndicationProtocolIEs_Entry {
 )]
 pub struct PWSRestartIndicationProtocolIEs(pub Vec<PWSRestartIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PagingProtocolIEs_EntryValue {
     #[asn(key = 211)]
@@ -9846,7 +9845,7 @@ pub enum PagingProtocolIEs_EntryValue {
     Id_pagingDRX(PagingDRX),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9855,7 +9854,7 @@ pub struct PagingProtocolIEs_Entry {
     pub value: PagingProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9864,11 +9863,11 @@ pub struct PagingProtocolIEs_Entry {
 )]
 pub struct PagingProtocolIEs(pub Vec<PagingProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Paging_eDRXInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9877,11 +9876,11 @@ pub struct Paging_eDRXInformationIE_Extensions_Entry {}
 )]
 pub struct Paging_eDRXInformationIE_Extensions(pub Vec<Paging_eDRXInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingAttemptInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9892,7 +9891,7 @@ pub struct PagingAttemptInformationIE_Extensions(
     pub Vec<PagingAttemptInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestProtocolIEs_EntryValue {
     #[asn(key = 127)]
@@ -9927,7 +9926,7 @@ pub enum PathSwitchRequestProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9936,7 +9935,7 @@ pub struct PathSwitchRequestProtocolIEs_Entry {
     pub value: PathSwitchRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9945,7 +9944,7 @@ pub struct PathSwitchRequestProtocolIEs_Entry {
 )]
 pub struct PathSwitchRequestProtocolIEs(pub Vec<PathSwitchRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 299)]
@@ -10000,7 +9999,7 @@ pub enum PathSwitchRequestAcknowledgeProtocolIEs_EntryValue {
     Id_uEaggregateMaximumBitrate(UEAggregateMaximumBitrate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10009,7 +10008,7 @@ pub struct PathSwitchRequestAcknowledgeProtocolIEs_Entry {
     pub value: PathSwitchRequestAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10020,7 +10019,7 @@ pub struct PathSwitchRequestAcknowledgeProtocolIEs(
     pub Vec<PathSwitchRequestAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -10033,7 +10032,7 @@ pub enum PathSwitchRequestFailureProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10042,7 +10041,7 @@ pub struct PathSwitchRequestFailureProtocolIEs_Entry {
     pub value: PathSwitchRequestFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10051,19 +10050,19 @@ pub struct PathSwitchRequestFailureProtocolIEs_Entry {
 )]
 pub struct PathSwitchRequestFailureProtocolIEs(pub Vec<PathSwitchRequestFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct INTEGER_48(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OBJECT-IDENTIFIER")]
 pub struct OBJECT_IDENTIFIER_49;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PrivateMessagePrivateIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10072,14 +10071,14 @@ pub struct PrivateMessagePrivateIEs_Entry {}
 )]
 pub struct PrivateMessagePrivateIEs(pub Vec<PrivateMessagePrivateIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ProSeAuthorizedIE_Extensions_EntryExtensionValue {
     #[asn(key = 216)]
     Id_ProSeUEtoNetworkRelaying(ProSeUEtoNetworkRelaying),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ProSeAuthorizedIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10088,7 +10087,7 @@ pub struct ProSeAuthorizedIE_Extensions_Entry {
     pub extension_value: ProSeAuthorizedIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10097,7 +10096,7 @@ pub struct ProSeAuthorizedIE_Extensions_Entry {
 )]
 pub struct ProSeAuthorizedIE_Extensions(pub Vec<ProSeAuthorizedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -10106,11 +10105,11 @@ pub struct ProSeAuthorizedIE_Extensions(pub Vec<ProSeAuthorizedIE_Extensions_Ent
 )]
 pub struct OCTET_STRING_50(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RIMTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10119,14 +10118,14 @@ pub struct RIMTransferIE_Extensions_Entry {}
 )]
 pub struct RIMTransferIE_Extensions(pub Vec<RIMTransferIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RLFReportInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 313)]
     Id_NB_IoT_RLF_Report_Container(NB_IoT_RLF_Report_Container),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RLFReportInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10135,7 +10134,7 @@ pub struct RLFReportInformationIE_Extensions_Entry {
     pub extension_value: RLFReportInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10144,15 +10143,15 @@ pub struct RLFReportInformationIE_Extensions_Entry {
 )]
 pub struct RLFReportInformationIE_Extensions(pub Vec<RLFReportInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct INTEGER_51(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedCellItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10161,14 +10160,14 @@ pub struct RecommendedCellItemIE_Extensions_Entry {}
 )]
 pub struct RecommendedCellItemIE_Extensions(pub Vec<RecommendedCellItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RecommendedCellList_EntryValue {
     #[asn(key = 214)]
     Id_RecommendedCellItem(RecommendedCellItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedCellList_Entry {
     #[asn(key_field = true)]
@@ -10177,11 +10176,11 @@ pub struct RecommendedCellList_Entry {
     pub value: RecommendedCellList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedCellsForPagingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10192,11 +10191,11 @@ pub struct RecommendedCellsForPagingIE_Extensions(
     pub Vec<RecommendedCellsForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedENBItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10205,14 +10204,14 @@ pub struct RecommendedENBItemIE_Extensions_Entry {}
 )]
 pub struct RecommendedENBItemIE_Extensions(pub Vec<RecommendedENBItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RecommendedENBList_EntryValue {
     #[asn(key = 215)]
     Id_RecommendedENBItem(RecommendedENBItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedENBList_Entry {
     #[asn(key_field = true)]
@@ -10221,11 +10220,11 @@ pub struct RecommendedENBList_Entry {
     pub value: RecommendedENBList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedENBsForPagingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10236,14 +10235,14 @@ pub struct RecommendedENBsForPagingIE_Extensions(
     pub Vec<RecommendedENBsForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RequestTypeIE_Extensions_EntryExtensionValue {
     #[asn(key = 298)]
     Id_RequestTypeAdditionalInfo(RequestTypeAdditionalInfo),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RequestTypeIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10252,7 +10251,7 @@ pub struct RequestTypeIE_Extensions_Entry {
     pub extension_value: RequestTypeIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10261,7 +10260,7 @@ pub struct RequestTypeIE_Extensions_Entry {
 )]
 pub struct RequestTypeIE_Extensions(pub Vec<RequestTypeIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RerouteNASRequestProtocolIEs_EntryValue {
     #[asn(key = 224)]
@@ -10276,7 +10275,7 @@ pub enum RerouteNASRequestProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RerouteNASRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10285,7 +10284,7 @@ pub struct RerouteNASRequestProtocolIEs_Entry {
     pub value: RerouteNASRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10294,7 +10293,7 @@ pub struct RerouteNASRequestProtocolIEs_Entry {
 )]
 pub struct RerouteNASRequestProtocolIEs(pub Vec<RerouteNASRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -10303,7 +10302,7 @@ pub enum ResetProtocolIEs_EntryValue {
     Id_ResetType(ResetType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10312,7 +10311,7 @@ pub struct ResetProtocolIEs_Entry {
     pub value: ResetProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10321,7 +10320,7 @@ pub struct ResetProtocolIEs_Entry {
 )]
 pub struct ResetProtocolIEs(pub Vec<ResetProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ResetAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -10330,7 +10329,7 @@ pub enum ResetAcknowledgeProtocolIEs_EntryValue {
     Id_UE_associatedLogicalS1_ConnectionListResAck(UE_associatedLogicalS1_ConnectionListResAck),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10339,7 +10338,7 @@ pub struct ResetAcknowledgeProtocolIEs_Entry {
     pub value: ResetAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10348,14 +10347,14 @@ pub struct ResetAcknowledgeProtocolIEs_Entry {
 )]
 pub struct ResetAcknowledgeProtocolIEs(pub Vec<ResetAcknowledgeProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RetrieveUEInformationProtocolIEs_EntryValue {
     #[asn(key = 96)]
     Id_S_TMSI(S_TMSI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RetrieveUEInformationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10364,7 +10363,7 @@ pub struct RetrieveUEInformationProtocolIEs_Entry {
     pub value: RetrieveUEInformationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10373,11 +10372,11 @@ pub struct RetrieveUEInformationProtocolIEs_Entry {
 )]
 pub struct RetrieveUEInformationProtocolIEs(pub Vec<RetrieveUEInformationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct S_TMSIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10386,7 +10385,7 @@ pub struct S_TMSIIE_Extensions_Entry {}
 )]
 pub struct S_TMSIIE_Extensions(pub Vec<S_TMSIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum S1SetupFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -10397,7 +10396,7 @@ pub enum S1SetupFailureProtocolIEs_EntryValue {
     Id_TimeToWait(TimeToWait),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct S1SetupFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10406,7 +10405,7 @@ pub struct S1SetupFailureProtocolIEs_Entry {
     pub value: S1SetupFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10415,7 +10414,7 @@ pub struct S1SetupFailureProtocolIEs_Entry {
 )]
 pub struct S1SetupFailureProtocolIEs(pub Vec<S1SetupFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum S1SetupRequestProtocolIEs_EntryValue {
     #[asn(key = 128)]
@@ -10436,7 +10435,7 @@ pub enum S1SetupRequestProtocolIEs_EntryValue {
     Id_eNBname(ENBname),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct S1SetupRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10445,7 +10444,7 @@ pub struct S1SetupRequestProtocolIEs_Entry {
     pub value: S1SetupRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10454,7 +10453,7 @@ pub struct S1SetupRequestProtocolIEs_Entry {
 )]
 pub struct S1SetupRequestProtocolIEs(pub Vec<S1SetupRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum S1SetupResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -10475,7 +10474,7 @@ pub enum S1SetupResponseProtocolIEs_EntryValue {
     Id_UE_RetentionInformation(UE_RetentionInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct S1SetupResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10484,7 +10483,7 @@ pub struct S1SetupResponseProtocolIEs_Entry {
     pub value: S1SetupResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10493,7 +10492,7 @@ pub struct S1SetupResponseProtocolIEs_Entry {
 )]
 pub struct S1SetupResponseProtocolIEs(pub Vec<S1SetupResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SONConfigurationTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 209)]
@@ -10502,7 +10501,7 @@ pub enum SONConfigurationTransferIE_Extensions_EntryExtensionValue {
     Id_x2TNLConfigurationInfo(X2TNLConfigurationInfo),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SONConfigurationTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10511,7 +10510,7 @@ pub struct SONConfigurationTransferIE_Extensions_Entry {
     pub extension_value: SONConfigurationTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10522,14 +10521,14 @@ pub struct SONConfigurationTransferIE_Extensions(
     pub Vec<SONConfigurationTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SONInformation_ExtensionValue {
     #[asn(key = 206)]
     Id_SON_Information_Report(SONInformationReport),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SONInformationReplyIE_Extensions_EntryExtensionValue {
     #[asn(key = 208)]
@@ -10538,7 +10537,7 @@ pub enum SONInformationReplyIE_Extensions_EntryExtensionValue {
     Id_Time_Synchronisation_Info(TimeSynchronisationInfo),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SONInformationReplyIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10547,7 +10546,7 @@ pub struct SONInformationReplyIE_Extensions_Entry {
     pub extension_value: SONInformationReplyIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10556,39 +10555,39 @@ pub struct SONInformationReplyIE_Extensions_Entry {
 )]
 pub struct SONInformationReplyIE_Extensions(pub Vec<SONInformationReplyIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_52;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_53;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_54;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_55;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "7", sz_ub = "7")]
 pub struct BIT_STRING_56(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "86399", extensible = true)]
 pub struct INTEGER_57(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "86399", extensible = true)]
 pub struct INTEGER_58(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ScheduledCommunicationTimeIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10599,7 +10598,7 @@ pub struct ScheduledCommunicationTimeIE_Extensions(
     pub Vec<ScheduledCommunicationTimeIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SecondaryRATDataUsageReportProtocolIEs_EntryValue {
     #[asn(key = 266)]
@@ -10616,7 +10615,7 @@ pub enum SecondaryRATDataUsageReportProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecondaryRATDataUsageReportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10625,7 +10624,7 @@ pub struct SecondaryRATDataUsageReportProtocolIEs_Entry {
     pub value: SecondaryRATDataUsageReportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10636,11 +10635,11 @@ pub struct SecondaryRATDataUsageReportProtocolIEs(
     pub Vec<SecondaryRATDataUsageReportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecondaryRATDataUsageReportItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10651,14 +10650,14 @@ pub struct SecondaryRATDataUsageReportItemIE_Extensions(
     pub Vec<SecondaryRATDataUsageReportItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SecondaryRATDataUsageReportList_EntryValue {
     #[asn(key = 265)]
     Id_SecondaryRATDataUsageReportItem(SecondaryRATDataUsageReportItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecondaryRATDataUsageReportList_Entry {
     #[asn(key_field = true)]
@@ -10667,15 +10666,15 @@ pub struct SecondaryRATDataUsageReportList_Entry {
     pub value: SecondaryRATDataUsageReportList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "7")]
 pub struct INTEGER_59(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityContextIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10684,11 +10683,11 @@ pub struct SecurityContextIE_Extensions_Entry {}
 )]
 pub struct SecurityContextIE_Extensions(pub Vec<SecurityContextIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ServedDCNsItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10697,14 +10696,14 @@ pub struct ServedDCNsItemIE_Extensions_Entry {}
 )]
 pub struct ServedDCNsItemIE_Extensions(pub Vec<ServedDCNsItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ServedGUMMEIsItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 170)]
     Id_GUMMEIType(GUMMEIType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ServedGUMMEIsItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10713,7 +10712,7 @@ pub struct ServedGUMMEIsItemIE_Extensions_Entry {
     pub extension_value: ServedGUMMEIsItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10722,11 +10721,11 @@ pub struct ServedGUMMEIsItemIE_Extensions_Entry {
 )]
 pub struct ServedGUMMEIsItemIE_Extensions(pub Vec<ServedGUMMEIsItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceNgRanNode_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10735,11 +10734,11 @@ pub struct SourceNgRanNode_IDIE_Extensions_Entry {}
 )]
 pub struct SourceNgRanNode_IDIE_Extensions(pub Vec<SourceNgRanNode_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceeNB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10748,7 +10747,7 @@ pub struct SourceeNB_IDIE_Extensions_Entry {}
 )]
 pub struct SourceeNB_IDIE_Extensions(pub Vec<SourceeNB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions_EntryExtensionValue {
     #[asn(key = 299)]
@@ -10769,7 +10768,7 @@ pub enum SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions_EntryExtensionV
     Id_uE_HistoryInformationFromTheUE(UE_HistoryInformationFromTheUE),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10779,7 +10778,7 @@ pub struct SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions_Entry {
         SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10790,7 +10789,7 @@ pub struct SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions(
     pub Vec<SourceeNB_ToTargeteNB_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_60(pub u8);
 impl ENUMERATED_60 {
@@ -10798,11 +10797,11 @@ impl ENUMERATED_60 {
     pub const ONDEMAND: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "3600", extensible = true)]
 pub struct INTEGER_61(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_62(pub u8);
 impl ENUMERATED_62 {
@@ -10810,7 +10809,7 @@ impl ENUMERATED_62 {
     pub const MOBILE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct ENUMERATED_63(pub u8);
 impl ENUMERATED_63 {
@@ -10819,7 +10818,7 @@ impl ENUMERATED_63 {
     pub const MULTIPLE_PACKETS: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct ENUMERATED_64(pub u8);
 impl ENUMERATED_64 {
@@ -10828,11 +10827,11 @@ impl ENUMERATED_64 {
     pub const NOT_BATTERY_POWERED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Subscription_Based_UE_DifferentiationInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10843,7 +10842,7 @@ pub struct Subscription_Based_UE_DifferentiationInfoIE_Extensions(
     pub Vec<Subscription_Based_UE_DifferentiationInfoIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SuccessfulOutcomeValue {
     #[asn(key = 50)]
@@ -10892,14 +10891,14 @@ pub enum SuccessfulOutcomeValue {
     Id_WriteReplaceWarning(WriteReplaceWarningResponse),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SupportedTAs_ItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 232)]
     Id_RAT_Type(RAT_Type),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SupportedTAs_ItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10908,7 +10907,7 @@ pub struct SupportedTAs_ItemIE_Extensions_Entry {
     pub extension_value: SupportedTAs_ItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10917,11 +10916,11 @@ pub struct SupportedTAs_ItemIE_Extensions_Entry {
 )]
 pub struct SupportedTAs_ItemIE_Extensions(pub Vec<SupportedTAs_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SynchronisationInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10932,11 +10931,11 @@ pub struct SynchronisationInformationIE_Extensions(
     pub Vec<SynchronisationInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TABasedMDTIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10945,11 +10944,11 @@ pub struct TABasedMDTIE_Extensions_Entry {}
 )]
 pub struct TABasedMDTIE_Extensions(pub Vec<TABasedMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TABasedQMCIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10958,11 +10957,11 @@ pub struct TABasedQMCIE_Extensions_Entry {}
 )]
 pub struct TABasedQMCIE_Extensions(pub Vec<TABasedQMCIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10971,11 +10970,11 @@ pub struct TAIIE_Extensions_Entry {}
 )]
 pub struct TAIIE_Extensions(pub Vec<TAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAI_Broadcast_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10984,11 +10983,11 @@ pub struct TAI_Broadcast_ItemIE_Extensions_Entry {}
 )]
 pub struct TAI_Broadcast_ItemIE_Extensions(pub Vec<TAI_Broadcast_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAI_Cancelled_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10997,11 +10996,11 @@ pub struct TAI_Cancelled_ItemIE_Extensions_Entry {}
 )]
 pub struct TAI_Cancelled_ItemIE_Extensions(pub Vec<TAI_Cancelled_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIBasedMDTIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11010,11 +11009,11 @@ pub struct TAIBasedMDTIE_Extensions_Entry {}
 )]
 pub struct TAIBasedMDTIE_Extensions(pub Vec<TAIBasedMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIBasedQMCIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11023,11 +11022,11 @@ pub struct TAIBasedQMCIE_Extensions_Entry {}
 )]
 pub struct TAIBasedQMCIE_Extensions(pub Vec<TAIBasedQMCIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11036,14 +11035,14 @@ pub struct TAIItemIE_Extensions_Entry {}
 )]
 pub struct TAIItemIE_Extensions(pub Vec<TAIItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TAIList_EntryValue {
     #[asn(key = 47)]
     Id_TAIItem(TAIItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIList_Entry {
     #[asn(key_field = true)]
@@ -11052,11 +11051,11 @@ pub struct TAIList_Entry {
     pub value: TAIList_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetNgRanNode_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11065,11 +11064,11 @@ pub struct TargetNgRanNode_IDIE_Extensions_Entry {}
 )]
 pub struct TargetNgRanNode_IDIE_Extensions(pub Vec<TargetNgRanNode_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetRNC_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11078,11 +11077,11 @@ pub struct TargetRNC_IDIE_Extensions_Entry {}
 )]
 pub struct TargetRNC_IDIE_Extensions(pub Vec<TargetRNC_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargeteNB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11091,14 +11090,14 @@ pub struct TargeteNB_IDIE_Extensions_Entry {}
 )]
 pub struct TargeteNB_IDIE_Extensions(pub Vec<TargeteNB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TargeteNB_ToSourceeNB_TransparentContainerIE_Extensions_EntryExtensionValue {
     #[asn(key = 318)]
     Id_DAPSResponseInfoList(DAPSResponseInfoList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargeteNB_ToSourceeNB_TransparentContainerIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11108,7 +11107,7 @@ pub struct TargeteNB_ToSourceeNB_TransparentContainerIE_Extensions_Entry {
         TargeteNB_ToSourceeNB_TransparentContainerIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11119,14 +11118,14 @@ pub struct TargeteNB_ToSourceeNB_TransparentContainerIE_Extensions(
     pub Vec<TargeteNB_ToSourceeNB_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TimeSynchronisationInfoIE_Extensions_EntryExtensionValue {
     #[asn(key = 207)]
     Id_Muting_Availability_Indication(MutingAvailabilityIndication),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TimeSynchronisationInfoIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11135,7 +11134,7 @@ pub struct TimeSynchronisationInfoIE_Extensions_Entry {
     pub extension_value: TimeSynchronisationInfoIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11146,11 +11145,11 @@ pub struct TimeSynchronisationInfoIE_Extensions(
     pub Vec<TimeSynchronisationInfoIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_65(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TraceActivationIE_Extensions_EntryExtensionValue {
     #[asn(key = 162)]
@@ -11163,7 +11162,7 @@ pub enum TraceActivationIE_Extensions_EntryExtensionValue {
     Id_UEAppLayerMeasConfig(UEAppLayerMeasConfig),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceActivationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11172,7 +11171,7 @@ pub struct TraceActivationIE_Extensions_Entry {
     pub extension_value: TraceActivationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11181,7 +11180,7 @@ pub struct TraceActivationIE_Extensions_Entry {
 )]
 pub struct TraceActivationIE_Extensions(pub Vec<TraceActivationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TraceFailureIndicationProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -11194,7 +11193,7 @@ pub enum TraceFailureIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceFailureIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11203,7 +11202,7 @@ pub struct TraceFailureIndicationProtocolIEs_Entry {
     pub value: TraceFailureIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11212,7 +11211,7 @@ pub struct TraceFailureIndicationProtocolIEs_Entry {
 )]
 pub struct TraceFailureIndicationProtocolIEs(pub Vec<TraceFailureIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TraceStartProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -11223,7 +11222,7 @@ pub enum TraceStartProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceStartProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11232,7 +11231,7 @@ pub struct TraceStartProtocolIEs_Entry {
     pub value: TraceStartProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11241,11 +11240,11 @@ pub struct TraceStartProtocolIEs_Entry {
 )]
 pub struct TraceStartProtocolIEs(pub Vec<TraceStartProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TunnelInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11254,11 +11253,11 @@ pub struct TunnelInformationIE_Extensions_Entry {}
 )]
 pub struct TunnelInformationIE_Extensions(pub Vec<TunnelInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_S1AP_ID_pairIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11267,11 +11266,11 @@ pub struct UE_S1AP_ID_pairIE_Extensions_Entry {}
 )]
 pub struct UE_S1AP_ID_pairIE_Extensions(pub Vec<UE_S1AP_ID_pairIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_associatedLogicalS1_ConnectionItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11282,14 +11281,14 @@ pub struct UE_associatedLogicalS1_ConnectionItemIE_Extensions(
     pub Vec<UE_associatedLogicalS1_ConnectionItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UE_associatedLogicalS1_ConnectionListRes_EntryValue {
     #[asn(key = 91)]
     Id_UE_associatedLogicalS1_ConnectionItem(UE_associatedLogicalS1_ConnectionItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_associatedLogicalS1_ConnectionListRes_Entry {
     #[asn(key_field = true)]
@@ -11298,14 +11297,14 @@ pub struct UE_associatedLogicalS1_ConnectionListRes_Entry {
     pub value: UE_associatedLogicalS1_ConnectionListRes_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UE_associatedLogicalS1_ConnectionListResAck_EntryValue {
     #[asn(key = 91)]
     Id_UE_associatedLogicalS1_ConnectionItem(UE_associatedLogicalS1_ConnectionItem),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_associatedLogicalS1_ConnectionListResAck_Entry {
     #[asn(key_field = true)]
@@ -11314,7 +11313,7 @@ pub struct UE_associatedLogicalS1_ConnectionListResAck_Entry {
     pub value: UE_associatedLogicalS1_ConnectionListResAck_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEAggregateMaximumBitrateIE_Extensions_EntryExtensionValue {
     #[asn(key = 259)]
@@ -11323,7 +11322,7 @@ pub enum UEAggregateMaximumBitrateIE_Extensions_EntryExtensionValue {
     Id_extended_uEaggregateMaximumBitRateUL(ExtendedBitRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEAggregateMaximumBitrateIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11332,7 +11331,7 @@ pub struct UEAggregateMaximumBitrateIE_Extensions_Entry {
     pub extension_value: UEAggregateMaximumBitrateIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11343,7 +11342,7 @@ pub struct UEAggregateMaximumBitrateIE_Extensions(
     pub Vec<UEAggregateMaximumBitrateIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -11352,14 +11351,14 @@ pub struct UEAggregateMaximumBitrateIE_Extensions(
 )]
 pub struct OCTET_STRING_66(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEAppLayerMeasConfigIE_Extensions_EntryExtensionValue {
     #[asn(key = 276)]
     Id_serviceType(ServiceType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEAppLayerMeasConfigIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11368,7 +11367,7 @@ pub struct UEAppLayerMeasConfigIE_Extensions_Entry {
     pub extension_value: UEAppLayerMeasConfigIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11377,7 +11376,7 @@ pub struct UEAppLayerMeasConfigIE_Extensions_Entry {
 )]
 pub struct UEAppLayerMeasConfigIE_Extensions(pub Vec<UEAppLayerMeasConfigIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UECapabilityInfoIndicationProtocolIEs_EntryValue {
     #[asn(key = 272)]
@@ -11396,7 +11395,7 @@ pub enum UECapabilityInfoIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UECapabilityInfoIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11405,7 +11404,7 @@ pub struct UECapabilityInfoIndicationProtocolIEs_Entry {
     pub value: UECapabilityInfoIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11416,7 +11415,7 @@ pub struct UECapabilityInfoIndicationProtocolIEs(
     pub Vec<UECapabilityInfoIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationConfirmProtocolIEs_EntryValue {
     #[asn(key = 146)]
@@ -11429,7 +11428,7 @@ pub enum UEContextModificationConfirmProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationConfirmProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11438,7 +11437,7 @@ pub struct UEContextModificationConfirmProtocolIEs_Entry {
     pub value: UEContextModificationConfirmProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11449,7 +11448,7 @@ pub struct UEContextModificationConfirmProtocolIEs(
     pub Vec<UEContextModificationConfirmProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -11462,7 +11461,7 @@ pub enum UEContextModificationFailureProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11471,7 +11470,7 @@ pub struct UEContextModificationFailureProtocolIEs_Entry {
     pub value: UEContextModificationFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11482,7 +11481,7 @@ pub struct UEContextModificationFailureProtocolIEs(
     pub Vec<UEContextModificationFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationIndicationProtocolIEs_EntryValue {
     #[asn(key = 226)]
@@ -11493,7 +11492,7 @@ pub enum UEContextModificationIndicationProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11502,7 +11501,7 @@ pub struct UEContextModificationIndicationProtocolIEs_Entry {
     pub value: UEContextModificationIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11513,7 +11512,7 @@ pub struct UEContextModificationIndicationProtocolIEs(
     pub Vec<UEContextModificationIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationRequestProtocolIEs_EntryValue {
     #[asn(key = 187)]
@@ -11564,7 +11563,7 @@ pub enum UEContextModificationRequestProtocolIEs_EntryValue {
     Id_uEaggregateMaximumBitrate(UEAggregateMaximumBitrate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11573,7 +11572,7 @@ pub struct UEContextModificationRequestProtocolIEs_Entry {
     pub value: UEContextModificationRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11584,7 +11583,7 @@ pub struct UEContextModificationRequestProtocolIEs(
     pub Vec<UEContextModificationRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -11595,7 +11594,7 @@ pub enum UEContextModificationResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11604,7 +11603,7 @@ pub struct UEContextModificationResponseProtocolIEs_Entry {
     pub value: UEContextModificationResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11615,7 +11614,7 @@ pub struct UEContextModificationResponseProtocolIEs(
     pub Vec<UEContextModificationResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextReleaseCommandProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -11624,7 +11623,7 @@ pub enum UEContextReleaseCommandProtocolIEs_EntryValue {
     Id_UE_S1AP_IDs(UE_S1AP_IDs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextReleaseCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11633,7 +11632,7 @@ pub struct UEContextReleaseCommandProtocolIEs_Entry {
     pub value: UEContextReleaseCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11642,7 +11641,7 @@ pub struct UEContextReleaseCommandProtocolIEs_Entry {
 )]
 pub struct UEContextReleaseCommandProtocolIEs(pub Vec<UEContextReleaseCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextReleaseCompleteProtocolIEs_EntryValue {
     #[asn(key = 212)]
@@ -11663,7 +11662,7 @@ pub enum UEContextReleaseCompleteProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextReleaseCompleteProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11672,7 +11671,7 @@ pub struct UEContextReleaseCompleteProtocolIEs_Entry {
     pub value: UEContextReleaseCompleteProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11681,7 +11680,7 @@ pub struct UEContextReleaseCompleteProtocolIEs_Entry {
 )]
 pub struct UEContextReleaseCompleteProtocolIEs(pub Vec<UEContextReleaseCompleteProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextReleaseRequestProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -11696,7 +11695,7 @@ pub enum UEContextReleaseRequestProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextReleaseRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11705,7 +11704,7 @@ pub struct UEContextReleaseRequestProtocolIEs_Entry {
     pub value: UEContextReleaseRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11714,7 +11713,7 @@ pub struct UEContextReleaseRequestProtocolIEs_Entry {
 )]
 pub struct UEContextReleaseRequestProtocolIEs(pub Vec<UEContextReleaseRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextResumeFailureProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -11727,7 +11726,7 @@ pub enum UEContextResumeFailureProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11736,7 +11735,7 @@ pub struct UEContextResumeFailureProtocolIEs_Entry {
     pub value: UEContextResumeFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11745,7 +11744,7 @@ pub struct UEContextResumeFailureProtocolIEs_Entry {
 )]
 pub struct UEContextResumeFailureProtocolIEs(pub Vec<UEContextResumeFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextResumeRequestProtocolIEs_EntryValue {
     #[asn(key = 235)]
@@ -11758,7 +11757,7 @@ pub enum UEContextResumeRequestProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11767,7 +11766,7 @@ pub struct UEContextResumeRequestProtocolIEs_Entry {
     pub value: UEContextResumeRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11776,7 +11775,7 @@ pub struct UEContextResumeRequestProtocolIEs_Entry {
 )]
 pub struct UEContextResumeRequestProtocolIEs(pub Vec<UEContextResumeRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextResumeResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -11793,7 +11792,7 @@ pub enum UEContextResumeResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11802,7 +11801,7 @@ pub struct UEContextResumeResponseProtocolIEs_Entry {
     pub value: UEContextResumeResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11811,7 +11810,7 @@ pub struct UEContextResumeResponseProtocolIEs_Entry {
 )]
 pub struct UEContextResumeResponseProtocolIEs(pub Vec<UEContextResumeResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextSuspendRequestProtocolIEs_EntryValue {
     #[asn(key = 212)]
@@ -11830,7 +11829,7 @@ pub enum UEContextSuspendRequestProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextSuspendRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11839,7 +11838,7 @@ pub struct UEContextSuspendRequestProtocolIEs_Entry {
     pub value: UEContextSuspendRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11848,7 +11847,7 @@ pub struct UEContextSuspendRequestProtocolIEs_Entry {
 )]
 pub struct UEContextSuspendRequestProtocolIEs(pub Vec<UEContextSuspendRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextSuspendResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -11861,7 +11860,7 @@ pub enum UEContextSuspendResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextSuspendResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11870,7 +11869,7 @@ pub struct UEContextSuspendResponseProtocolIEs_Entry {
     pub value: UEContextSuspendResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11879,7 +11878,7 @@ pub struct UEContextSuspendResponseProtocolIEs_Entry {
 )]
 pub struct UEContextSuspendResponseProtocolIEs(pub Vec<UEContextSuspendResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEInformationTransferProtocolIEs_EntryValue {
     #[asn(key = 283)]
@@ -11894,7 +11893,7 @@ pub enum UEInformationTransferProtocolIEs_EntryValue {
     Id_UERadioCapability(UERadioCapability),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEInformationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11903,7 +11902,7 @@ pub struct UEInformationTransferProtocolIEs_Entry {
     pub value: UEInformationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11912,14 +11911,14 @@ pub struct UEInformationTransferProtocolIEs_Entry {
 )]
 pub struct UEInformationTransferProtocolIEs(pub Vec<UEInformationTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityIDMappingRequestProtocolIEs_EntryValue {
     #[asn(key = 314)]
     Id_UERadioCapabilityID(UERadioCapabilityID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityIDMappingRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11928,7 +11927,7 @@ pub struct UERadioCapabilityIDMappingRequestProtocolIEs_Entry {
     pub value: UERadioCapabilityIDMappingRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11939,7 +11938,7 @@ pub struct UERadioCapabilityIDMappingRequestProtocolIEs(
     pub Vec<UERadioCapabilityIDMappingRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityIDMappingResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -11950,7 +11949,7 @@ pub enum UERadioCapabilityIDMappingResponseProtocolIEs_EntryValue {
     Id_UERadioCapabilityID(UERadioCapabilityID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityIDMappingResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11959,7 +11958,7 @@ pub struct UERadioCapabilityIDMappingResponseProtocolIEs_Entry {
     pub value: UERadioCapabilityIDMappingResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11970,7 +11969,7 @@ pub struct UERadioCapabilityIDMappingResponseProtocolIEs(
     pub Vec<UERadioCapabilityIDMappingResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityMatchRequestProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -11983,7 +11982,7 @@ pub enum UERadioCapabilityMatchRequestProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityMatchRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11992,7 +11991,7 @@ pub struct UERadioCapabilityMatchRequestProtocolIEs_Entry {
     pub value: UERadioCapabilityMatchRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12003,7 +12002,7 @@ pub struct UERadioCapabilityMatchRequestProtocolIEs(
     pub Vec<UERadioCapabilityMatchRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityMatchResponseProtocolIEs_EntryValue {
     #[asn(key = 58)]
@@ -12016,7 +12015,7 @@ pub enum UERadioCapabilityMatchResponseProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityMatchResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12025,7 +12024,7 @@ pub struct UERadioCapabilityMatchResponseProtocolIEs_Entry {
     pub value: UERadioCapabilityMatchResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12036,11 +12035,11 @@ pub struct UERadioCapabilityMatchResponseProtocolIEs(
     pub Vec<UERadioCapabilityMatchResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UESecurityCapabilitiesIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12049,11 +12048,11 @@ pub struct UESecurityCapabilitiesIE_Extensions_Entry {}
 )]
 pub struct UESecurityCapabilitiesIE_Extensions(pub Vec<UESecurityCapabilitiesIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UESidelinkAggregateMaximumBitrateIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12064,11 +12063,11 @@ pub struct UESidelinkAggregateMaximumBitrateIE_Extensions(
     pub Vec<UESidelinkAggregateMaximumBitrateIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UL_CP_SecurityInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12079,7 +12078,7 @@ pub struct UL_CP_SecurityInformationIE_Extensions(
     pub Vec<UL_CP_SecurityInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UnsuccessfulOutcomeValue {
     #[asn(key = 29)]
@@ -12102,7 +12101,7 @@ pub enum UnsuccessfulOutcomeValue {
     Id_UEContextResume(UEContextResumeFailure),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkNASTransportProtocolIEs_EntryValue {
     #[asn(key = 100)]
@@ -12125,7 +12124,7 @@ pub enum UplinkNASTransportProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkNASTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12134,7 +12133,7 @@ pub struct UplinkNASTransportProtocolIEs_Entry {
     pub value: UplinkNASTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12143,7 +12142,7 @@ pub struct UplinkNASTransportProtocolIEs_Entry {
 )]
 pub struct UplinkNASTransportProtocolIEs(pub Vec<UplinkNASTransportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkNonUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 147)]
@@ -12152,7 +12151,7 @@ pub enum UplinkNonUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     Id_Routing_ID(Routing_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkNonUEAssociatedLPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12161,7 +12160,7 @@ pub struct UplinkNonUEAssociatedLPPaTransportProtocolIEs_Entry {
     pub value: UplinkNonUEAssociatedLPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12172,7 +12171,7 @@ pub struct UplinkNonUEAssociatedLPPaTransportProtocolIEs(
     pub Vec<UplinkNonUEAssociatedLPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkS1cdma2000tunnellingProtocolIEs_EntryValue {
     #[asn(key = 140)]
@@ -12195,7 +12194,7 @@ pub enum UplinkS1cdma2000tunnellingProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkS1cdma2000tunnellingProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12204,7 +12203,7 @@ pub struct UplinkS1cdma2000tunnellingProtocolIEs_Entry {
     pub value: UplinkS1cdma2000tunnellingProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12215,7 +12214,7 @@ pub struct UplinkS1cdma2000tunnellingProtocolIEs(
     pub Vec<UplinkS1cdma2000tunnellingProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 147)]
@@ -12228,7 +12227,7 @@ pub enum UplinkUEAssociatedLPPaTransportProtocolIEs_EntryValue {
     Id_eNB_UE_S1AP_ID(ENB_UE_S1AP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkUEAssociatedLPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12237,7 +12236,7 @@ pub struct UplinkUEAssociatedLPPaTransportProtocolIEs_Entry {
     pub value: UplinkUEAssociatedLPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12248,14 +12247,14 @@ pub struct UplinkUEAssociatedLPPaTransportProtocolIEs(
     pub Vec<UplinkUEAssociatedLPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UserLocationInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 288)]
     Id_PSCellInformation(PSCellInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12264,7 +12263,7 @@ pub struct UserLocationInformationIE_Extensions_Entry {
     pub extension_value: UserLocationInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12275,11 +12274,11 @@ pub struct UserLocationInformationIE_Extensions(
     pub Vec<UserLocationInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct V2XServicesAuthorizedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12288,25 +12287,25 @@ pub struct V2XServicesAuthorizedIE_Extensions_Entry {}
 )]
 pub struct V2XServicesAuthorizedIE_Extensions(pub Vec<V2XServicesAuthorizedIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_67(pub u8);
 impl ENUMERATED_67 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_68(pub u8);
 impl ENUMERATED_68 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WLANMeasurementConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12317,11 +12316,11 @@ pub struct WLANMeasurementConfigurationIE_Extensions(
     pub Vec<WLANMeasurementConfigurationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WUS_Assistance_InformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12332,7 +12331,7 @@ pub struct WUS_Assistance_InformationIE_Extensions(
     pub Vec<WUS_Assistance_InformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum WriteReplaceWarningRequestProtocolIEs_EntryValue {
     #[asn(key = 142)]
@@ -12361,7 +12360,7 @@ pub enum WriteReplaceWarningRequestProtocolIEs_EntryValue {
     Id_WarningType(WarningType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WriteReplaceWarningRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12370,7 +12369,7 @@ pub struct WriteReplaceWarningRequestProtocolIEs_Entry {
     pub value: WriteReplaceWarningRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12381,7 +12380,7 @@ pub struct WriteReplaceWarningRequestProtocolIEs(
     pub Vec<WriteReplaceWarningRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum WriteReplaceWarningResponseProtocolIEs_EntryValue {
     #[asn(key = 120)]
@@ -12394,7 +12393,7 @@ pub enum WriteReplaceWarningResponseProtocolIEs_EntryValue {
     Id_SerialNumber(SerialNumber),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WriteReplaceWarningResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12403,7 +12402,7 @@ pub struct WriteReplaceWarningResponseProtocolIEs_Entry {
     pub value: WriteReplaceWarningResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12414,7 +12413,7 @@ pub struct WriteReplaceWarningResponseProtocolIEs(
     pub Vec<WriteReplaceWarningResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum X2TNLConfigurationInfoIE_Extensions_EntryExtensionValue {
     #[asn(key = 193)]
@@ -12423,7 +12422,7 @@ pub enum X2TNLConfigurationInfoIE_Extensions_EntryExtensionValue {
     Id_eNBX2ExtendedTransportLayerAddresses(ENBX2ExtTLAs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct X2TNLConfigurationInfoIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12432,7 +12431,7 @@ pub struct X2TNLConfigurationInfoIE_Extensions_Entry {
     pub extension_value: X2TNLConfigurationInfoIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,

--- a/examples/tests/13-ngap.rs
+++ b/examples/tests/13-ngap.rs
@@ -1,9 +1,8 @@
 #![allow(dead_code, unreachable_patterns, non_camel_case_types)]
-use asn1_codecs_derive::AperCodec;
 use bitvec::order::Msb0;
 use bitvec::vec::BitVec;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AMF_TNLAssociationSetupItem {
     pub amf_tnl_association_address: CPTransportLayerInformation,
@@ -11,11 +10,11 @@ pub struct AMF_TNLAssociationSetupItem {
     pub ie_extensions: Option<AMF_TNLAssociationSetupItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct AMF_TNLAssociationSetupList(pub Vec<AMF_TNLAssociationSetupItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct AMF_TNLAssociationToAddItem {
     pub amf_tnl_association_address: CPTransportLayerInformation,
@@ -26,11 +25,11 @@ pub struct AMF_TNLAssociationToAddItem {
     pub ie_extensions: Option<AMF_TNLAssociationToAddItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct AMF_TNLAssociationToAddList(pub Vec<AMF_TNLAssociationToAddItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AMF_TNLAssociationToRemoveItem {
     pub amf_tnl_association_address: CPTransportLayerInformation,
@@ -38,11 +37,11 @@ pub struct AMF_TNLAssociationToRemoveItem {
     pub ie_extensions: Option<AMF_TNLAssociationToRemoveItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct AMF_TNLAssociationToRemoveList(pub Vec<AMF_TNLAssociationToRemoveItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct AMF_TNLAssociationToUpdateItem {
     pub amf_tnl_association_address: CPTransportLayerInformation,
@@ -54,39 +53,39 @@ pub struct AMF_TNLAssociationToUpdateItem {
     pub ie_extensions: Option<AMF_TNLAssociationToUpdateItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct AMF_TNLAssociationToUpdateList(pub Vec<AMF_TNLAssociationToUpdateItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1099511627775")]
 pub struct AMF_UE_NGAP_ID(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct AMFCPRelocationIndication {
     pub protocol_i_es: AMFCPRelocationIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct AMFConfigurationUpdate {
     pub protocol_i_es: AMFConfigurationUpdateProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct AMFConfigurationUpdateAcknowledge {
     pub protocol_i_es: AMFConfigurationUpdateAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct AMFConfigurationUpdateFailure {
     pub protocol_i_es: AMFConfigurationUpdateFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "PrintableString",
     sz_extensible = true,
@@ -95,11 +94,11 @@ pub struct AMFConfigurationUpdateFailure {
 )]
 pub struct AMFName(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "UTF8String", sz_extensible = true, sz_lb = "1", sz_ub = "150")]
 pub struct AMFNameUTF8String(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "VisibleString",
     sz_extensible = true,
@@ -108,7 +107,7 @@ pub struct AMFNameUTF8String(pub String);
 )]
 pub struct AMFNameVisibleString(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum AMFPagingTarget {
     #[asn(key = 0, extended = false)]
@@ -119,25 +118,25 @@ pub enum AMFPagingTarget {
     Choice_Extensions(AMFPagingTargetchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "6", sz_ub = "6")]
 pub struct AMFPointer(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct AMFRegionID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "10", sz_ub = "10")]
 pub struct AMFSetID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct AMFStatusIndication {
     pub protocol_i_es: AMFStatusIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct AdditionalDLUPTNLInformationForHOItem {
     pub additional_dl_ngu_up_tnl_information: UPTransportLayerInformation,
@@ -148,18 +147,18 @@ pub struct AdditionalDLUPTNLInformationForHOItem {
     pub ie_extensions: Option<AdditionalDLUPTNLInformationForHOItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "3")]
 pub struct AdditionalDLUPTNLInformationForHOList(pub Vec<AdditionalDLUPTNLInformationForHOItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct AdditionalQosFlowInformation(pub u8);
 impl AdditionalQosFlowInformation {
     pub const MORE_LIKELY: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AllocationAndRetentionPriority {
     pub priority_level_arp: PriorityLevelARP,
@@ -169,7 +168,7 @@ pub struct AllocationAndRetentionPriority {
     pub ie_extensions: Option<AllocationAndRetentionPriorityIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -178,7 +177,7 @@ pub struct AllocationAndRetentionPriority {
 )]
 pub struct Allowed_CAG_List_per_PLMN(pub Vec<CAG_ID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Allowed_PNI_NPN_Item {
     pub plmn_identity: PLMNIdentity,
@@ -188,15 +187,15 @@ pub struct Allowed_PNI_NPN_Item {
     pub ie_extensions: Option<Allowed_PNI_NPN_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct Allowed_PNI_NPN_List(pub Vec<Allowed_PNI_NPN_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct AllowedNSSAI(pub Vec<AllowedNSSAI_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AllowedNSSAI_Item {
     pub s_nssai: S_NSSAI,
@@ -204,15 +203,15 @@ pub struct AllowedNSSAI_Item {
     pub ie_extensions: Option<AllowedNSSAI_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct AllowedTACs(pub Vec<TAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "8", extensible = true)]
 pub struct AlternativeQoSParaSetIndex(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct AlternativeQoSParaSetItem {
     pub alternative_qo_s_para_set_index: AlternativeQoSParaSetIndex,
@@ -228,15 +227,15 @@ pub struct AlternativeQoSParaSetItem {
     pub ie_extensions: Option<AlternativeQoSParaSetItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct AlternativeQoSParaSetList(pub Vec<AlternativeQoSParaSetItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "8", extensible = true)]
 pub struct AlternativeQoSParaSetNotifyIndex(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct AreaOfInterest {
     #[asn(optional_idx = 0)]
@@ -249,7 +248,7 @@ pub struct AreaOfInterest {
     pub ie_extensions: Option<AreaOfInterestIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AreaOfInterestCellItem {
     pub ngran_cgi: NGRAN_CGI,
@@ -257,7 +256,7 @@ pub struct AreaOfInterestCellItem {
     pub ie_extensions: Option<AreaOfInterestCellItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -266,7 +265,7 @@ pub struct AreaOfInterestCellItem {
 )]
 pub struct AreaOfInterestCellList(pub Vec<AreaOfInterestCellItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AreaOfInterestItem {
     pub area_of_interest: AreaOfInterest,
@@ -275,11 +274,11 @@ pub struct AreaOfInterestItem {
     pub ie_extensions: Option<AreaOfInterestItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct AreaOfInterestList(pub Vec<AreaOfInterestItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AreaOfInterestRANNodeItem {
     pub global_ran_node_id: GlobalRANNodeID,
@@ -287,11 +286,11 @@ pub struct AreaOfInterestRANNodeItem {
     pub ie_extensions: Option<AreaOfInterestRANNodeItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct AreaOfInterestRANNodeList(pub Vec<AreaOfInterestRANNodeItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AreaOfInterestTAIItem {
     pub tai: TAI,
@@ -299,11 +298,11 @@ pub struct AreaOfInterestTAIItem {
     pub ie_extensions: Option<AreaOfInterestTAIItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct AreaOfInterestTAIList(pub Vec<AreaOfInterestTAIItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "4", extensible = false)]
 pub enum AreaScopeOfMDT_EUTRA {
     #[asn(key = 0, extended = false)]
@@ -318,7 +317,7 @@ pub enum AreaScopeOfMDT_EUTRA {
     Choice_Extensions(AreaScopeOfMDT_EUTRAchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "4", extensible = false)]
 pub enum AreaScopeOfMDT_NR {
     #[asn(key = 0, extended = false)]
@@ -333,7 +332,7 @@ pub enum AreaScopeOfMDT_NR {
     Choice_Extensions(AreaScopeOfMDT_NRchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct AreaScopeOfNeighCellsItem {
     pub nr_frequency_info: NRFrequencyInfo,
@@ -343,11 +342,11 @@ pub struct AreaScopeOfNeighCellsItem {
     pub ie_extensions: Option<AreaScopeOfNeighCellsItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct AreaScopeOfNeighCellsList(pub Vec<AreaScopeOfNeighCellsItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct AssistanceDataForPaging {
     #[asn(optional_idx = 0)]
@@ -358,7 +357,7 @@ pub struct AssistanceDataForPaging {
     pub ie_extensions: Option<AssistanceDataForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct AssistanceDataForRecommendedCells {
     pub recommended_cells_for_paging: RecommendedCellsForPaging,
@@ -366,7 +365,7 @@ pub struct AssistanceDataForRecommendedCells {
     pub ie_extensions: Option<AssistanceDataForRecommendedCellsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct AssociatedQosFlowItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -376,33 +375,33 @@ pub struct AssociatedQosFlowItem {
     pub ie_extensions: Option<AssociatedQosFlowItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct AssociatedQosFlowList(pub Vec<AssociatedQosFlowItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct AuthenticatedIndication(pub u8);
 impl AuthenticatedIndication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095", extensible = true)]
 pub struct AveragingWindow(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4000000000000", extensible = true)]
 pub struct BitRate(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct BluetoothMeasConfig(pub u8);
 impl BluetoothMeasConfig {
     pub const SETUP: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct BluetoothMeasConfigNameItem {
     pub bluetooth_name: BluetoothName,
@@ -410,11 +409,11 @@ pub struct BluetoothMeasConfigNameItem {
     pub ie_extensions: Option<BluetoothMeasConfigNameItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "4")]
 pub struct BluetoothMeasConfigNameList(pub Vec<BluetoothMeasConfigNameItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct BluetoothMeasurementConfiguration {
     pub bluetooth_meas_config: BluetoothMeasConfig,
@@ -426,7 +425,7 @@ pub struct BluetoothMeasurementConfiguration {
     pub ie_extensions: Option<BluetoothMeasurementConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -435,7 +434,7 @@ pub struct BluetoothMeasurementConfiguration {
 )]
 pub struct BluetoothName(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "6", extensible = false)]
 pub enum BroadcastCancelledAreaList {
     #[asn(key = 0, extended = false)]
@@ -454,7 +453,7 @@ pub enum BroadcastCancelledAreaList {
     Choice_Extensions(BroadcastCancelledAreaListchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "6", extensible = false)]
 pub enum BroadcastCompletedAreaList {
     #[asn(key = 0, extended = false)]
@@ -473,7 +472,7 @@ pub enum BroadcastCompletedAreaList {
     Choice_Extensions(BroadcastCompletedAreaListchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct BroadcastPLMNItem {
     pub plmn_identity: PLMNIdentity,
@@ -482,26 +481,26 @@ pub struct BroadcastPLMNItem {
     pub ie_extensions: Option<BroadcastPLMNItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "12")]
 pub struct BroadcastPLMNList(pub Vec<BroadcastPLMNItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct BurstArrivalTime(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "32", sz_ub = "32")]
 pub struct CAG_ID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct CEmodeBSupport_Indicator(pub u8);
 impl CEmodeBSupport_Indicator {
     pub const SUPPORTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct CEmodeBrestricted(pub u8);
 impl CEmodeBrestricted {
@@ -509,7 +508,7 @@ impl CEmodeBrestricted {
     pub const NOT_RESTRICTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct CNAssistedRANTuning {
     #[asn(optional_idx = 0)]
@@ -518,11 +517,11 @@ pub struct CNAssistedRANTuning {
     pub ie_extensions: Option<CNAssistedRANTuningIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "15")]
 pub struct CNTypeRestrictionsForEquivalent(pub Vec<CNTypeRestrictionsForEquivalentItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CNTypeRestrictionsForEquivalentItem {
     pub plmn_identity: PLMNIdentity,
@@ -531,14 +530,14 @@ pub struct CNTypeRestrictionsForEquivalentItem {
     pub ie_extensions: Option<CNTypeRestrictionsForEquivalentItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct CNTypeRestrictionsForServing(pub u8);
 impl CNTypeRestrictionsForServing {
     pub const EPC_FORBIDDEN: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct COUNTValueForPDCP_SN12 {
     pub pdcp_sn12: INTEGER_8,
@@ -547,7 +546,7 @@ pub struct COUNTValueForPDCP_SN12 {
     pub ie_extensions: Option<COUNTValueForPDCP_SN12IE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct COUNTValueForPDCP_SN18 {
     pub pdcp_sn18: INTEGER_10,
@@ -556,7 +555,7 @@ pub struct COUNTValueForPDCP_SN18 {
     pub ie_extensions: Option<COUNTValueForPDCP_SN18IE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum CPTransportLayerInformation {
     #[asn(key = 0, extended = false)]
@@ -565,14 +564,14 @@ pub enum CPTransportLayerInformation {
     Choice_Extensions(CPTransportLayerInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct CancelAllWarningMessages(pub u8);
 impl CancelAllWarningMessages {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -581,7 +580,7 @@ impl CancelAllWarningMessages {
 )]
 pub struct CancelledCellsInEAI_EUTRA(pub Vec<CancelledCellsInEAI_EUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CancelledCellsInEAI_EUTRA_Item {
     pub eutra_cgi: EUTRA_CGI,
@@ -590,7 +589,7 @@ pub struct CancelledCellsInEAI_EUTRA_Item {
     pub ie_extensions: Option<CancelledCellsInEAI_EUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -599,7 +598,7 @@ pub struct CancelledCellsInEAI_EUTRA_Item {
 )]
 pub struct CancelledCellsInEAI_NR(pub Vec<CancelledCellsInEAI_NR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CancelledCellsInEAI_NR_Item {
     pub nr_cgi: NR_CGI,
@@ -608,7 +607,7 @@ pub struct CancelledCellsInEAI_NR_Item {
     pub ie_extensions: Option<CancelledCellsInEAI_NR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -617,7 +616,7 @@ pub struct CancelledCellsInEAI_NR_Item {
 )]
 pub struct CancelledCellsInTAI_EUTRA(pub Vec<CancelledCellsInTAI_EUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CancelledCellsInTAI_EUTRA_Item {
     pub eutra_cgi: EUTRA_CGI,
@@ -626,7 +625,7 @@ pub struct CancelledCellsInTAI_EUTRA_Item {
     pub ie_extensions: Option<CancelledCellsInTAI_EUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -635,7 +634,7 @@ pub struct CancelledCellsInTAI_EUTRA_Item {
 )]
 pub struct CancelledCellsInTAI_NR(pub Vec<CancelledCellsInTAI_NR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CancelledCellsInTAI_NR_Item {
     pub nr_cgi: NR_CGI,
@@ -644,7 +643,7 @@ pub struct CancelledCellsInTAI_NR_Item {
     pub ie_extensions: Option<CancelledCellsInTAI_NR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum CandidateCell {
     #[asn(key = 0, extended = false)]
@@ -655,7 +654,7 @@ pub enum CandidateCell {
     Choice_Extensions(CandidateCellchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CandidateCellID {
     pub candidate_cell_id: NR_CGI,
@@ -663,7 +662,7 @@ pub struct CandidateCellID {
     pub ie_extensions: Option<CandidateCellIDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CandidateCellItem {
     pub candidate_cell: CandidateCell,
@@ -671,11 +670,11 @@ pub struct CandidateCellItem {
     pub ie_extensions: Option<CandidateCellItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct CandidateCellList(pub Vec<CandidateCellItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CandidatePCI {
     pub candidate_pci: INTEGER_12,
@@ -684,7 +683,7 @@ pub struct CandidatePCI {
     pub ie_extensions: Option<CandidatePCIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "5", extensible = false)]
 pub enum Cause {
     #[asn(key = 0, extended = false)]
@@ -701,7 +700,7 @@ pub enum Cause {
     Choice_Extensions(Causechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct CauseMisc(pub u8);
 impl CauseMisc {
@@ -713,7 +712,7 @@ impl CauseMisc {
     pub const UNSPECIFIED: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct CauseNas(pub u8);
 impl CauseNas {
@@ -723,7 +722,7 @@ impl CauseNas {
     pub const UNSPECIFIED: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "6")]
 pub struct CauseProtocol(pub u8);
 impl CauseProtocol {
@@ -736,7 +735,7 @@ impl CauseProtocol {
     pub const UNSPECIFIED: u8 = 6u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "44")]
 pub struct CauseRadioNetwork(pub u8);
 impl CauseRadioNetwork {
@@ -787,7 +786,7 @@ impl CauseRadioNetwork {
     pub const RELEASE_DUE_TO_CN_DETECTED_MOBILITY: u8 = 44u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct CauseTransport(pub u8);
 impl CauseTransport {
@@ -795,7 +794,7 @@ impl CauseTransport {
     pub const UNSPECIFIED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct Cell_CAGInformation {
     pub ngran_cgi: NGRAN_CGI,
@@ -804,7 +803,7 @@ pub struct Cell_CAGInformation {
     pub ie_extensions: Option<Cell_CAGInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellBasedMDT_EUTRA {
     pub cell_id_listfor_mdt: CellIdListforMDT_EUTRA,
@@ -812,7 +811,7 @@ pub struct CellBasedMDT_EUTRA {
     pub ie_extensions: Option<CellBasedMDT_EUTRAIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellBasedMDT_NR {
     pub cell_id_listfor_mdt: CellIdListforMDT_NR,
@@ -820,11 +819,11 @@ pub struct CellBasedMDT_NR {
     pub ie_extensions: Option<CellBasedMDT_NRIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct CellCAGList(pub Vec<CAG_ID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -833,7 +832,7 @@ pub struct CellCAGList(pub Vec<CAG_ID>);
 )]
 pub struct CellIDBroadcastEUTRA(pub Vec<CellIDBroadcastEUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellIDBroadcastEUTRA_Item {
     pub eutra_cgi: EUTRA_CGI,
@@ -841,7 +840,7 @@ pub struct CellIDBroadcastEUTRA_Item {
     pub ie_extensions: Option<CellIDBroadcastEUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -850,7 +849,7 @@ pub struct CellIDBroadcastEUTRA_Item {
 )]
 pub struct CellIDBroadcastNR(pub Vec<CellIDBroadcastNR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellIDBroadcastNR_Item {
     pub nr_cgi: NR_CGI,
@@ -858,7 +857,7 @@ pub struct CellIDBroadcastNR_Item {
     pub ie_extensions: Option<CellIDBroadcastNR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -867,7 +866,7 @@ pub struct CellIDBroadcastNR_Item {
 )]
 pub struct CellIDCancelledEUTRA(pub Vec<CellIDCancelledEUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellIDCancelledEUTRA_Item {
     pub eutra_cgi: EUTRA_CGI,
@@ -876,7 +875,7 @@ pub struct CellIDCancelledEUTRA_Item {
     pub ie_extensions: Option<CellIDCancelledEUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -885,7 +884,7 @@ pub struct CellIDCancelledEUTRA_Item {
 )]
 pub struct CellIDCancelledNR(pub Vec<CellIDCancelledNR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellIDCancelledNR_Item {
     pub nr_cgi: NR_CGI,
@@ -894,7 +893,7 @@ pub struct CellIDCancelledNR_Item {
     pub ie_extensions: Option<CellIDCancelledNR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum CellIDListForRestart {
     #[asn(key = 0, extended = false)]
@@ -905,15 +904,15 @@ pub enum CellIDListForRestart {
     Choice_Extensions(CellIDListForRestartchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct CellIdListforMDT_EUTRA(pub Vec<EUTRA_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct CellIdListforMDT_NR(pub Vec<NR_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct CellSize(pub u8);
 impl CellSize {
@@ -923,13 +922,13 @@ impl CellSize {
     pub const LARGE: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct CellTrafficTrace {
     pub protocol_i_es: CellTrafficTraceProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CellType {
     pub cell_size: CellSize,
@@ -937,11 +936,11 @@ pub struct CellType {
     pub ie_extensions: Option<CellTypeIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct CommonNetworkInstance(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -950,7 +949,7 @@ pub struct CommonNetworkInstance(pub Vec<u8>);
 )]
 pub struct CompletedCellsInEAI_EUTRA(pub Vec<CompletedCellsInEAI_EUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CompletedCellsInEAI_EUTRA_Item {
     pub eutra_cgi: EUTRA_CGI,
@@ -958,7 +957,7 @@ pub struct CompletedCellsInEAI_EUTRA_Item {
     pub ie_extensions: Option<CompletedCellsInEAI_EUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -967,7 +966,7 @@ pub struct CompletedCellsInEAI_EUTRA_Item {
 )]
 pub struct CompletedCellsInEAI_NR(pub Vec<CompletedCellsInEAI_NR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CompletedCellsInEAI_NR_Item {
     pub nr_cgi: NR_CGI,
@@ -975,7 +974,7 @@ pub struct CompletedCellsInEAI_NR_Item {
     pub ie_extensions: Option<CompletedCellsInEAI_NR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -984,7 +983,7 @@ pub struct CompletedCellsInEAI_NR_Item {
 )]
 pub struct CompletedCellsInTAI_EUTRA(pub Vec<CompletedCellsInTAI_EUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CompletedCellsInTAI_EUTRA_Item {
     pub eutra_cgi: EUTRA_CGI,
@@ -992,7 +991,7 @@ pub struct CompletedCellsInTAI_EUTRA_Item {
     pub ie_extensions: Option<CompletedCellsInTAI_EUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1001,7 +1000,7 @@ pub struct CompletedCellsInTAI_EUTRA_Item {
 )]
 pub struct CompletedCellsInTAI_NR(pub Vec<CompletedCellsInTAI_NR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CompletedCellsInTAI_NR_Item {
     pub nr_cgi: NR_CGI,
@@ -1009,14 +1008,14 @@ pub struct CompletedCellsInTAI_NR_Item {
     pub ie_extensions: Option<CompletedCellsInTAI_NR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ConcurrentWarningMessageInd(pub u8);
 impl ConcurrentWarningMessageInd {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct ConfidentialityProtectionIndication(pub u8);
 impl ConfidentialityProtectionIndication {
@@ -1025,7 +1024,7 @@ impl ConfidentialityProtectionIndication {
     pub const NOT_NEEDED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ConfidentialityProtectionResult(pub u8);
 impl ConfidentialityProtectionResult {
@@ -1033,7 +1032,7 @@ impl ConfidentialityProtectionResult {
     pub const NOT_PERFORMED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -1042,20 +1041,20 @@ impl ConfidentialityProtectionResult {
 )]
 pub struct ConfiguredNSSAI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ConfiguredTACIndication(pub u8);
 impl ConfiguredTACIndication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ConnectionEstablishmentIndication {
     pub protocol_i_es: ConnectionEstablishmentIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct CoreNetworkAssistanceInformationForInactive {
     pub ue_identity_index_value: UEIdentityIndexValue,
@@ -1071,11 +1070,11 @@ pub struct CoreNetworkAssistanceInformationForInactive {
     pub ie_extensions: Option<CoreNetworkAssistanceInformationForInactiveIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct CoverageEnhancementLevel(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct Criticality(pub u8);
 impl Criticality {
@@ -1084,7 +1083,7 @@ impl Criticality {
     pub const NOTIFY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct CriticalityDiagnostics {
     #[asn(optional_idx = 0)]
@@ -1099,7 +1098,7 @@ pub struct CriticalityDiagnostics {
     pub ie_extensions: Option<CriticalityDiagnosticsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct CriticalityDiagnostics_IE_Item {
     pub ie_criticality: Criticality,
@@ -1109,7 +1108,7 @@ pub struct CriticalityDiagnostics_IE_Item {
     pub ie_extensions: Option<CriticalityDiagnostics_IE_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1118,7 +1117,7 @@ pub struct CriticalityDiagnostics_IE_Item {
 )]
 pub struct CriticalityDiagnostics_IE_List(pub Vec<CriticalityDiagnostics_IE_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DAPSRequestInfo {
     pub daps_indicator: ENUMERATED_14,
@@ -1126,7 +1125,7 @@ pub struct DAPSRequestInfo {
     pub ie_extensions: Option<DAPSRequestInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DAPSResponseInfo {
     pub dapsresponseindicator: ENUMERATED_15,
@@ -1134,7 +1133,7 @@ pub struct DAPSResponseInfo {
     pub ie_extensions: Option<DAPSResponseInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DAPSResponseInfoItem {
     pub drb_id: DRB_ID,
@@ -1143,11 +1142,11 @@ pub struct DAPSResponseInfoItem {
     pub ie_extension: Option<DAPSResponseInfoItemIE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct DAPSResponseInfoList(pub Vec<DAPSResponseInfoItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DL_CP_SecurityInformation {
     pub dl_nas_mac: DL_NAS_MAC,
@@ -1155,29 +1154,29 @@ pub struct DL_CP_SecurityInformation {
     pub ie_extensions: Option<DL_CP_SecurityInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct DL_NAS_MAC(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct DL_NGU_TNLInformationReused(pub u8);
 impl DL_NGU_TNLInformationReused {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct DLForwarding(pub u8);
 impl DLForwarding {
     pub const DL_FORWARDING_PROPOSED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "32", extensible = true)]
 pub struct DRB_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum DRBStatusDL {
     #[asn(key = 0, extended = false)]
@@ -1188,7 +1187,7 @@ pub enum DRBStatusDL {
     Choice_Extensions(DRBStatusDLchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DRBStatusDL12 {
     pub dl_count_value: COUNTValueForPDCP_SN12,
@@ -1196,7 +1195,7 @@ pub struct DRBStatusDL12 {
     pub ie_extension: Option<DRBStatusDL12IE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DRBStatusDL18 {
     pub dl_count_value: COUNTValueForPDCP_SN18,
@@ -1204,7 +1203,7 @@ pub struct DRBStatusDL18 {
     pub ie_extension: Option<DRBStatusDL18IE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum DRBStatusUL {
     #[asn(key = 0, extended = false)]
@@ -1215,7 +1214,7 @@ pub enum DRBStatusUL {
     Choice_Extensions(DRBStatusULchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct DRBStatusUL12 {
     pub ul_count_value: COUNTValueForPDCP_SN12,
@@ -1225,7 +1224,7 @@ pub struct DRBStatusUL12 {
     pub ie_extension: Option<DRBStatusUL12IE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct DRBStatusUL18 {
     pub ul_count_value: COUNTValueForPDCP_SN18,
@@ -1235,7 +1234,7 @@ pub struct DRBStatusUL18 {
     pub ie_extension: Option<DRBStatusUL18IE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DRBsSubjectToEarlyStatusTransfer_Item {
     pub drb_id: DRB_ID,
@@ -1244,11 +1243,11 @@ pub struct DRBsSubjectToEarlyStatusTransfer_Item {
     pub ie_extension: Option<DRBsSubjectToEarlyStatusTransfer_ItemIE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct DRBsSubjectToEarlyStatusTransfer_List(pub Vec<DRBsSubjectToEarlyStatusTransfer_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DRBsSubjectToStatusTransferItem {
     pub drb_id: DRB_ID,
@@ -1258,11 +1257,11 @@ pub struct DRBsSubjectToStatusTransferItem {
     pub ie_extension: Option<DRBsSubjectToStatusTransferItemIE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct DRBsSubjectToStatusTransferList(pub Vec<DRBsSubjectToStatusTransferItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DRBsToQosFlowsMappingItem {
     pub drb_id: DRB_ID,
@@ -1271,29 +1270,29 @@ pub struct DRBsToQosFlowsMappingItem {
     pub ie_extensions: Option<DRBsToQosFlowsMappingItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct DRBsToQosFlowsMappingList(pub Vec<DRBsToQosFlowsMappingItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct DataCodingScheme(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct DataForwardingAccepted(pub u8);
 impl DataForwardingAccepted {
     pub const DATA_FORWARDING_ACCEPTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct DataForwardingNotPossible(pub u8);
 impl DataForwardingNotPossible {
     pub const DATA_FORWARDING_NOT_POSSIBLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct DataForwardingResponseDRBItem {
     pub drb_id: DRB_ID,
@@ -1305,11 +1304,11 @@ pub struct DataForwardingResponseDRBItem {
     pub ie_extensions: Option<DataForwardingResponseDRBItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct DataForwardingResponseDRBList(pub Vec<DataForwardingResponseDRBItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1318,7 +1317,7 @@ pub struct DataForwardingResponseDRBList(pub Vec<DataForwardingResponseDRBItem>)
 )]
 pub struct DataForwardingResponseERABList(pub Vec<DataForwardingResponseERABListItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct DataForwardingResponseERABListItem {
     pub e_rab_id: E_RAB_ID,
@@ -1327,13 +1326,13 @@ pub struct DataForwardingResponseERABListItem {
     pub ie_extensions: Option<DataForwardingResponseERABListItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DeactivateTrace {
     pub protocol_i_es: DeactivateTraceProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct DelayCritical(pub u8);
 impl DelayCritical {
@@ -1341,56 +1340,56 @@ impl DelayCritical {
     pub const NON_DELAY_CRITICAL: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct DirectForwardingPathAvailability(pub u8);
 impl DirectForwardingPathAvailability {
     pub const DIRECT_PATH_AVAILABLE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkNASTransport {
     pub protocol_i_es: DownlinkNASTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkNonUEAssociatedNRPPaTransport {
     pub protocol_i_es: DownlinkNonUEAssociatedNRPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkRANConfigurationTransfer {
     pub protocol_i_es: DownlinkRANConfigurationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkRANEarlyStatusTransfer {
     pub protocol_i_es: DownlinkRANEarlyStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkRANStatusTransfer {
     pub protocol_i_es: DownlinkRANStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkRIMInformationTransfer {
     pub protocol_i_es: DownlinkRIMInformationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct DownlinkUEAssociatedNRPPaTransport {
     pub protocol_i_es: DownlinkUEAssociatedNRPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct Dynamic5QIDescriptor {
     pub priority_level_qos: PriorityLevelQos,
@@ -1408,11 +1407,11 @@ pub struct Dynamic5QIDescriptor {
     pub ie_extensions: Option<Dynamic5QIDescriptorIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "15", extensible = true)]
 pub struct E_RAB_ID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct E_RABInformationItem {
     pub e_rab_id: E_RAB_ID,
@@ -1422,7 +1421,7 @@ pub struct E_RABInformationItem {
     pub ie_extensions: Option<E_RABInformationItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1431,18 +1430,18 @@ pub struct E_RABInformationItem {
 )]
 pub struct E_RABInformationList(pub Vec<E_RABInformationItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct EDT_Session(pub u8);
 impl EDT_Session {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct EN_DCSONConfigurationTransfer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "4", extensible = false)]
 pub enum ENB_ID {
     #[asn(key = 0, extended = false)]
@@ -1457,11 +1456,11 @@ pub enum ENB_ID {
     Choice_Extensions(ENB_IDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct EPS_TAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EPS_TAI {
     pub plmn_identity: PLMNIdentity,
@@ -1470,7 +1469,7 @@ pub struct EPS_TAI {
     pub ie_extensions: Option<EPS_TAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EUTRA_CGI {
     pub plmn_identity: PLMNIdentity,
@@ -1479,7 +1478,7 @@ pub struct EUTRA_CGI {
     pub ie_extensions: Option<EUTRA_CGIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1488,7 +1487,7 @@ pub struct EUTRA_CGI {
 )]
 pub struct EUTRA_CGIList(pub Vec<EUTRA_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1497,19 +1496,19 @@ pub struct EUTRA_CGIList(pub Vec<EUTRA_CGI>);
 )]
 pub struct EUTRA_CGIListForWarning(pub Vec<EUTRA_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "28", sz_ub = "28")]
 pub struct EUTRACellIdentity(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct EUTRAencryptionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct EUTRAintegrityProtectionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EarlyStatusTransfer_TransparentContainer {
     pub procedure_stage: ProcedureStageChoice,
@@ -1517,11 +1516,11 @@ pub struct EarlyStatusTransfer_TransparentContainer {
     pub ie_extensions: Option<EarlyStatusTransfer_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct EmergencyAreaID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1530,7 +1529,7 @@ pub struct EmergencyAreaID(pub Vec<u8>);
 )]
 pub struct EmergencyAreaIDBroadcastEUTRA(pub Vec<EmergencyAreaIDBroadcastEUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EmergencyAreaIDBroadcastEUTRA_Item {
     pub emergency_area_id: EmergencyAreaID,
@@ -1539,7 +1538,7 @@ pub struct EmergencyAreaIDBroadcastEUTRA_Item {
     pub ie_extensions: Option<EmergencyAreaIDBroadcastEUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1548,7 +1547,7 @@ pub struct EmergencyAreaIDBroadcastEUTRA_Item {
 )]
 pub struct EmergencyAreaIDBroadcastNR(pub Vec<EmergencyAreaIDBroadcastNR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EmergencyAreaIDBroadcastNR_Item {
     pub emergency_area_id: EmergencyAreaID,
@@ -1557,7 +1556,7 @@ pub struct EmergencyAreaIDBroadcastNR_Item {
     pub ie_extensions: Option<EmergencyAreaIDBroadcastNR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1566,7 +1565,7 @@ pub struct EmergencyAreaIDBroadcastNR_Item {
 )]
 pub struct EmergencyAreaIDCancelledEUTRA(pub Vec<EmergencyAreaIDCancelledEUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EmergencyAreaIDCancelledEUTRA_Item {
     pub emergency_area_id: EmergencyAreaID,
@@ -1575,7 +1574,7 @@ pub struct EmergencyAreaIDCancelledEUTRA_Item {
     pub ie_extensions: Option<EmergencyAreaIDCancelledEUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1584,7 +1583,7 @@ pub struct EmergencyAreaIDCancelledEUTRA_Item {
 )]
 pub struct EmergencyAreaIDCancelledNR(pub Vec<EmergencyAreaIDCancelledNR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EmergencyAreaIDCancelledNR_Item {
     pub emergency_area_id: EmergencyAreaID,
@@ -1593,7 +1592,7 @@ pub struct EmergencyAreaIDCancelledNR_Item {
     pub ie_extensions: Option<EmergencyAreaIDCancelledNR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1602,7 +1601,7 @@ pub struct EmergencyAreaIDCancelledNR_Item {
 )]
 pub struct EmergencyAreaIDList(pub Vec<EmergencyAreaID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1611,7 +1610,7 @@ pub struct EmergencyAreaIDList(pub Vec<EmergencyAreaID>);
 )]
 pub struct EmergencyAreaIDListForRestart(pub Vec<EmergencyAreaID>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct EmergencyFallbackIndicator {
     pub emergency_fallback_request_indicator: EmergencyFallbackRequestIndicator,
@@ -1621,14 +1620,14 @@ pub struct EmergencyFallbackIndicator {
     pub ie_extensions: Option<EmergencyFallbackIndicatorIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct EmergencyFallbackRequestIndicator(pub u8);
 impl EmergencyFallbackRequestIndicator {
     pub const EMERGENCY_FALLBACK_REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct EmergencyServiceTargetCN(pub u8);
 impl EmergencyServiceTargetCN {
@@ -1636,7 +1635,7 @@ impl EmergencyServiceTargetCN {
     pub const EPC: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct EndIndication(pub u8);
 impl EndIndication {
@@ -1644,7 +1643,7 @@ impl EndIndication {
     pub const FURTHER_DATA_EXISTS: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct EndpointIPAddressAndPort {
     pub endpoint_ip_address: TransportLayerAddress,
@@ -1653,24 +1652,24 @@ pub struct EndpointIPAddressAndPort {
     pub ie_extensions: Option<EndpointIPAddressAndPortIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Enhanced_CoverageRestriction(pub u8);
 impl Enhanced_CoverageRestriction {
     pub const RESTRICTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "15")]
 pub struct EquivalentPLMNs(pub Vec<PLMNIdentity>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct ErrorIndication {
     pub protocol_i_es: ErrorIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct EventL1LoggedMDTConfig {
     pub l1_threshold: MeasurementThresholdL1LoggedMDT,
@@ -1680,7 +1679,7 @@ pub struct EventL1LoggedMDTConfig {
     pub ie_extensions: Option<EventL1LoggedMDTConfigIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum EventTrigger {
     #[asn(key = 0, extended = false)]
@@ -1691,7 +1690,7 @@ pub enum EventTrigger {
     Choice_Extensions(EventTriggerchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct EventType(pub u8);
 impl EventType {
@@ -1703,11 +1702,11 @@ impl EventType {
     pub const CANCEL_LOCATION_REPORTING_FOR_THE_UE: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "30", extensible = true)]
 pub struct ExpectedActivityPeriod(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "6")]
 pub struct ExpectedHOInterval(pub u8);
 impl ExpectedHOInterval {
@@ -1720,11 +1719,11 @@ impl ExpectedHOInterval {
     pub const LONG_TIME: u8 = 6u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "30", extensible = true)]
 pub struct ExpectedIdlePeriod(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct ExpectedUEActivityBehaviour {
     #[asn(optional_idx = 0)]
@@ -1737,7 +1736,7 @@ pub struct ExpectedUEActivityBehaviour {
     pub ie_extensions: Option<ExpectedUEActivityBehaviourIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct ExpectedUEBehaviour {
     #[asn(optional_idx = 0)]
@@ -1752,7 +1751,7 @@ pub struct ExpectedUEBehaviour {
     pub ie_extensions: Option<ExpectedUEBehaviourIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ExpectedUEMobility(pub u8);
 impl ExpectedUEMobility {
@@ -1760,11 +1759,11 @@ impl ExpectedUEMobility {
     pub const MOBILE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ExpectedUEMovingTrajectory(pub Vec<ExpectedUEMovingTrajectoryItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct ExpectedUEMovingTrajectoryItem {
     pub ngran_cgi: NGRAN_CGI,
@@ -1774,7 +1773,7 @@ pub struct ExpectedUEMovingTrajectoryItem {
     pub ie_extensions: Option<ExpectedUEMovingTrajectoryItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct Extended_AMFName {
     #[asn(optional_idx = 0)]
@@ -1785,11 +1784,11 @@ pub struct Extended_AMFName {
     pub ie_extensions: Option<Extended_AMFNameIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct Extended_ConnectedTime(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct Extended_RANNodeName {
     #[asn(optional_idx = 0)]
@@ -1800,11 +1799,11 @@ pub struct Extended_RANNodeName {
     pub ie_extensions: Option<Extended_RANNodeNameIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "65535", extensible = true)]
 pub struct ExtendedPacketDelayBudget(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ExtendedRATRestrictionInformation {
     pub primary_rat_restriction: BIT_STRING_24,
@@ -1813,11 +1812,11 @@ pub struct ExtendedRATRestrictionInformation {
     pub ie_extensions: Option<ExtendedRATRestrictionInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "4096", ub = "65535")]
 pub struct ExtendedRNC_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1826,11 +1825,11 @@ pub struct ExtendedRNC_ID(pub u16);
 )]
 pub struct ExtendedSliceSupportList(pub Vec<SliceSupportItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct ExtendedUEIdentityIndexValue(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct FailureIndication {
     pub uerlf_report_container: UERLFReportContainer,
@@ -1838,7 +1837,7 @@ pub struct FailureIndication {
     pub ie_extensions: Option<FailureIndicationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct FirstDLCount {
     pub dr_bs_subject_to_early_status_transfer: DRBsSubjectToEarlyStatusTransfer_List,
@@ -1846,7 +1845,7 @@ pub struct FirstDLCount {
     pub ie_extension: Option<FirstDLCountIE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct FiveG_S_TMSI {
     pub amf_set_id: AMFSetID,
@@ -1856,19 +1855,19 @@ pub struct FiveG_S_TMSI {
     pub ie_extensions: Option<FiveG_S_TMSIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct FiveG_TMSI(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255", extensible = true)]
 pub struct FiveQI(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ForbiddenAreaInformation(pub Vec<ForbiddenAreaInformation_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct ForbiddenAreaInformation_Item {
     pub plmn_identity: PLMNIdentity,
@@ -1877,7 +1876,7 @@ pub struct ForbiddenAreaInformation_Item {
     pub ie_extensions: Option<ForbiddenAreaInformation_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -1886,7 +1885,7 @@ pub struct ForbiddenAreaInformation_Item {
 )]
 pub struct ForbiddenTACs(pub Vec<TAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct FromEUTRANtoNGRAN {
     pub sourcee_nbid: IntersystemSONeNBID,
@@ -1895,7 +1894,7 @@ pub struct FromEUTRANtoNGRAN {
     pub ie_extensions: Option<FromEUTRANtoNGRANIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 1)]
 pub struct FromNGRANtoEUTRAN {
     pub source_ngra_nnode_id: IntersystemSONNGRANnodeID,
@@ -1904,7 +1903,7 @@ pub struct FromNGRANtoEUTRAN {
     pub ie_extensions: Option<FromNGRANtoEUTRANIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct GBR_QosInformation {
     pub maximum_flow_bit_rate_dl: BitRate,
@@ -1921,7 +1920,7 @@ pub struct GBR_QosInformation {
     pub ie_extensions: Option<GBR_QosInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum GNB_ID {
     #[asn(key = 0, extended = false)]
@@ -1930,15 +1929,15 @@ pub enum GNB_ID {
     Choice_Extensions(GNB_IDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "22", sz_ub = "22")]
 pub struct GNBSetID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct GTP_TEID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GTPTunnel {
     pub transport_layer_address: TransportLayerAddress,
@@ -1947,7 +1946,7 @@ pub struct GTPTunnel {
     pub ie_extensions: Option<GTPTunnelIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GUAMI {
     pub plmn_identity: PLMNIdentity,
@@ -1958,7 +1957,7 @@ pub struct GUAMI {
     pub ie_extensions: Option<GUAMIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct GUAMIType(pub u8);
 impl GUAMIType {
@@ -1966,11 +1965,11 @@ impl GUAMIType {
     pub const MAPPED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct GlobalCable_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GlobalENB_ID {
     pub plm_nidentity: PLMNIdentity,
@@ -1979,7 +1978,7 @@ pub struct GlobalENB_ID {
     pub ie_extensions: Option<GlobalENB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GlobalGNB_ID {
     pub plmn_identity: PLMNIdentity,
@@ -1988,7 +1987,7 @@ pub struct GlobalGNB_ID {
     pub ie_extensions: Option<GlobalGNB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct GlobalLine_ID {
     pub global_line_identity: GlobalLineIdentity,
@@ -1998,11 +1997,11 @@ pub struct GlobalLine_ID {
     pub ie_extensions: Option<GlobalLine_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct GlobalLineIdentity(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GlobalN3IWF_ID {
     pub plmn_identity: PLMNIdentity,
@@ -2011,7 +2010,7 @@ pub struct GlobalN3IWF_ID {
     pub ie_extensions: Option<GlobalN3IWF_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GlobalNgENB_ID {
     pub plmn_identity: PLMNIdentity,
@@ -2020,7 +2019,7 @@ pub struct GlobalNgENB_ID {
     pub ie_extensions: Option<GlobalNgENB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = false)]
 pub enum GlobalRANNodeID {
     #[asn(key = 0, extended = false)]
@@ -2033,7 +2032,7 @@ pub enum GlobalRANNodeID {
     Choice_Extensions(GlobalRANNodeIDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GlobalTNGF_ID {
     pub plmn_identity: PLMNIdentity,
@@ -2042,7 +2041,7 @@ pub struct GlobalTNGF_ID {
     pub ie_extensions: Option<GlobalTNGF_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GlobalTWIF_ID {
     pub plmn_identity: PLMNIdentity,
@@ -2051,7 +2050,7 @@ pub struct GlobalTWIF_ID {
     pub ie_extensions: Option<GlobalTWIF_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct GlobalW_AGF_ID {
     pub plmn_identity: PLMNIdentity,
@@ -2060,11 +2059,11 @@ pub struct GlobalW_AGF_ID {
     pub ie_extensions: Option<GlobalW_AGF_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct HFCNode_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 6)]
 pub struct HOReport {
     pub handover_report_type: ENUMERATED_27,
@@ -2085,25 +2084,25 @@ pub struct HOReport {
     pub ie_extensions: Option<HOReportIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverCancel {
     pub protocol_i_es: HandoverCancelProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverCancelAcknowledge {
     pub protocol_i_es: HandoverCancelAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverCommand {
     pub protocol_i_es: HandoverCommandProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct HandoverCommandTransfer {
     #[asn(optional_idx = 0)]
@@ -2116,32 +2115,32 @@ pub struct HandoverCommandTransfer {
     pub ie_extensions: Option<HandoverCommandTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverFailure {
     pub protocol_i_es: HandoverFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct HandoverFlag(pub u8);
 impl HandoverFlag {
     pub const HANDOVER_PREPARATION: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverNotify {
     pub protocol_i_es: HandoverNotifyProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverPreparationFailure {
     pub protocol_i_es: HandoverPreparationFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct HandoverPreparationUnsuccessfulTransfer {
     pub cause: Cause,
@@ -2149,19 +2148,19 @@ pub struct HandoverPreparationUnsuccessfulTransfer {
     pub ie_extensions: Option<HandoverPreparationUnsuccessfulTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverRequest {
     pub protocol_i_es: HandoverRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverRequestAcknowledge {
     pub protocol_i_es: HandoverRequestAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct HandoverRequestAcknowledgeTransfer {
     pub dl_ngu_up_tnl_information: UPTransportLayerInformation,
@@ -2178,13 +2177,13 @@ pub struct HandoverRequestAcknowledgeTransfer {
     pub ie_extensions: Option<HandoverRequestAcknowledgeTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverRequired {
     pub protocol_i_es: HandoverRequiredProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct HandoverRequiredTransfer {
     #[asn(optional_idx = 0)]
@@ -2193,7 +2192,7 @@ pub struct HandoverRequiredTransfer {
     pub ie_extensions: Option<HandoverRequiredTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct HandoverResourceAllocationUnsuccessfulTransfer {
     pub cause: Cause,
@@ -2203,13 +2202,13 @@ pub struct HandoverResourceAllocationUnsuccessfulTransfer {
     pub ie_extensions: Option<HandoverResourceAllocationUnsuccessfulTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct HandoverSuccess {
     pub protocol_i_es: HandoverSuccessProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct HandoverType(pub u8);
 impl HandoverType {
@@ -2218,11 +2217,11 @@ impl HandoverType {
     pub const EPS_TO_5GS: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "30")]
 pub struct Hysteresis(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct IAB_Authorized(pub u8);
 impl IAB_Authorized {
@@ -2230,21 +2229,21 @@ impl IAB_Authorized {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct IAB_Supported(pub u8);
 impl IAB_Supported {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct IABNodeIndication(pub u8);
 impl IABNodeIndication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct IMSVoiceSupportIndicator(pub u8);
 impl IMSVoiceSupportIndicator {
@@ -2252,7 +2251,7 @@ impl IMSVoiceSupportIndicator {
     pub const NOT_SUPPORTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 10)]
 pub struct ImmediateMDTNr {
     pub measurements_to_activate: MeasurementsToActivate,
@@ -2278,11 +2277,11 @@ pub struct ImmediateMDTNr {
     pub ie_extensions: Option<ImmediateMDTNrIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "256", extensible = true)]
 pub struct IndexToRFSP(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InfoOnRecommendedCellsAndRANNodesForPaging {
     pub recommended_cells_for_paging: RecommendedCellsForPaging,
@@ -2291,31 +2290,31 @@ pub struct InfoOnRecommendedCellsAndRANNodesForPaging {
     pub ie_extensions: Option<InfoOnRecommendedCellsAndRANNodesForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialContextSetupFailure {
     pub protocol_i_es: InitialContextSetupFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialContextSetupRequest {
     pub protocol_i_es: InitialContextSetupRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialContextSetupResponse {
     pub protocol_i_es: InitialContextSetupResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct InitialUEMessage {
     pub protocol_i_es: InitialUEMessageProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitiatingMessage {
     #[asn(key_field = true)]
@@ -2324,7 +2323,7 @@ pub struct InitiatingMessage {
     pub value: InitiatingMessageValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct IntegrityProtectionIndication(pub u8);
 impl IntegrityProtectionIndication {
@@ -2333,7 +2332,7 @@ impl IntegrityProtectionIndication {
     pub const NOT_NEEDED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct IntegrityProtectionResult(pub u8);
 impl IntegrityProtectionResult {
@@ -2341,11 +2340,11 @@ impl IntegrityProtectionResult {
     pub const NOT_PERFORMED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "16", extensible = true)]
 pub struct IntendedNumberOfPagingAttempts(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct InterSystemFailureIndication {
     #[asn(optional_idx = 0)]
@@ -2354,7 +2353,7 @@ pub struct InterSystemFailureIndication {
     pub ie_extensions: Option<InterSystemFailureIndicationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct InterSystemHOReport {
     pub handover_report_type: InterSystemHandoverReportType,
@@ -2362,7 +2361,7 @@ pub struct InterSystemHOReport {
     pub ie_extensions: Option<InterSystemHOReportIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum InterSystemHandoverReportType {
     #[asn(key = 0, extended = false)]
@@ -2373,11 +2372,11 @@ pub enum InterSystemHandoverReportType {
     Choice_Extensions(InterSystemHandoverReportTypechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct InterfacesToTrace(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct IntersystemSONConfigurationTransfer {
     pub transfer_type: IntersystemSONTransferType,
@@ -2386,7 +2385,7 @@ pub struct IntersystemSONConfigurationTransfer {
     pub ie_extensions: Option<IntersystemSONConfigurationTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum IntersystemSONInformation {
     #[asn(key = 0, extended = false)]
@@ -2395,7 +2394,7 @@ pub enum IntersystemSONInformation {
     Choice_Extensions(IntersystemSONInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum IntersystemSONInformationReport {
     #[asn(key = 0, extended = false)]
@@ -2406,7 +2405,7 @@ pub enum IntersystemSONInformationReport {
     Choice_Extensions(IntersystemSONInformationReportchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct IntersystemSONNGRANnodeID {
     pub global_ran_node_id: GlobalRANNodeID,
@@ -2415,7 +2414,7 @@ pub struct IntersystemSONNGRANnodeID {
     pub ie_extensions: Option<IntersystemSONNGRANnodeIDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum IntersystemSONTransferType {
     #[asn(key = 0, extended = false)]
@@ -2426,7 +2425,7 @@ pub enum IntersystemSONTransferType {
     Choice_Extensions(IntersystemSONTransferTypechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct IntersystemSONeNBID {
     pub globale_nbid: GlobalENB_ID,
@@ -2435,7 +2434,7 @@ pub struct IntersystemSONeNBID {
     pub ie_extensions: Option<IntersystemSONeNBIDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct IntersystemUnnecessaryHO {
     pub sourcecell_id: NGRAN_CGI,
@@ -2446,11 +2445,11 @@ pub struct IntersystemUnnecessaryHO {
     pub ie_extensions: Option<IntersystemUnnecessaryHOIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct LAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LAI {
     pub plm_nidentity: PLMNIdentity,
@@ -2459,18 +2458,18 @@ pub struct LAI {
     pub ie_extensions: Option<LAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct LTEM_Indication(pub u8);
 impl LTEM_Indication {
     pub const LTE_M: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct LTEUERLFReportContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LTEUESidelinkAggregateMaximumBitrate {
     pub ue_sidelink_aggregate_maximum_bit_rate: BitRate,
@@ -2478,7 +2477,7 @@ pub struct LTEUESidelinkAggregateMaximumBitrate {
     pub ie_extensions: Option<LTEUESidelinkAggregateMaximumBitrateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct LTEV2XServicesAuthorized {
     #[asn(optional_idx = 0)]
@@ -2489,7 +2488,7 @@ pub struct LTEV2XServicesAuthorized {
     pub ie_extensions: Option<LTEV2XServicesAuthorizedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "4", extensible = false)]
 pub enum LastVisitedCellInformation {
     #[asn(key = 0, extended = false)]
@@ -2504,7 +2503,7 @@ pub enum LastVisitedCellInformation {
     Choice_Extensions(LastVisitedCellInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct LastVisitedCellItem {
     pub last_visited_cell_information: LastVisitedCellInformation,
@@ -2512,15 +2511,15 @@ pub struct LastVisitedCellItem {
     pub ie_extensions: Option<LastVisitedCellItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct LastVisitedEUTRANCellInformation(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct LastVisitedGERANCellInformation(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct LastVisitedNGRANCellInformation {
     pub global_cell_id: NGRAN_CGI,
@@ -2534,11 +2533,11 @@ pub struct LastVisitedNGRANCellInformation {
     pub ie_extensions: Option<LastVisitedNGRANCellInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct LastVisitedUTRANCellInformation(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct LineType(pub u8);
 impl LineType {
@@ -2546,7 +2545,7 @@ impl LineType {
     pub const PON: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct Links_to_log(pub u8);
 impl Links_to_log {
@@ -2555,36 +2554,36 @@ impl Links_to_log {
     pub const BOTH_UPLINK_AND_DOWNLINK: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct LocationReport {
     pub protocol_i_es: LocationReportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct LocationReportingAdditionalInfo(pub u8);
 impl LocationReportingAdditionalInfo {
     pub const INCLUDE_PS_CELL: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct LocationReportingControl {
     pub protocol_i_es: LocationReportingControlProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct LocationReportingFailureIndication {
     pub protocol_i_es: LocationReportingFailureIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "64", extensible = true)]
 pub struct LocationReportingReferenceID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct LocationReportingRequestType {
     pub event_type: EventType,
@@ -2597,7 +2596,7 @@ pub struct LocationReportingRequestType {
     pub ie_extensions: Option<LocationReportingRequestTypeIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct LoggedMDTNr {
     pub logging_interval: LoggingInterval,
@@ -2615,7 +2614,7 @@ pub struct LoggedMDTNr {
     pub ie_extensions: Option<LoggedMDTNrIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum LoggedMDTTrigger {
     #[asn(key = 0, extended = false)]
@@ -2626,7 +2625,7 @@ pub enum LoggedMDTTrigger {
     Choice_Extensions(LoggedMDTTriggerchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct LoggingDuration(pub u8);
 impl LoggingDuration {
@@ -2638,7 +2637,7 @@ impl LoggingDuration {
     pub const M120: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "10")]
 pub struct LoggingInterval(pub u8);
 impl LoggingInterval {
@@ -2655,7 +2654,7 @@ impl LoggingInterval {
     pub const INFINITY: u8 = 10u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct M1Configuration {
     pub m1reporting_trigger: M1ReportingTrigger,
@@ -2667,7 +2666,7 @@ pub struct M1Configuration {
     pub ie_extensions: Option<M1ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M1PeriodicReporting {
     pub report_interval: ReportIntervalMDT,
@@ -2676,7 +2675,7 @@ pub struct M1PeriodicReporting {
     pub ie_extensions: Option<M1PeriodicReportingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct M1ReportingTrigger(pub u8);
 impl M1ReportingTrigger {
@@ -2685,7 +2684,7 @@ impl M1ReportingTrigger {
     pub const A2EVENTTRIGGERED_PERIODIC: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M1ThresholdEventA2 {
     pub m1_threshold_type: M1ThresholdType,
@@ -2693,7 +2692,7 @@ pub struct M1ThresholdEventA2 {
     pub ie_extensions: Option<M1ThresholdEventA2IE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = false)]
 pub enum M1ThresholdType {
     #[asn(key = 0, extended = false)]
@@ -2706,7 +2705,7 @@ pub enum M1ThresholdType {
     Choice_Extensions(M1ThresholdTypechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M4Configuration {
     pub m4period: M4period,
@@ -2715,7 +2714,7 @@ pub struct M4Configuration {
     pub ie_extensions: Option<M4ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct M4period(pub u8);
 impl M4period {
@@ -2726,7 +2725,7 @@ impl M4period {
     pub const MIN1: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M5Configuration {
     pub m5period: M5period,
@@ -2735,7 +2734,7 @@ pub struct M5Configuration {
     pub ie_extensions: Option<M5ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct M5period(pub u8);
 impl M5period {
@@ -2746,7 +2745,7 @@ impl M5period {
     pub const MIN1: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M6Configuration {
     pub m6report_interval: M6report_Interval,
@@ -2755,7 +2754,7 @@ pub struct M6Configuration {
     pub ie_extensions: Option<M6ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "13")]
 pub struct M6report_Interval(pub u8);
 impl M6report_Interval {
@@ -2775,7 +2774,7 @@ impl M6report_Interval {
     pub const MIN30: u8 = 13u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct M7Configuration {
     pub m7period: M7period,
@@ -2784,11 +2783,11 @@ pub struct M7Configuration {
     pub ie_extensions: Option<M7ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "60", extensible = true)]
 pub struct M7period(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct MDT_Activation(pub u8);
 impl MDT_Activation {
@@ -2797,7 +2796,7 @@ impl MDT_Activation {
     pub const IMMEDIATE_MDT_AND_TRACE: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct MDT_Configuration {
     #[asn(optional_idx = 0)]
@@ -2808,7 +2807,7 @@ pub struct MDT_Configuration {
     pub ie_extensions: Option<MDT_ConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct MDT_Configuration_EUTRA {
     pub mdt_activation: MDT_Activation,
@@ -2820,7 +2819,7 @@ pub struct MDT_Configuration_EUTRA {
     pub ie_extensions: Option<MDT_Configuration_EUTRAIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct MDT_Configuration_NR {
     pub mdt_activation: MDT_Activation,
@@ -2832,7 +2831,7 @@ pub struct MDT_Configuration_NR {
     pub ie_extensions: Option<MDT_Configuration_NRIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct MDT_Location_Info {
     pub mdt_location_information: MDT_Location_Information,
@@ -2840,15 +2839,15 @@ pub struct MDT_Location_Info {
     pub ie_extensions: Option<MDT_Location_InfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct MDT_Location_Information(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct MDTModeEutra(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum MDTModeNr {
     #[asn(key = 0, extended = false)]
@@ -2859,26 +2858,26 @@ pub enum MDTModeNr {
     Choice_Extensions(MDTModeNrchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct MDTPLMNList(pub Vec<PLMNIdentity>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct MICOModeIndication(pub u8);
 impl MICOModeIndication {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "64", sz_ub = "64")]
 pub struct MaskedIMEISV(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095", extensible = true)]
 pub struct MaximumDataBurstVolume(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct MaximumIntegrityProtectedDataRate(pub u8);
 impl MaximumIntegrityProtectedDataRate {
@@ -2886,7 +2885,7 @@ impl MaximumIntegrityProtectedDataRate {
     pub const MAXIMUM_UE_RATE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum MeasurementThresholdL1LoggedMDT {
     #[asn(key = 0, extended = false)]
@@ -2897,19 +2896,19 @@ pub enum MeasurementThresholdL1LoggedMDT {
     Choice_Extensions(MeasurementThresholdL1LoggedMDTchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct MeasurementsToActivate(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct MessageIdentifier(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct MobilityInformation(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 5)]
 pub struct MobilityRestrictionList {
     pub serving_plmn: PLMNIdentity,
@@ -2925,7 +2924,7 @@ pub struct MobilityRestrictionList {
     pub ie_extensions: Option<MobilityRestrictionListIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum N3IWF_ID {
     #[asn(key = 0, extended = false)]
@@ -2934,21 +2933,21 @@ pub enum N3IWF_ID {
     Choice_Extensions(N3IWF_IDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NAS_PDU(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NASNonDeliveryIndication {
     pub protocol_i_es: NASNonDeliveryIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NASSecurityParametersFromNGRAN(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct NB_IoT_DefaultPagingDRX(pub u8);
 impl NB_IoT_DefaultPagingDRX {
@@ -2958,7 +2957,7 @@ impl NB_IoT_DefaultPagingDRX {
     pub const RF1024: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "15")]
 pub struct NB_IoT_Paging_TimeWindow(pub u8);
 impl NB_IoT_Paging_TimeWindow {
@@ -2980,7 +2979,7 @@ impl NB_IoT_Paging_TimeWindow {
     pub const S16: u8 = 15u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "13")]
 pub struct NB_IoT_Paging_eDRXCycle(pub u8);
 impl NB_IoT_Paging_eDRXCycle {
@@ -3000,7 +2999,7 @@ impl NB_IoT_Paging_eDRXCycle {
     pub const HF1024: u8 = 13u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct NB_IoT_Paging_eDRXInfo {
     pub nb_io_t_paging_e_drx_cycle: NB_IoT_Paging_eDRXCycle,
@@ -3010,7 +3009,7 @@ pub struct NB_IoT_Paging_eDRXInfo {
     pub ie_extensions: Option<NB_IoT_Paging_eDRXInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct NB_IoT_PagingDRX(pub u8);
 impl NB_IoT_PagingDRX {
@@ -3022,11 +3021,11 @@ impl NB_IoT_PagingDRX {
     pub const RF1024: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255", extensible = true)]
 pub struct NB_IoT_UEPriority(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = true)]
 pub enum NGAP_PDU {
     #[asn(key = 0, extended = false)]
@@ -3037,7 +3036,7 @@ pub enum NGAP_PDU {
     UnsuccessfulOutcome(UnsuccessfulOutcome),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum NGRAN_CGI {
     #[asn(key = 0, extended = false)]
@@ -3048,7 +3047,7 @@ pub enum NGRAN_CGI {
     Choice_Extensions(NGRAN_CGIchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false, optional_fields = 2)]
 pub struct NGRAN_TNLAssociationToRemoveItem {
     pub tnl_association_transport_layer_address: CPTransportLayerInformation,
@@ -3058,49 +3057,49 @@ pub struct NGRAN_TNLAssociationToRemoveItem {
     pub ie_extensions: Option<NGRAN_TNLAssociationToRemoveItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct NGRAN_TNLAssociationToRemoveList(pub Vec<NGRAN_TNLAssociationToRemoveItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct NGRANTraceID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NGReset {
     pub protocol_i_es: NGResetProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NGResetAcknowledge {
     pub protocol_i_es: NGResetAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NGSetupFailure {
     pub protocol_i_es: NGSetupFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NGSetupRequest {
     pub protocol_i_es: NGSetupRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct NGSetupResponse {
     pub protocol_i_es: NGSetupResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "44", sz_ub = "44")]
 pub struct NID(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum NPN_AccessInformation {
     #[asn(key = 0, extended = false)]
@@ -3109,7 +3108,7 @@ pub enum NPN_AccessInformation {
     Choice_Extensions(NPN_AccessInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum NPN_MobilityInformation {
     #[asn(key = 0, extended = false)]
@@ -3120,7 +3119,7 @@ pub enum NPN_MobilityInformation {
     Choice_Extensions(NPN_MobilityInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum NPN_PagingAssistanceInformation {
     #[asn(key = 0, extended = false)]
@@ -3129,7 +3128,7 @@ pub enum NPN_PagingAssistanceInformation {
     Choice_Extensions(NPN_PagingAssistanceInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum NPN_Support {
     #[asn(key = 0, extended = false)]
@@ -3138,7 +3137,7 @@ pub enum NPN_Support {
     Choice_Extensions(NPN_Supportchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NR_CGI {
     pub plmn_identity: PLMNIdentity,
@@ -3147,7 +3146,7 @@ pub struct NR_CGI {
     pub ie_extensions: Option<NR_CGIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3156,7 +3155,7 @@ pub struct NR_CGI {
 )]
 pub struct NR_CGIList(pub Vec<NR_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3165,27 +3164,27 @@ pub struct NR_CGIList(pub Vec<NR_CGI>);
 )]
 pub struct NR_CGIListForWarning(pub Vec<NR_CGI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1007", extensible = true)]
 pub struct NR_PCI(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "3279165")]
 pub struct NRARFCN(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "36", sz_ub = "36")]
 pub struct NRCellIdentity(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "1024", extensible = true)]
 pub struct NRFrequencyBand(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct NRFrequencyBand_List(pub Vec<NRFrequencyBandItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NRFrequencyBandItem {
     pub nr_frequency_band: NRFrequencyBand,
@@ -3193,7 +3192,7 @@ pub struct NRFrequencyBandItem {
     pub ie_extension: Option<NRFrequencyBandItemIE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NRFrequencyInfo {
     pub nr_arfcn: NRARFCN,
@@ -3202,19 +3201,19 @@ pub struct NRFrequencyInfo {
     pub ie_extension: Option<NRFrequencyInfoIE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NRMobilityHistoryReport(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NRPPa_PDU(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct NRUERLFReportContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct NRUESidelinkAggregateMaximumBitrate {
     pub ue_sidelink_aggregate_maximum_bit_rate: BitRate,
@@ -3222,7 +3221,7 @@ pub struct NRUESidelinkAggregateMaximumBitrate {
     pub ie_extensions: Option<NRUESidelinkAggregateMaximumBitrateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct NRV2XServicesAuthorized {
     #[asn(optional_idx = 0)]
@@ -3233,30 +3232,30 @@ pub struct NRV2XServicesAuthorized {
     pub ie_extensions: Option<NRV2XServicesAuthorizedIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct NRencryptionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct NRintegrityProtectionAlgorithms(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "256", extensible = true)]
 pub struct NetworkInstance(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct NewSecurityContextInd(pub u8);
 impl NewSecurityContextInd {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "7")]
 pub struct NextHopChainingCount(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct NextPagingAreaScope(pub u8);
 impl NextPagingAreaScope {
@@ -3264,7 +3263,7 @@ impl NextPagingAreaScope {
     pub const CHANGED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = false)]
 pub enum NgENB_ID {
     #[asn(key = 0, extended = false)]
@@ -3277,7 +3276,7 @@ pub enum NgENB_ID {
     Choice_Extensions(NgENB_IDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct NonDynamic5QIDescriptor {
     pub five_qi: FiveQI,
@@ -3291,11 +3290,11 @@ pub struct NonDynamic5QIDescriptor {
     pub ie_extensions: Option<NonDynamic5QIDescriptorIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct NotAllowedTACs(pub Vec<TAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct NotificationCause(pub u8);
 impl NotificationCause {
@@ -3303,29 +3302,29 @@ impl NotificationCause {
     pub const NOT_FULFILLED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct NotificationControl(pub u8);
 impl NotificationControl {
     pub const NOTIFICATION_REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct NotifySourceNGRANNode(pub u8);
 impl NotifySourceNGRANNode {
     pub const NOTIFY_SOURCE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct NumberOfBroadcasts(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct NumberOfBroadcastsRequested(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct OverloadAction(pub u8);
 impl OverloadAction {
@@ -3335,7 +3334,7 @@ impl OverloadAction {
     pub const PERMIT_HIGH_PRIORITY_SESSIONS_AND_MOBILE_TERMINATED_SERVICES_ONLY: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum OverloadResponse {
     #[asn(key = 0, extended = false)]
@@ -3344,13 +3343,13 @@ pub enum OverloadResponse {
     Choice_Extensions(OverloadResponsechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct OverloadStart {
     pub protocol_i_es: OverloadStartProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct OverloadStartNSSAIItem {
     pub slice_overload_list: SliceOverloadList,
@@ -3362,7 +3361,7 @@ pub struct OverloadStartNSSAIItem {
     pub ie_extensions: Option<OverloadStartNSSAIItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3371,13 +3370,13 @@ pub struct OverloadStartNSSAIItem {
 )]
 pub struct OverloadStartNSSAIList(pub Vec<OverloadStartNSSAIItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct OverloadStop {
     pub protocol_i_es: OverloadStopProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PC5FlowBitRates {
     pub guaranteed_flow_bit_rate: BitRate,
@@ -3386,7 +3385,7 @@ pub struct PC5FlowBitRates {
     pub ie_extensions: Option<PC5FlowBitRatesIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct PC5QoSFlowItem {
     pub pqi: FiveQI,
@@ -3398,7 +3397,7 @@ pub struct PC5QoSFlowItem {
     pub ie_extensions: Option<PC5QoSFlowItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3407,7 +3406,7 @@ pub struct PC5QoSFlowItem {
 )]
 pub struct PC5QoSFlowList(pub Vec<PC5QoSFlowItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PC5QoSParameters {
     pub pc5_qo_s_flow_list: PC5QoSFlowList,
@@ -3417,11 +3416,11 @@ pub struct PC5QoSParameters {
     pub ie_extensions: Option<PC5QoSParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct PCIListForMDT(pub Vec<NR_PCI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionAggregateMaximumBitRate {
     pub pdu_session_aggregate_maximum_bit_rate_dl: BitRate,
@@ -3430,11 +3429,11 @@ pub struct PDUSessionAggregateMaximumBitRate {
     pub ie_extensions: Option<PDUSessionAggregateMaximumBitRateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct PDUSessionID(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceAdmittedItem {
     pub pdu_session_id: PDUSessionID,
@@ -3443,7 +3442,7 @@ pub struct PDUSessionResourceAdmittedItem {
     pub ie_extensions: Option<PDUSessionResourceAdmittedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3452,7 +3451,7 @@ pub struct PDUSessionResourceAdmittedItem {
 )]
 pub struct PDUSessionResourceAdmittedList(pub Vec<PDUSessionResourceAdmittedItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToModifyItemModCfm {
     pub pdu_session_id: PDUSessionID,
@@ -3461,7 +3460,7 @@ pub struct PDUSessionResourceFailedToModifyItemModCfm {
     pub ie_extensions: Option<PDUSessionResourceFailedToModifyItemModCfmIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToModifyItemModRes {
     pub pdu_session_id: PDUSessionID,
@@ -3470,7 +3469,7 @@ pub struct PDUSessionResourceFailedToModifyItemModRes {
     pub ie_extensions: Option<PDUSessionResourceFailedToModifyItemModResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3481,7 +3480,7 @@ pub struct PDUSessionResourceFailedToModifyListModCfm(
     pub Vec<PDUSessionResourceFailedToModifyItemModCfm>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3492,7 +3491,7 @@ pub struct PDUSessionResourceFailedToModifyListModRes(
     pub Vec<PDUSessionResourceFailedToModifyItemModRes>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToResumeItemRESReq {
     pub pdu_session_id: PDUSessionID,
@@ -3501,7 +3500,7 @@ pub struct PDUSessionResourceFailedToResumeItemRESReq {
     pub ie_extensions: Option<PDUSessionResourceFailedToResumeItemRESReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToResumeItemRESRes {
     pub pdu_session_id: PDUSessionID,
@@ -3510,7 +3509,7 @@ pub struct PDUSessionResourceFailedToResumeItemRESRes {
     pub ie_extensions: Option<PDUSessionResourceFailedToResumeItemRESResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3521,7 +3520,7 @@ pub struct PDUSessionResourceFailedToResumeListRESReq(
     pub Vec<PDUSessionResourceFailedToResumeItemRESReq>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3532,7 +3531,7 @@ pub struct PDUSessionResourceFailedToResumeListRESRes(
     pub Vec<PDUSessionResourceFailedToResumeItemRESRes>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToSetupItemCxtFail {
     pub pdu_session_id: PDUSessionID,
@@ -3541,7 +3540,7 @@ pub struct PDUSessionResourceFailedToSetupItemCxtFail {
     pub ie_extensions: Option<PDUSessionResourceFailedToSetupItemCxtFailIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToSetupItemCxtRes {
     pub pdu_session_id: PDUSessionID,
@@ -3550,7 +3549,7 @@ pub struct PDUSessionResourceFailedToSetupItemCxtRes {
     pub ie_extensions: Option<PDUSessionResourceFailedToSetupItemCxtResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToSetupItemHOAck {
     pub pdu_session_id: PDUSessionID,
@@ -3559,7 +3558,7 @@ pub struct PDUSessionResourceFailedToSetupItemHOAck {
     pub ie_extensions: Option<PDUSessionResourceFailedToSetupItemHOAckIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToSetupItemPSReq {
     pub pdu_session_id: PDUSessionID,
@@ -3568,7 +3567,7 @@ pub struct PDUSessionResourceFailedToSetupItemPSReq {
     pub ie_extensions: Option<PDUSessionResourceFailedToSetupItemPSReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceFailedToSetupItemSURes {
     pub pdu_session_id: PDUSessionID,
@@ -3577,7 +3576,7 @@ pub struct PDUSessionResourceFailedToSetupItemSURes {
     pub ie_extensions: Option<PDUSessionResourceFailedToSetupItemSUResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3588,7 +3587,7 @@ pub struct PDUSessionResourceFailedToSetupListCxtFail(
     pub Vec<PDUSessionResourceFailedToSetupItemCxtFail>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3599,7 +3598,7 @@ pub struct PDUSessionResourceFailedToSetupListCxtRes(
     pub Vec<PDUSessionResourceFailedToSetupItemCxtRes>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3610,7 +3609,7 @@ pub struct PDUSessionResourceFailedToSetupListHOAck(
     pub Vec<PDUSessionResourceFailedToSetupItemHOAck>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3621,7 +3620,7 @@ pub struct PDUSessionResourceFailedToSetupListPSReq(
     pub Vec<PDUSessionResourceFailedToSetupItemPSReq>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3632,7 +3631,7 @@ pub struct PDUSessionResourceFailedToSetupListSURes(
     pub Vec<PDUSessionResourceFailedToSetupItemSURes>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceHandoverItem {
     pub pdu_session_id: PDUSessionID,
@@ -3641,7 +3640,7 @@ pub struct PDUSessionResourceHandoverItem {
     pub ie_extensions: Option<PDUSessionResourceHandoverItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3650,7 +3649,7 @@ pub struct PDUSessionResourceHandoverItem {
 )]
 pub struct PDUSessionResourceHandoverList(pub Vec<PDUSessionResourceHandoverItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PDUSessionResourceInformationItem {
     pub pdu_session_id: PDUSessionID,
@@ -3661,7 +3660,7 @@ pub struct PDUSessionResourceInformationItem {
     pub ie_extensions: Option<PDUSessionResourceInformationItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3670,7 +3669,7 @@ pub struct PDUSessionResourceInformationItem {
 )]
 pub struct PDUSessionResourceInformationList(pub Vec<PDUSessionResourceInformationItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceItemCxtRelCpl {
     pub pdu_session_id: PDUSessionID,
@@ -3678,7 +3677,7 @@ pub struct PDUSessionResourceItemCxtRelCpl {
     pub ie_extensions: Option<PDUSessionResourceItemCxtRelCplIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceItemCxtRelReq {
     pub pdu_session_id: PDUSessionID,
@@ -3686,7 +3685,7 @@ pub struct PDUSessionResourceItemCxtRelReq {
     pub ie_extensions: Option<PDUSessionResourceItemCxtRelReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceItemHORqd {
     pub pdu_session_id: PDUSessionID,
@@ -3695,7 +3694,7 @@ pub struct PDUSessionResourceItemHORqd {
     pub ie_extensions: Option<PDUSessionResourceItemHORqdIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3704,7 +3703,7 @@ pub struct PDUSessionResourceItemHORqd {
 )]
 pub struct PDUSessionResourceListCxtRelCpl(pub Vec<PDUSessionResourceItemCxtRelCpl>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3713,7 +3712,7 @@ pub struct PDUSessionResourceListCxtRelCpl(pub Vec<PDUSessionResourceItemCxtRelC
 )]
 pub struct PDUSessionResourceListCxtRelReq(pub Vec<PDUSessionResourceItemCxtRelReq>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3722,13 +3721,13 @@ pub struct PDUSessionResourceListCxtRelReq(pub Vec<PDUSessionResourceItemCxtRelR
 )]
 pub struct PDUSessionResourceListHORqd(pub Vec<PDUSessionResourceItemHORqd>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceModifyConfirm {
     pub protocol_i_es: PDUSessionResourceModifyConfirmProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct PDUSessionResourceModifyConfirmTransfer {
     pub qos_flow_modify_confirm_list: QosFlowModifyConfirmList,
@@ -3741,13 +3740,13 @@ pub struct PDUSessionResourceModifyConfirmTransfer {
     pub ie_extensions: Option<PDUSessionResourceModifyConfirmTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceModifyIndication {
     pub protocol_i_es: PDUSessionResourceModifyIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PDUSessionResourceModifyIndicationTransfer {
     pub dl_qos_flow_per_tnl_information: QosFlowPerTNLInformation,
@@ -3757,7 +3756,7 @@ pub struct PDUSessionResourceModifyIndicationTransfer {
     pub ie_extensions: Option<PDUSessionResourceModifyIndicationTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceModifyIndicationUnsuccessfulTransfer {
     pub cause: Cause,
@@ -3765,7 +3764,7 @@ pub struct PDUSessionResourceModifyIndicationUnsuccessfulTransfer {
     pub ie_extensions: Option<PDUSessionResourceModifyIndicationUnsuccessfulTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceModifyItemModCfm {
     pub pdu_session_id: PDUSessionID,
@@ -3774,7 +3773,7 @@ pub struct PDUSessionResourceModifyItemModCfm {
     pub ie_extensions: Option<PDUSessionResourceModifyItemModCfmIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceModifyItemModInd {
     pub pdu_session_id: PDUSessionID,
@@ -3783,7 +3782,7 @@ pub struct PDUSessionResourceModifyItemModInd {
     pub ie_extensions: Option<PDUSessionResourceModifyItemModIndIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PDUSessionResourceModifyItemModReq {
     pub pdu_session_id: PDUSessionID,
@@ -3794,7 +3793,7 @@ pub struct PDUSessionResourceModifyItemModReq {
     pub ie_extensions: Option<PDUSessionResourceModifyItemModReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceModifyItemModRes {
     pub pdu_session_id: PDUSessionID,
@@ -3803,7 +3802,7 @@ pub struct PDUSessionResourceModifyItemModRes {
     pub ie_extensions: Option<PDUSessionResourceModifyItemModResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3812,7 +3811,7 @@ pub struct PDUSessionResourceModifyItemModRes {
 )]
 pub struct PDUSessionResourceModifyListModCfm(pub Vec<PDUSessionResourceModifyItemModCfm>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3821,7 +3820,7 @@ pub struct PDUSessionResourceModifyListModCfm(pub Vec<PDUSessionResourceModifyIt
 )]
 pub struct PDUSessionResourceModifyListModInd(pub Vec<PDUSessionResourceModifyItemModInd>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3830,7 +3829,7 @@ pub struct PDUSessionResourceModifyListModInd(pub Vec<PDUSessionResourceModifyIt
 )]
 pub struct PDUSessionResourceModifyListModReq(pub Vec<PDUSessionResourceModifyItemModReq>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3839,25 +3838,25 @@ pub struct PDUSessionResourceModifyListModReq(pub Vec<PDUSessionResourceModifyIt
 )]
 pub struct PDUSessionResourceModifyListModRes(pub Vec<PDUSessionResourceModifyItemModRes>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceModifyRequest {
     pub protocol_i_es: PDUSessionResourceModifyRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceModifyRequestTransfer {
     pub protocol_i_es: PDUSessionResourceModifyRequestTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceModifyResponse {
     pub protocol_i_es: PDUSessionResourceModifyResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 6)]
 pub struct PDUSessionResourceModifyResponseTransfer {
     #[asn(optional_idx = 0)]
@@ -3874,7 +3873,7 @@ pub struct PDUSessionResourceModifyResponseTransfer {
     pub ie_extensions: Option<PDUSessionResourceModifyResponseTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PDUSessionResourceModifyUnsuccessfulTransfer {
     pub cause: Cause,
@@ -3884,13 +3883,13 @@ pub struct PDUSessionResourceModifyUnsuccessfulTransfer {
     pub ie_extensions: Option<PDUSessionResourceModifyUnsuccessfulTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceNotify {
     pub protocol_i_es: PDUSessionResourceNotifyProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceNotifyItem {
     pub pdu_session_id: PDUSessionID,
@@ -3899,7 +3898,7 @@ pub struct PDUSessionResourceNotifyItem {
     pub ie_extensions: Option<PDUSessionResourceNotifyItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3908,7 +3907,7 @@ pub struct PDUSessionResourceNotifyItem {
 )]
 pub struct PDUSessionResourceNotifyList(pub Vec<PDUSessionResourceNotifyItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceNotifyReleasedTransfer {
     pub cause: Cause,
@@ -3916,7 +3915,7 @@ pub struct PDUSessionResourceNotifyReleasedTransfer {
     pub ie_extensions: Option<PDUSessionResourceNotifyReleasedTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct PDUSessionResourceNotifyTransfer {
     #[asn(optional_idx = 0)]
@@ -3927,13 +3926,13 @@ pub struct PDUSessionResourceNotifyTransfer {
     pub ie_extensions: Option<PDUSessionResourceNotifyTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceReleaseCommand {
     pub protocol_i_es: PDUSessionResourceReleaseCommandProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceReleaseCommandTransfer {
     pub cause: Cause,
@@ -3941,20 +3940,20 @@ pub struct PDUSessionResourceReleaseCommandTransfer {
     pub ie_extensions: Option<PDUSessionResourceReleaseCommandTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceReleaseResponse {
     pub protocol_i_es: PDUSessionResourceReleaseResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceReleaseResponseTransfer {
     #[asn(optional_idx = 0)]
     pub ie_extensions: Option<PDUSessionResourceReleaseResponseTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceReleasedItemNot {
     pub pdu_session_id: PDUSessionID,
@@ -3963,7 +3962,7 @@ pub struct PDUSessionResourceReleasedItemNot {
     pub ie_extensions: Option<PDUSessionResourceReleasedItemNotIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceReleasedItemPSAck {
     pub pdu_session_id: PDUSessionID,
@@ -3972,7 +3971,7 @@ pub struct PDUSessionResourceReleasedItemPSAck {
     pub ie_extensions: Option<PDUSessionResourceReleasedItemPSAckIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceReleasedItemPSFail {
     pub pdu_session_id: PDUSessionID,
@@ -3981,7 +3980,7 @@ pub struct PDUSessionResourceReleasedItemPSFail {
     pub ie_extensions: Option<PDUSessionResourceReleasedItemPSFailIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceReleasedItemRelRes {
     pub pdu_session_id: PDUSessionID,
@@ -3990,7 +3989,7 @@ pub struct PDUSessionResourceReleasedItemRelRes {
     pub ie_extensions: Option<PDUSessionResourceReleasedItemRelResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -3999,7 +3998,7 @@ pub struct PDUSessionResourceReleasedItemRelRes {
 )]
 pub struct PDUSessionResourceReleasedListNot(pub Vec<PDUSessionResourceReleasedItemNot>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4008,7 +4007,7 @@ pub struct PDUSessionResourceReleasedListNot(pub Vec<PDUSessionResourceReleasedI
 )]
 pub struct PDUSessionResourceReleasedListPSAck(pub Vec<PDUSessionResourceReleasedItemPSAck>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4017,7 +4016,7 @@ pub struct PDUSessionResourceReleasedListPSAck(pub Vec<PDUSessionResourceRelease
 )]
 pub struct PDUSessionResourceReleasedListPSFail(pub Vec<PDUSessionResourceReleasedItemPSFail>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4026,7 +4025,7 @@ pub struct PDUSessionResourceReleasedListPSFail(pub Vec<PDUSessionResourceReleas
 )]
 pub struct PDUSessionResourceReleasedListRelRes(pub Vec<PDUSessionResourceReleasedItemRelRes>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceResumeItemRESReq {
     pub pdu_session_id: PDUSessionID,
@@ -4035,7 +4034,7 @@ pub struct PDUSessionResourceResumeItemRESReq {
     pub ie_extensions: Option<PDUSessionResourceResumeItemRESReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceResumeItemRESRes {
     pub pdu_session_id: PDUSessionID,
@@ -4044,7 +4043,7 @@ pub struct PDUSessionResourceResumeItemRESRes {
     pub ie_extensions: Option<PDUSessionResourceResumeItemRESResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4053,7 +4052,7 @@ pub struct PDUSessionResourceResumeItemRESRes {
 )]
 pub struct PDUSessionResourceResumeListRESReq(pub Vec<PDUSessionResourceResumeItemRESReq>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4062,7 +4061,7 @@ pub struct PDUSessionResourceResumeListRESReq(pub Vec<PDUSessionResourceResumeIt
 )]
 pub struct PDUSessionResourceResumeListRESRes(pub Vec<PDUSessionResourceResumeItemRESRes>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceSecondaryRATUsageItem {
     pub pdu_session_id: PDUSessionID,
@@ -4071,7 +4070,7 @@ pub struct PDUSessionResourceSecondaryRATUsageItem {
     pub ie_extensions: Option<PDUSessionResourceSecondaryRATUsageItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4082,7 +4081,7 @@ pub struct PDUSessionResourceSecondaryRATUsageList(
     pub Vec<PDUSessionResourceSecondaryRATUsageItem>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PDUSessionResourceSetupItemCxtReq {
     pub pdu_session_id: PDUSessionID,
@@ -4094,7 +4093,7 @@ pub struct PDUSessionResourceSetupItemCxtReq {
     pub ie_extensions: Option<PDUSessionResourceSetupItemCxtReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceSetupItemCxtRes {
     pub pdu_session_id: PDUSessionID,
@@ -4103,7 +4102,7 @@ pub struct PDUSessionResourceSetupItemCxtRes {
     pub ie_extensions: Option<PDUSessionResourceSetupItemCxtResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceSetupItemHOReq {
     pub pdu_session_id: PDUSessionID,
@@ -4113,7 +4112,7 @@ pub struct PDUSessionResourceSetupItemHOReq {
     pub ie_extensions: Option<PDUSessionResourceSetupItemHOReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PDUSessionResourceSetupItemSUReq {
     pub pdu_session_id: PDUSessionID,
@@ -4125,7 +4124,7 @@ pub struct PDUSessionResourceSetupItemSUReq {
     pub ie_extensions: Option<PDUSessionResourceSetupItemSUReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceSetupItemSURes {
     pub pdu_session_id: PDUSessionID,
@@ -4134,7 +4133,7 @@ pub struct PDUSessionResourceSetupItemSURes {
     pub ie_extensions: Option<PDUSessionResourceSetupItemSUResIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4143,7 +4142,7 @@ pub struct PDUSessionResourceSetupItemSURes {
 )]
 pub struct PDUSessionResourceSetupListCxtReq(pub Vec<PDUSessionResourceSetupItemCxtReq>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4152,7 +4151,7 @@ pub struct PDUSessionResourceSetupListCxtReq(pub Vec<PDUSessionResourceSetupItem
 )]
 pub struct PDUSessionResourceSetupListCxtRes(pub Vec<PDUSessionResourceSetupItemCxtRes>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4161,7 +4160,7 @@ pub struct PDUSessionResourceSetupListCxtRes(pub Vec<PDUSessionResourceSetupItem
 )]
 pub struct PDUSessionResourceSetupListHOReq(pub Vec<PDUSessionResourceSetupItemHOReq>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4170,7 +4169,7 @@ pub struct PDUSessionResourceSetupListHOReq(pub Vec<PDUSessionResourceSetupItemH
 )]
 pub struct PDUSessionResourceSetupListSUReq(pub Vec<PDUSessionResourceSetupItemSUReq>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4179,25 +4178,25 @@ pub struct PDUSessionResourceSetupListSUReq(pub Vec<PDUSessionResourceSetupItemS
 )]
 pub struct PDUSessionResourceSetupListSURes(pub Vec<PDUSessionResourceSetupItemSURes>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceSetupRequest {
     pub protocol_i_es: PDUSessionResourceSetupRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceSetupRequestTransfer {
     pub protocol_i_es: PDUSessionResourceSetupRequestTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PDUSessionResourceSetupResponse {
     pub protocol_i_es: PDUSessionResourceSetupResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct PDUSessionResourceSetupResponseTransfer {
     pub dl_qos_flow_per_tnl_information: QosFlowPerTNLInformation,
@@ -4211,7 +4210,7 @@ pub struct PDUSessionResourceSetupResponseTransfer {
     pub ie_extensions: Option<PDUSessionResourceSetupResponseTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PDUSessionResourceSetupUnsuccessfulTransfer {
     pub cause: Cause,
@@ -4221,7 +4220,7 @@ pub struct PDUSessionResourceSetupUnsuccessfulTransfer {
     pub ie_extensions: Option<PDUSessionResourceSetupUnsuccessfulTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceSuspendItemSUSReq {
     pub pdu_session_id: PDUSessionID,
@@ -4230,7 +4229,7 @@ pub struct PDUSessionResourceSuspendItemSUSReq {
     pub ie_extensions: Option<PDUSessionResourceSuspendItemSUSReqIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4239,7 +4238,7 @@ pub struct PDUSessionResourceSuspendItemSUSReq {
 )]
 pub struct PDUSessionResourceSuspendListSUSReq(pub Vec<PDUSessionResourceSuspendItemSUSReq>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceSwitchedItem {
     pub pdu_session_id: PDUSessionID,
@@ -4248,7 +4247,7 @@ pub struct PDUSessionResourceSwitchedItem {
     pub ie_extensions: Option<PDUSessionResourceSwitchedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4257,7 +4256,7 @@ pub struct PDUSessionResourceSwitchedItem {
 )]
 pub struct PDUSessionResourceSwitchedList(pub Vec<PDUSessionResourceSwitchedItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceToBeSwitchedDLItem {
     pub pdu_session_id: PDUSessionID,
@@ -4266,7 +4265,7 @@ pub struct PDUSessionResourceToBeSwitchedDLItem {
     pub ie_extensions: Option<PDUSessionResourceToBeSwitchedDLItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4275,7 +4274,7 @@ pub struct PDUSessionResourceToBeSwitchedDLItem {
 )]
 pub struct PDUSessionResourceToBeSwitchedDLList(pub Vec<PDUSessionResourceToBeSwitchedDLItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceToReleaseItemHOCmd {
     pub pdu_session_id: PDUSessionID,
@@ -4284,7 +4283,7 @@ pub struct PDUSessionResourceToReleaseItemHOCmd {
     pub ie_extensions: Option<PDUSessionResourceToReleaseItemHOCmdIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionResourceToReleaseItemRelCmd {
     pub pdu_session_id: PDUSessionID,
@@ -4293,7 +4292,7 @@ pub struct PDUSessionResourceToReleaseItemRelCmd {
     pub ie_extensions: Option<PDUSessionResourceToReleaseItemRelCmdIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4302,7 +4301,7 @@ pub struct PDUSessionResourceToReleaseItemRelCmd {
 )]
 pub struct PDUSessionResourceToReleaseListHOCmd(pub Vec<PDUSessionResourceToReleaseItemHOCmd>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -4311,7 +4310,7 @@ pub struct PDUSessionResourceToReleaseListHOCmd(pub Vec<PDUSessionResourceToRele
 )]
 pub struct PDUSessionResourceToReleaseListRelCmd(pub Vec<PDUSessionResourceToReleaseItemRelCmd>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "4")]
 pub struct PDUSessionType(pub u8);
 impl PDUSessionType {
@@ -4322,7 +4321,7 @@ impl PDUSessionType {
     pub const UNSTRUCTURED: u8 = 4u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PDUSessionUsageReport {
     pub rat_type: ENUMERATED_67,
@@ -4331,11 +4330,11 @@ pub struct PDUSessionUsageReport {
     pub ie_extensions: Option<PDUSessionUsageReportIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct PLMNIdentity(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PLMNSupportItem {
     pub plmn_identity: PLMNIdentity,
@@ -4344,11 +4343,11 @@ pub struct PLMNSupportItem {
     pub ie_extensions: Option<PLMNSupportItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "12")]
 pub struct PLMNSupportList(pub Vec<PLMNSupportItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PNI_NPN_MobilityInformation {
     pub allowed_pni_npi_list: Allowed_PNI_NPN_List,
@@ -4356,19 +4355,19 @@ pub struct PNI_NPN_MobilityInformation {
     pub ie_extensions: Option<PNI_NPN_MobilityInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PWSCancelRequest {
     pub protocol_i_es: PWSCancelRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PWSCancelResponse {
     pub protocol_i_es: PWSCancelResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum PWSFailedCellIDList {
     #[asn(key = 0, extended = false)]
@@ -4379,23 +4378,23 @@ pub enum PWSFailedCellIDList {
     Choice_Extensions(PWSFailedCellIDListchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PWSFailureIndication {
     pub protocol_i_es: PWSFailureIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PWSRestartIndication {
     pub protocol_i_es: PWSRestartIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1023", extensible = true)]
 pub struct PacketDelayBudget(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PacketErrorRate {
     pub per_scalar: INTEGER_68,
@@ -4404,17 +4403,17 @@ pub struct PacketErrorRate {
     pub ie_extensions: Option<PacketErrorRateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1000", extensible = true)]
 pub struct PacketLossRate(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct Paging {
     pub protocol_i_es: PagingProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "15")]
 pub struct Paging_Time_Window(pub u8);
 impl Paging_Time_Window {
@@ -4436,7 +4435,7 @@ impl Paging_Time_Window {
     pub const S16: u8 = 15u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "13")]
 pub struct Paging_eDRX_Cycle(pub u8);
 impl Paging_eDRX_Cycle {
@@ -4456,7 +4455,7 @@ impl Paging_eDRX_Cycle {
     pub const HF256: u8 = 13u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PagingAssisDataforCEcapabUE {
     pub eutra_cgi: EUTRA_CGI,
@@ -4465,11 +4464,11 @@ pub struct PagingAssisDataforCEcapabUE {
     pub ie_extensions: Option<PagingAssisDataforCEcapabUEIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "16", extensible = true)]
 pub struct PagingAttemptCount(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PagingAttemptInformation {
     pub paging_attempt_count: PagingAttemptCount,
@@ -4480,7 +4479,7 @@ pub struct PagingAttemptInformation {
     pub ie_extensions: Option<PagingAttemptInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "3")]
 pub struct PagingDRX(pub u8);
 impl PagingDRX {
@@ -4490,14 +4489,14 @@ impl PagingDRX {
     pub const V256: u8 = 3u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct PagingOrigin(pub u8);
 impl PagingOrigin {
     pub const NON_3GPP: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "7")]
 pub struct PagingPriority(pub u8);
 impl PagingPriority {
@@ -4511,7 +4510,7 @@ impl PagingPriority {
     pub const PRIOLEVEL8: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "20")]
 pub struct PagingProbabilityInformation(pub u8);
 impl PagingProbabilityInformation {
@@ -4538,7 +4537,7 @@ impl PagingProbabilityInformation {
     pub const P100: u8 = 20u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct PagingeDRXInformation {
     pub paging_e_drx_cycle: Paging_eDRX_Cycle,
@@ -4548,19 +4547,19 @@ pub struct PagingeDRXInformation {
     pub ie_extensions: Option<PagingeDRXInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PathSwitchRequest {
     pub protocol_i_es: PathSwitchRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PathSwitchRequestAcknowledge {
     pub protocol_i_es: PathSwitchRequestAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct PathSwitchRequestAcknowledgeTransfer {
     #[asn(optional_idx = 0)]
@@ -4571,13 +4570,13 @@ pub struct PathSwitchRequestAcknowledgeTransfer {
     pub ie_extensions: Option<PathSwitchRequestAcknowledgeTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PathSwitchRequestFailure {
     pub protocol_i_es: PathSwitchRequestFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PathSwitchRequestSetupFailedTransfer {
     pub cause: Cause,
@@ -4585,7 +4584,7 @@ pub struct PathSwitchRequestSetupFailedTransfer {
     pub ie_extensions: Option<PathSwitchRequestSetupFailedTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct PathSwitchRequestTransfer {
     pub dl_ngu_up_tnl_information: UPTransportLayerInformation,
@@ -4598,7 +4597,7 @@ pub struct PathSwitchRequestTransfer {
     pub ie_extensions: Option<PathSwitchRequestTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct PathSwitchRequestUnsuccessfulTransfer {
     pub cause: Cause,
@@ -4606,7 +4605,7 @@ pub struct PathSwitchRequestUnsuccessfulTransfer {
     pub ie_extensions: Option<PathSwitchRequestUnsuccessfulTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct PedestrianUE(pub u8);
 impl PedestrianUE {
@@ -4614,19 +4613,19 @@ impl PedestrianUE {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "8", sz_ub = "8")]
 pub struct PeriodicRegistrationUpdateTimer(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "640000", extensible = true)]
 pub struct Periodicity(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct PortNumber(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct Pre_emptionCapability(pub u8);
 impl Pre_emptionCapability {
@@ -4634,7 +4633,7 @@ impl Pre_emptionCapability {
     pub const MAY_TRIGGER_PRE_EMPTION: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct Pre_emptionVulnerability(pub u8);
 impl Pre_emptionVulnerability {
@@ -4642,7 +4641,7 @@ impl Pre_emptionVulnerability {
     pub const PRE_EMPTABLE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct Presence(pub u8);
 impl Presence {
@@ -4651,15 +4650,15 @@ impl Presence {
     pub const MANDATORY: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "15")]
 pub struct PriorityLevelARP(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "127", extensible = true)]
 pub struct PriorityLevelQos(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct PrivacyIndicator(pub u8);
 impl PrivacyIndicator {
@@ -4667,7 +4666,7 @@ impl PrivacyIndicator {
     pub const LOGGED_MDT: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum PrivateIE_ID {
     #[asn(key = 0, extended = false)]
@@ -4676,17 +4675,17 @@ pub enum PrivateIE_ID {
     Global(OBJECT_IDENTIFIER_71),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct PrivateMessage {
     pub private_i_es: PrivateMessagePrivateIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct ProcedureCode(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum ProcedureStageChoice {
     #[asn(key = 0, extended = false)]
@@ -4695,15 +4694,15 @@ pub enum ProcedureStageChoice {
     Choice_Extensions(ProcedureStageChoicechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct ProtocolExtensionID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct ProtocolIE_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QoSFlowsUsageReport_Item {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4713,11 +4712,11 @@ pub struct QoSFlowsUsageReport_Item {
     pub ie_extensions: Option<QoSFlowsUsageReport_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QoSFlowsUsageReportList(pub Vec<QoSFlowsUsageReport_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum QosCharacteristics {
     #[asn(key = 0, extended = false)]
@@ -4728,7 +4727,7 @@ pub enum QosCharacteristics {
     Choice_Extensions(QosCharacteristicschoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowAcceptedItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4736,11 +4735,11 @@ pub struct QosFlowAcceptedItem {
     pub ie_extensions: Option<QosFlowAcceptedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowAcceptedList(pub Vec<QosFlowAcceptedItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct QosFlowAddOrModifyRequestItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4752,11 +4751,11 @@ pub struct QosFlowAddOrModifyRequestItem {
     pub ie_extensions: Option<QosFlowAddOrModifyRequestItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowAddOrModifyRequestList(pub Vec<QosFlowAddOrModifyRequestItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowAddOrModifyResponseItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4764,11 +4763,11 @@ pub struct QosFlowAddOrModifyResponseItem {
     pub ie_extensions: Option<QosFlowAddOrModifyResponseItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowAddOrModifyResponseList(pub Vec<QosFlowAddOrModifyResponseItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct QosFlowFeedbackItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4782,15 +4781,15 @@ pub struct QosFlowFeedbackItem {
     pub ie_extensions: Option<QosFlowFeedbackItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowFeedbackList(pub Vec<QosFlowFeedbackItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "63", extensible = true)]
 pub struct QosFlowIdentifier(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct QosFlowInformationItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4800,11 +4799,11 @@ pub struct QosFlowInformationItem {
     pub ie_extensions: Option<QosFlowInformationItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowInformationList(pub Vec<QosFlowInformationItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct QosFlowItemWithDataForwarding {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4814,7 +4813,7 @@ pub struct QosFlowItemWithDataForwarding {
     pub ie_extensions: Option<QosFlowItemWithDataForwardingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct QosFlowLevelQosParameters {
     pub qos_characteristics: QosCharacteristics,
@@ -4829,15 +4828,15 @@ pub struct QosFlowLevelQosParameters {
     pub ie_extensions: Option<QosFlowLevelQosParametersIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowListWithCause(pub Vec<QosFlowWithCauseItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowListWithDataForwarding(pub Vec<QosFlowItemWithDataForwarding>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowModifyConfirmItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4845,11 +4844,11 @@ pub struct QosFlowModifyConfirmItem {
     pub ie_extensions: Option<QosFlowModifyConfirmItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowModifyConfirmList(pub Vec<QosFlowModifyConfirmItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowNotifyItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4858,11 +4857,11 @@ pub struct QosFlowNotifyItem {
     pub ie_extensions: Option<QosFlowNotifyItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowNotifyList(pub Vec<QosFlowNotifyItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct QosFlowParametersItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4872,11 +4871,11 @@ pub struct QosFlowParametersItem {
     pub ie_extensions: Option<QosFlowParametersItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowParametersList(pub Vec<QosFlowParametersItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowPerTNLInformation {
     pub up_transport_layer_information: UPTransportLayerInformation,
@@ -4885,7 +4884,7 @@ pub struct QosFlowPerTNLInformation {
     pub ie_extensions: Option<QosFlowPerTNLInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowPerTNLInformationItem {
     pub qos_flow_per_tnl_information: QosFlowPerTNLInformation,
@@ -4893,11 +4892,11 @@ pub struct QosFlowPerTNLInformationItem {
     pub ie_extensions: Option<QosFlowPerTNLInformationItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "3")]
 pub struct QosFlowPerTNLInformationList(pub Vec<QosFlowPerTNLInformationItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct QosFlowSetupRequestItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4908,11 +4907,11 @@ pub struct QosFlowSetupRequestItem {
     pub ie_extensions: Option<QosFlowSetupRequestItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowSetupRequestList(pub Vec<QosFlowSetupRequestItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowToBeForwardedItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4920,11 +4919,11 @@ pub struct QosFlowToBeForwardedItem {
     pub ie_extensions: Option<QosFlowToBeForwardedItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct QosFlowToBeForwardedList(pub Vec<QosFlowToBeForwardedItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct QosFlowWithCauseItem {
     pub qos_flow_identifier: QosFlowIdentifier,
@@ -4933,11 +4932,11 @@ pub struct QosFlowWithCauseItem {
     pub ie_extensions: Option<QosFlowWithCauseItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "1800", extensible = true)]
 pub struct QosMonitoringReportingFrequency(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct QosMonitoringRequest(pub u8);
 impl QosMonitoringRequest {
@@ -4946,35 +4945,35 @@ impl QosMonitoringRequest {
     pub const BOTH: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4294967295")]
 pub struct RAN_UE_NGAP_ID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RANCPRelocationIndication {
     pub protocol_i_es: RANCPRelocationIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RANConfigurationUpdate {
     pub protocol_i_es: RANConfigurationUpdateProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RANConfigurationUpdateAcknowledge {
     pub protocol_i_es: RANConfigurationUpdateAcknowledgeProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RANConfigurationUpdateFailure {
     pub protocol_i_es: RANConfigurationUpdateFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "PrintableString",
     sz_extensible = true,
@@ -4983,11 +4982,11 @@ pub struct RANConfigurationUpdateFailure {
 )]
 pub struct RANNodeName(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "UTF8String", sz_extensible = true, sz_lb = "1", sz_ub = "150")]
 pub struct RANNodeNameUTF8String(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "VisibleString",
     sz_extensible = true,
@@ -4996,11 +4995,11 @@ pub struct RANNodeNameUTF8String(pub String);
 )]
 pub struct RANNodeNameVisibleString(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "256")]
 pub struct RANPagingPriority(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RANStatusTransfer_TransparentContainer {
     pub dr_bs_subject_to_status_transfer_list: DRBsSubjectToStatusTransferList,
@@ -5008,7 +5007,7 @@ pub struct RANStatusTransfer_TransparentContainer {
     pub ie_extensions: Option<RANStatusTransfer_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct RAT_Information(pub u8);
 impl RAT_Information {
@@ -5016,15 +5015,15 @@ impl RAT_Information {
     pub const NB_IO_T: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "8", sz_ub = "8")]
 pub struct RATRestrictionInformation(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct RATRestrictions(pub Vec<RATRestrictions_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RATRestrictions_Item {
     pub plmn_identity: PLMNIdentity,
@@ -5033,11 +5032,11 @@ pub struct RATRestrictions_Item {
     pub ie_extensions: Option<RATRestrictions_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct RGLevelWirelineAccessCharacteristics(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RIMInformation {
     pub targetg_nb_set_id: GNBSetID,
@@ -5046,7 +5045,7 @@ pub struct RIMInformation {
     pub ie_extensions: Option<RIMInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RIMInformationTransfer {
     pub target_ran_node_id: TargetRANNodeID,
@@ -5056,15 +5055,15 @@ pub struct RIMInformationTransfer {
     pub ie_extensions: Option<RIMInformationTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct RNC_ID(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct RRCContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "9")]
 pub struct RRCEstablishmentCause(pub u8);
 impl RRCEstablishmentCause {
@@ -5080,13 +5079,13 @@ impl RRCEstablishmentCause {
     pub const MCS_PRIORITY_ACCESS: u8 = 9u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RRCInactiveTransitionReport {
     pub protocol_i_es: RRCInactiveTransitionReportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct RRCInactiveTransitionReportRequest(pub u8);
 impl RRCInactiveTransitionReportRequest {
@@ -5095,7 +5094,7 @@ impl RRCInactiveTransitionReportRequest {
     pub const CANCEL_REPORT: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct RRCState(pub u8);
 impl RRCState {
@@ -5103,7 +5102,7 @@ impl RRCState {
     pub const CONNECTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct RSN(pub u8);
 impl RSN {
@@ -5111,7 +5110,7 @@ impl RSN {
     pub const V2: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "8")]
 pub struct Range(pub u8);
 impl Range {
@@ -5126,7 +5125,7 @@ impl Range {
     pub const M1000: u8 = 8u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct RecommendedCellItem {
     pub ngran_cgi: NGRAN_CGI,
@@ -5136,11 +5135,11 @@ pub struct RecommendedCellItem {
     pub ie_extensions: Option<RecommendedCellItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct RecommendedCellList(pub Vec<RecommendedCellItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RecommendedCellsForPaging {
     pub recommended_cell_list: RecommendedCellList,
@@ -5148,7 +5147,7 @@ pub struct RecommendedCellsForPaging {
     pub ie_extensions: Option<RecommendedCellsForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RecommendedRANNodeItem {
     pub amf_paging_target: AMFPagingTarget,
@@ -5156,11 +5155,11 @@ pub struct RecommendedRANNodeItem {
     pub ie_extensions: Option<RecommendedRANNodeItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct RecommendedRANNodeList(pub Vec<RecommendedRANNodeItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RecommendedRANNodesForPaging {
     pub recommended_ran_node_list: RecommendedRANNodeList,
@@ -5168,7 +5167,7 @@ pub struct RecommendedRANNodesForPaging {
     pub ie_extensions: Option<RecommendedRANNodesForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct RedirectionVoiceFallback(pub u8);
 impl RedirectionVoiceFallback {
@@ -5176,7 +5175,7 @@ impl RedirectionVoiceFallback {
     pub const NOT_POSSIBLE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct RedundantPDUSessionInformation {
     pub rsn: RSN,
@@ -5184,7 +5183,7 @@ pub struct RedundantPDUSessionInformation {
     pub ie_extensions: Option<RedundantPDUSessionInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "1")]
 pub struct RedundantQosFlowIndicator(pub u8);
 impl RedundantQosFlowIndicator {
@@ -5192,14 +5191,14 @@ impl RedundantQosFlowIndicator {
     pub const FALSE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ReflectiveQosAttribute(pub u8);
 impl ReflectiveQosAttribute {
     pub const SUBJECT_TO: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -5208,7 +5207,7 @@ impl ReflectiveQosAttribute {
 )]
 pub struct RejectedNSSAIinPLMN(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -5217,15 +5216,15 @@ pub struct RejectedNSSAIinPLMN(pub Vec<u8>);
 )]
 pub struct RejectedNSSAIinTA(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct RelativeAMFCapacity(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "131071")]
 pub struct RepetitionPeriod(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "7")]
 pub struct ReportAmountMDT(pub u8);
 impl ReportAmountMDT {
@@ -5239,14 +5238,14 @@ impl ReportAmountMDT {
     pub const RINFINITY: u8 = 7u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ReportArea(pub u8);
 impl ReportArea {
     pub const CELL: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "12")]
 pub struct ReportIntervalMDT(pub u8);
 impl ReportIntervalMDT {
@@ -5265,20 +5264,20 @@ impl ReportIntervalMDT {
     pub const MIN60: u8 = 12u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RerouteNASRequest {
     pub protocol_i_es: RerouteNASRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ResetAll(pub u8);
 impl ResetAll {
     pub const RESET_ALL: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum ResetType {
     #[asn(key = 0, extended = false)]
@@ -5289,17 +5288,17 @@ pub enum ResetType {
     Choice_Extensions(ResetTypechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct RetrieveUEInformation {
     pub protocol_i_es: RetrieveUEInformationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct RoutingID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct S_NSSAI {
     pub sst: SST,
@@ -5309,15 +5308,15 @@ pub struct S_NSSAI {
     pub ie_extensions: Option<S_NSSAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct SCTP_TLAs(pub Vec<TransportLayerAddress>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct SD(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SNPN_MobilityInformation {
     pub serving_nid: NID,
@@ -5325,7 +5324,7 @@ pub struct SNPN_MobilityInformation {
     pub ie_extensions: Option<SNPN_MobilityInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct SONConfigurationTransfer {
     pub target_ran_node_id: TargetRANNodeID,
@@ -5337,7 +5336,7 @@ pub struct SONConfigurationTransfer {
     pub ie_extensions: Option<SONConfigurationTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum SONInformation {
     #[asn(key = 0, extended = false)]
@@ -5348,7 +5347,7 @@ pub enum SONInformation {
     Choice_Extensions(SONInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct SONInformationReply {
     #[asn(optional_idx = 0)]
@@ -5357,7 +5356,7 @@ pub struct SONInformationReply {
     pub ie_extensions: Option<SONInformationReplyIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum SONInformationReport {
     #[asn(key = 0, extended = false)]
@@ -5368,14 +5367,14 @@ pub enum SONInformationReport {
     Choice_Extensions(SONInformationReportchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SONInformationRequest(pub u8);
 impl SONInformationRequest {
     pub const XN_TNL_CONFIGURATION_INFO: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SRVCCOperationPossible(pub u8);
 impl SRVCCOperationPossible {
@@ -5383,11 +5382,11 @@ impl SRVCCOperationPossible {
     pub const NOT_POSSIBLE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "1", sz_ub = "1")]
 pub struct SST(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct ScheduledCommunicationTime {
     #[asn(optional_idx = 0)]
@@ -5400,13 +5399,13 @@ pub struct ScheduledCommunicationTime {
     pub ie_extensions: Option<ScheduledCommunicationTimeIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct SecondaryRATDataUsageReport {
     pub protocol_i_es: SecondaryRATDataUsageReportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct SecondaryRATDataUsageReportTransfer {
     #[asn(optional_idx = 0)]
@@ -5415,7 +5414,7 @@ pub struct SecondaryRATDataUsageReportTransfer {
     pub ie_extensions: Option<SecondaryRATDataUsageReportTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct SecondaryRATUsageInformation {
     #[asn(optional_idx = 0)]
@@ -5426,7 +5425,7 @@ pub struct SecondaryRATUsageInformation {
     pub ie_extension: Option<SecondaryRATUsageInformationIE_Extension>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SecurityContext {
     pub next_hop_chaining_count: NextHopChainingCount,
@@ -5435,7 +5434,7 @@ pub struct SecurityContext {
     pub ie_extensions: Option<SecurityContextIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct SecurityIndication {
     pub integrity_protection_indication: IntegrityProtectionIndication,
@@ -5446,7 +5445,7 @@ pub struct SecurityIndication {
     pub ie_extensions: Option<SecurityIndicationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -5455,7 +5454,7 @@ pub struct SecurityIndication {
 )]
 pub struct SecurityKey(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SecurityResult {
     pub integrity_protection_result: IntegrityProtectionResult,
@@ -5464,14 +5463,14 @@ pub struct SecurityResult {
     pub ie_extensions: Option<SecurityResultIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SensorMeasConfig(pub u8);
 impl SensorMeasConfig {
     pub const SETUP: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SensorMeasConfigNameItem {
     pub sensor_name_config: SensorNameConfig,
@@ -5479,11 +5478,11 @@ pub struct SensorMeasConfigNameItem {
     pub ie_extensions: Option<SensorMeasConfigNameItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "3")]
 pub struct SensorMeasConfigNameList(pub Vec<SensorMeasConfigNameItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct SensorMeasurementConfiguration {
     pub sensor_meas_config: SensorMeasConfig,
@@ -5493,7 +5492,7 @@ pub struct SensorMeasurementConfiguration {
     pub ie_extensions: Option<SensorMeasurementConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = false)]
 pub enum SensorNameConfig {
     #[asn(key = 0, extended = false)]
@@ -5506,11 +5505,11 @@ pub enum SensorNameConfig {
     Choice_Extensions(SensorNameConfigchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct SerialNumber(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct ServedGUAMIItem {
     pub guami: GUAMI,
@@ -5520,7 +5519,7 @@ pub struct ServedGUAMIItem {
     pub ie_extensions: Option<ServedGUAMIItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5529,11 +5528,11 @@ pub struct ServedGUAMIItem {
 )]
 pub struct ServedGUAMIList(pub Vec<ServedGUAMIItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct ServiceAreaInformation(pub Vec<ServiceAreaInformation_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct ServiceAreaInformation_Item {
     pub plmn_identity: PLMNIdentity,
@@ -5545,11 +5544,11 @@ pub struct ServiceAreaInformation_Item {
     pub ie_extensions: Option<ServiceAreaInformation_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4294967295")]
 pub struct SgNB_UE_X2AP_ID(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SliceOverloadItem {
     pub s_nssai: S_NSSAI,
@@ -5557,7 +5556,7 @@ pub struct SliceOverloadItem {
     pub ie_extensions: Option<SliceOverloadItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5566,7 +5565,7 @@ pub struct SliceOverloadItem {
 )]
 pub struct SliceOverloadList(pub Vec<SliceOverloadItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SliceSupportItem {
     pub s_nssai: S_NSSAI,
@@ -5574,7 +5573,7 @@ pub struct SliceSupportItem {
     pub ie_extensions: Option<SliceSupportItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5583,7 +5582,7 @@ pub struct SliceSupportItem {
 )]
 pub struct SliceSupportList(pub Vec<SliceSupportItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct SourceNGRANNode_ToTargetNGRANNode_TransparentContainer {
     pub rrc_container: RRCContainer,
@@ -5599,7 +5598,7 @@ pub struct SourceNGRANNode_ToTargetNGRANNode_TransparentContainer {
     pub ie_extensions: Option<SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct SourceOfUEActivityBehaviourInformation(pub u8);
 impl SourceOfUEActivityBehaviourInformation {
@@ -5607,7 +5606,7 @@ impl SourceOfUEActivityBehaviourInformation {
     pub const STATISTICS: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SourceRANNodeID {
     pub global_ran_node_id: GlobalRANNodeID,
@@ -5616,7 +5615,7 @@ pub struct SourceRANNodeID {
     pub ie_extensions: Option<SourceRANNodeIDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct SourceToTarget_AMFInformationReroute {
     #[asn(optional_idx = 0)]
@@ -5629,11 +5628,11 @@ pub struct SourceToTarget_AMFInformationReroute {
     pub ie_extensions: Option<SourceToTarget_AMFInformationRerouteIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct SourceToTarget_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SuccessfulOutcome {
     #[asn(key_field = true)]
@@ -5642,7 +5641,7 @@ pub struct SuccessfulOutcome {
     pub value: SuccessfulOutcomeValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct SupportedTAItem {
     pub tac: TAC,
@@ -5651,7 +5650,7 @@ pub struct SupportedTAItem {
     pub ie_extensions: Option<SupportedTAItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5660,28 +5659,28 @@ pub struct SupportedTAItem {
 )]
 pub struct SupportedTAList(pub Vec<SupportedTAItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Suspend_Request_Indication(pub u8);
 impl Suspend_Request_Indication {
     pub const SUSPEND_REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct Suspend_Response_Indication(pub u8);
 impl Suspend_Response_Indication {
     pub const SUSPEND_INDICATED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct SuspendIndicator(pub u8);
 impl SuspendIndicator {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TABasedMDT {
     pub ta_listfor_mdt: TAListforMDT,
@@ -5689,11 +5688,11 @@ pub struct TABasedMDT {
     pub ie_extensions: Option<TABasedMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "3", sz_ub = "3")]
 pub struct TAC(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAI {
     pub plmn_identity: PLMNIdentity,
@@ -5702,7 +5701,7 @@ pub struct TAI {
     pub ie_extensions: Option<TAIIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIBasedMDT {
     pub tai_listfor_mdt: TAIListforMDT,
@@ -5710,7 +5709,7 @@ pub struct TAIBasedMDT {
     pub ie_extensions: Option<TAIBasedMDTIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5719,7 +5718,7 @@ pub struct TAIBasedMDT {
 )]
 pub struct TAIBroadcastEUTRA(pub Vec<TAIBroadcastEUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIBroadcastEUTRA_Item {
     pub tai: TAI,
@@ -5728,7 +5727,7 @@ pub struct TAIBroadcastEUTRA_Item {
     pub ie_extensions: Option<TAIBroadcastEUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5737,7 +5736,7 @@ pub struct TAIBroadcastEUTRA_Item {
 )]
 pub struct TAIBroadcastNR(pub Vec<TAIBroadcastNR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIBroadcastNR_Item {
     pub tai: TAI,
@@ -5746,7 +5745,7 @@ pub struct TAIBroadcastNR_Item {
     pub ie_extensions: Option<TAIBroadcastNR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5755,7 +5754,7 @@ pub struct TAIBroadcastNR_Item {
 )]
 pub struct TAICancelledEUTRA(pub Vec<TAICancelledEUTRA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAICancelledEUTRA_Item {
     pub tai: TAI,
@@ -5764,7 +5763,7 @@ pub struct TAICancelledEUTRA_Item {
     pub ie_extensions: Option<TAICancelledEUTRA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5773,7 +5772,7 @@ pub struct TAICancelledEUTRA_Item {
 )]
 pub struct TAICancelledNR(pub Vec<TAICancelledNR_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAICancelledNR_Item {
     pub tai: TAI,
@@ -5782,11 +5781,11 @@ pub struct TAICancelledNR_Item {
     pub ie_extensions: Option<TAICancelledNR_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct TAIListForInactive(pub Vec<TAIListForInactiveItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIListForInactiveItem {
     pub tai: TAI,
@@ -5794,11 +5793,11 @@ pub struct TAIListForInactiveItem {
     pub ie_extensions: Option<TAIListForInactiveItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct TAIListForPaging(pub Vec<TAIListForPagingItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TAIListForPagingItem {
     pub tai: TAI,
@@ -5806,7 +5805,7 @@ pub struct TAIListForPagingItem {
     pub ie_extensions: Option<TAIListForPagingItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5815,7 +5814,7 @@ pub struct TAIListForPagingItem {
 )]
 pub struct TAIListForRestart(pub Vec<TAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -5824,19 +5823,19 @@ pub struct TAIListForRestart(pub Vec<TAI>);
 )]
 pub struct TAIListForWarning(pub Vec<TAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct TAIListforMDT(pub Vec<TAI>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "8")]
 pub struct TAListforMDT(pub Vec<TAC>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TNAP_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum TNGF_ID {
     #[asn(key = 0, extended = false)]
@@ -5845,11 +5844,11 @@ pub enum TNGF_ID {
     Choice_Extensions(TNGF_IDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "255")]
 pub struct TNLAddressWeightFactor(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TNLAssociationItem {
     pub tnl_association_address: CPTransportLayerInformation,
@@ -5858,11 +5857,11 @@ pub struct TNLAssociationItem {
     pub ie_extensions: Option<TNLAssociationItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "32")]
 pub struct TNLAssociationList(pub Vec<TNLAssociationItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct TNLAssociationUsage(pub u8);
 impl TNLAssociationUsage {
@@ -5871,7 +5870,7 @@ impl TNLAssociationUsage {
     pub const BOTH: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TSCAssistanceInformation {
     pub periodicity: Periodicity,
@@ -5881,7 +5880,7 @@ pub struct TSCAssistanceInformation {
     pub ie_extensions: Option<TSCAssistanceInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct TSCTrafficCharacteristics {
     #[asn(optional_idx = 0)]
@@ -5892,11 +5891,11 @@ pub struct TSCTrafficCharacteristics {
     pub ie_extensions: Option<TSCTrafficCharacteristicsIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TWAP_ID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum TWIF_ID {
     #[asn(key = 0, extended = false)]
@@ -5905,7 +5904,7 @@ pub enum TWIF_ID {
     Choice_Extensions(TWIF_IDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum TargetID {
     #[asn(key = 0, extended = false)]
@@ -5916,7 +5915,7 @@ pub enum TargetID {
     Choice_Extensions(TargetIDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargetNGRANNode_ToSourceNGRANNode_FailureTransparentContainer {
     pub cell_cag_information: Cell_CAGInformation,
@@ -5925,7 +5924,7 @@ pub struct TargetNGRANNode_ToSourceNGRANNode_FailureTransparentContainer {
         Option<TargetNGRANNode_ToSourceNGRANNode_FailureTransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargetNGRANNode_ToSourceNGRANNode_TransparentContainer {
     pub rrc_container: RRCContainer,
@@ -5933,7 +5932,7 @@ pub struct TargetNGRANNode_ToSourceNGRANNode_TransparentContainer {
     pub ie_extensions: Option<TargetNGRANNode_ToSourceNGRANNode_TransparentContainerIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargetRANNodeID {
     pub global_ran_node_id: GlobalRANNodeID,
@@ -5942,7 +5941,7 @@ pub struct TargetRANNodeID {
     pub ie_extensions: Option<TargetRANNodeIDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TargetRNC_ID {
     pub lai: LAI,
@@ -5953,11 +5952,11 @@ pub struct TargetRNC_ID {
     pub ie_extensions: Option<TargetRNC_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TargetToSource_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TargeteNB_ID {
     pub global_enb_id: GlobalNgENB_ID,
@@ -5966,27 +5965,27 @@ pub struct TargeteNB_ID {
     pub ie_extensions: Option<TargeteNB_IDIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct TargettoSource_Failure_TransparentContainer(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct Threshold_RSRP(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct Threshold_RSRQ(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "127")]
 pub struct Threshold_SINR(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct TimeStamp(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "15")]
 pub struct TimeToTrigger(pub u8);
 impl TimeToTrigger {
@@ -6008,7 +6007,7 @@ impl TimeToTrigger {
     pub const MS5120: u8 = 15u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct TimeToWait(pub u8);
 impl TimeToWait {
@@ -6020,22 +6019,22 @@ impl TimeToWait {
     pub const V60S: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct TimeUEStayedInCell(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "40950")]
 pub struct TimeUEStayedInCellEnhancedGranularity(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct TimerApproachForGUAMIRemoval(pub u8);
 impl TimerApproachForGUAMIRemoval {
     pub const APPLY_TIMER: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct TooearlyIntersystemHO {
     pub sourcecell_id: EUTRA_CGI,
@@ -6046,7 +6045,7 @@ pub struct TooearlyIntersystemHO {
     pub ie_extensions: Option<TooearlyIntersystemHOIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct TraceActivation {
     pub ngran_trace_id: NGRANTraceID,
@@ -6057,7 +6056,7 @@ pub struct TraceActivation {
     pub ie_extensions: Option<TraceActivationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "5")]
 pub struct TraceDepth(pub u8);
 impl TraceDepth {
@@ -6069,27 +6068,27 @@ impl TraceDepth {
     pub const MAXIMUM_WITHOUT_VENDOR_SPECIFIC_EXTENSION: u8 = 5u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct TraceFailureIndication {
     pub protocol_i_es: TraceFailureIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct TraceStart {
     pub protocol_i_es: TraceStartProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "99")]
 pub struct TrafficLoadReductionIndication(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "1", sz_ub = "160")]
 pub struct TransportLayerAddress(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", lb = "0", ub = "2")]
 pub struct TriggeringMessage(pub u8);
 impl TriggeringMessage {
@@ -6098,7 +6097,7 @@ impl TriggeringMessage {
     pub const UNSUCCESSFULL_OUTCOME: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct TypeOfError(pub u8);
 impl TypeOfError {
@@ -6106,7 +6105,7 @@ impl TypeOfError {
     pub const MISSING: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 7)]
 pub struct UE_DifferentiationInfo {
     #[asn(optional_idx = 0)]
@@ -6125,7 +6124,7 @@ pub struct UE_DifferentiationInfo {
     pub ie_extensions: Option<UE_DifferentiationInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UE_NGAP_ID_pair {
     pub amf_ue_ngap_id: AMF_UE_NGAP_ID,
@@ -6134,7 +6133,7 @@ pub struct UE_NGAP_ID_pair {
     pub ie_extensions: Option<UE_NGAP_ID_pairIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum UE_NGAP_IDs {
     #[asn(key = 0, extended = false)]
@@ -6145,14 +6144,14 @@ pub enum UE_NGAP_IDs {
     Choice_Extensions(UE_NGAP_IDschoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UE_UP_CIoT_Support(pub u8);
 impl UE_UP_CIoT_Support {
     pub const SUPPORTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct UE_associatedLogicalNG_connectionItem {
     #[asn(optional_idx = 0)]
@@ -6163,7 +6162,7 @@ pub struct UE_associatedLogicalNG_connectionItem {
     pub ie_extensions: Option<UE_associatedLogicalNG_connectionItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6172,7 +6171,7 @@ pub struct UE_associatedLogicalNG_connectionItem {
 )]
 pub struct UE_associatedLogicalNG_connectionList(pub Vec<UE_associatedLogicalNG_connectionItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UEAggregateMaximumBitRate {
     pub ue_aggregate_maximum_bit_rate_dl: BitRate,
@@ -6181,69 +6180,69 @@ pub struct UEAggregateMaximumBitRate {
     pub ie_extensions: Option<UEAggregateMaximumBitRateIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UECapabilityInfoRequest(pub u8);
 impl UECapabilityInfoRequest {
     pub const REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationFailure {
     pub protocol_i_es: UEContextModificationFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationRequest {
     pub protocol_i_es: UEContextModificationRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextModificationResponse {
     pub protocol_i_es: UEContextModificationResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextReleaseCommand {
     pub protocol_i_es: UEContextReleaseCommandProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextReleaseComplete {
     pub protocol_i_es: UEContextReleaseCompleteProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextReleaseRequest {
     pub protocol_i_es: UEContextReleaseRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UEContextRequest(pub u8);
 impl UEContextRequest {
     pub const REQUESTED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextResumeFailure {
     pub protocol_i_es: UEContextResumeFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextResumeRequest {
     pub protocol_i_es: UEContextResumeRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UEContextResumeRequestTransfer {
     #[asn(optional_idx = 0)]
@@ -6252,13 +6251,13 @@ pub struct UEContextResumeRequestTransfer {
     pub ie_extensions: Option<UEContextResumeRequestTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextResumeResponse {
     pub protocol_i_es: UEContextResumeResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UEContextResumeResponseTransfer {
     #[asn(optional_idx = 0)]
@@ -6267,19 +6266,19 @@ pub struct UEContextResumeResponseTransfer {
     pub ie_extensions: Option<UEContextResumeResponseTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextSuspendFailure {
     pub protocol_i_es: UEContextSuspendFailureProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextSuspendRequest {
     pub protocol_i_es: UEContextSuspendRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UEContextSuspendRequestTransfer {
     #[asn(optional_idx = 0)]
@@ -6288,17 +6287,17 @@ pub struct UEContextSuspendRequestTransfer {
     pub ie_extensions: Option<UEContextSuspendRequestTransferIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEContextSuspendResponse {
     pub protocol_i_es: UEContextSuspendResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct UEHistoryInformation(pub Vec<LastVisitedCellItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum UEHistoryInformationFromTheUE {
     #[asn(key = 0, extended = false)]
@@ -6307,7 +6306,7 @@ pub enum UEHistoryInformationFromTheUE {
     Choice_Extensions(UEHistoryInformationFromTheUEchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum UEIdentityIndexValue {
     #[asn(key = 0, extended = false)]
@@ -6316,13 +6315,13 @@ pub enum UEIdentityIndexValue {
     Choice_Extensions(UEIdentityIndexValuechoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UEInformationTransfer {
     pub protocol_i_es: UEInformationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum UEPagingIdentity {
     #[asn(key = 0, extended = false)]
@@ -6331,7 +6330,7 @@ pub enum UEPagingIdentity {
     Choice_Extensions(UEPagingIdentitychoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct UEPresence(pub u8);
 impl UEPresence {
@@ -6340,7 +6339,7 @@ impl UEPresence {
     pub const UNKNOWN: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UEPresenceInAreaOfInterestItem {
     pub location_reporting_reference_id: LocationReportingReferenceID,
@@ -6349,11 +6348,11 @@ pub struct UEPresenceInAreaOfInterestItem {
     pub ie_extensions: Option<UEPresenceInAreaOfInterestItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "64")]
 pub struct UEPresenceInAreaOfInterestList(pub Vec<UEPresenceInAreaOfInterestItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum UERLFReportContainer {
     #[asn(key = 0, extended = false)]
@@ -6364,23 +6363,23 @@ pub enum UERLFReportContainer {
     Choice_Extensions(UERLFReportContainerchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapability(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityCheckRequest {
     pub protocol_i_es: UERadioCapabilityCheckRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityCheckResponse {
     pub protocol_i_es: UERadioCapabilityCheckResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct UERadioCapabilityForPaging {
     #[asn(optional_idx = 0)]
@@ -6391,48 +6390,48 @@ pub struct UERadioCapabilityForPaging {
     pub ie_extensions: Option<UERadioCapabilityForPagingIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapabilityForPagingOfEUTRA(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapabilityForPagingOfNB_IoT(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapabilityForPagingOfNR(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct UERadioCapabilityID(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityIDMappingRequest {
     pub protocol_i_es: UERadioCapabilityIDMappingRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityIDMappingResponse {
     pub protocol_i_es: UERadioCapabilityIDMappingResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UERadioCapabilityInfoIndication {
     pub protocol_i_es: UERadioCapabilityInfoIndicationProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct UERetentionInformation(pub u8);
 impl UERetentionInformation {
     pub const UES_RETAINED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UESecurityCapabilities {
     pub n_rencryption_algorithms: NRencryptionAlgorithms,
@@ -6443,13 +6442,13 @@ pub struct UESecurityCapabilities {
     pub ie_extensions: Option<UESecurityCapabilitiesIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UETNLABindingReleaseRequest {
     pub protocol_i_es: UETNLABindingReleaseRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UL_CP_SecurityInformation {
     pub ul_nas_mac: UL_NAS_MAC,
@@ -6458,15 +6457,15 @@ pub struct UL_CP_SecurityInformation {
     pub ie_extensions: Option<UL_CP_SecurityInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "5", sz_ub = "5")]
 pub struct UL_NAS_Count(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct UL_NAS_MAC(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UL_NGU_UP_TNLModifyItem {
     pub ul_ngu_up_tnl_information: UPTransportLayerInformation,
@@ -6475,18 +6474,18 @@ pub struct UL_NGU_UP_TNLModifyItem {
     pub ie_extensions: Option<UL_NGU_UP_TNLModifyItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "4")]
 pub struct UL_NGU_UP_TNLModifyList(pub Vec<UL_NGU_UP_TNLModifyItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ULForwarding(pub u8);
 impl ULForwarding {
     pub const UL_FORWARDING_PROPOSED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum UPTransportLayerInformation {
     #[asn(key = 0, extended = false)]
@@ -6495,7 +6494,7 @@ pub enum UPTransportLayerInformation {
     Choice_Extensions(UPTransportLayerInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UPTransportLayerInformationItem {
     pub ngu_up_tnl_information: UPTransportLayerInformation,
@@ -6503,11 +6502,11 @@ pub struct UPTransportLayerInformationItem {
     pub ie_extensions: Option<UPTransportLayerInformationItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "3")]
 pub struct UPTransportLayerInformationList(pub Vec<UPTransportLayerInformationItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UPTransportLayerInformationPairItem {
     pub ul_ngu_up_tnl_information: UPTransportLayerInformation,
@@ -6516,15 +6515,15 @@ pub struct UPTransportLayerInformationPairItem {
     pub ie_extensions: Option<UPTransportLayerInformationPairItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "3")]
 pub struct UPTransportLayerInformationPairList(pub Vec<UPTransportLayerInformationPairItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "VisibleString")]
 pub struct URI_address(pub String);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct UnavailableGUAMIItem {
     pub guami: GUAMI,
@@ -6536,7 +6535,7 @@ pub struct UnavailableGUAMIItem {
     pub ie_extensions: Option<UnavailableGUAMIItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6545,7 +6544,7 @@ pub struct UnavailableGUAMIItem {
 )]
 pub struct UnavailableGUAMIList(pub Vec<UnavailableGUAMIItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UnsuccessfulOutcome {
     #[asn(key_field = true)]
@@ -6554,53 +6553,53 @@ pub struct UnsuccessfulOutcome {
     pub value: UnsuccessfulOutcomeValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "8", sz_ub = "8")]
 pub struct UpdateFeedback(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkNASTransport {
     pub protocol_i_es: UplinkNASTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkNonUEAssociatedNRPPaTransport {
     pub protocol_i_es: UplinkNonUEAssociatedNRPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkRANConfigurationTransfer {
     pub protocol_i_es: UplinkRANConfigurationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkRANEarlyStatusTransfer {
     pub protocol_i_es: UplinkRANEarlyStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkRANStatusTransfer {
     pub protocol_i_es: UplinkRANStatusTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkRIMInformationTransfer {
     pub protocol_i_es: UplinkRIMInformationTransferProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct UplinkUEAssociatedNRPPaTransport {
     pub protocol_i_es: UplinkUEAssociatedNRPPaTransportProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "3", extensible = false)]
 pub enum UserLocationInformation {
     #[asn(key = 0, extended = false)]
@@ -6613,7 +6612,7 @@ pub enum UserLocationInformation {
     Choice_Extensions(UserLocationInformationchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UserLocationInformationEUTRA {
     pub eutra_cgi: EUTRA_CGI,
@@ -6624,7 +6623,7 @@ pub struct UserLocationInformationEUTRA {
     pub ie_extensions: Option<UserLocationInformationEUTRAIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UserLocationInformationN3IWF {
     pub ip_address: TransportLayerAddress,
@@ -6633,7 +6632,7 @@ pub struct UserLocationInformationN3IWF {
     pub ie_extensions: Option<UserLocationInformationN3IWFIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UserLocationInformationNR {
     pub nr_cgi: NR_CGI,
@@ -6644,7 +6643,7 @@ pub struct UserLocationInformationNR {
     pub ie_extensions: Option<UserLocationInformationNRIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UserLocationInformationTNGF {
     pub tnap_id: TNAP_ID,
@@ -6655,7 +6654,7 @@ pub struct UserLocationInformationTNGF {
     pub ie_extensions: Option<UserLocationInformationTNGFIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct UserLocationInformationTWIF {
     pub twap_id: TWAP_ID,
@@ -6666,7 +6665,7 @@ pub struct UserLocationInformationTWIF {
     pub ie_extensions: Option<UserLocationInformationTWIFIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "2", extensible = false)]
 pub enum UserLocationInformationW_AGF {
     #[asn(key = 0, extended = false)]
@@ -6677,7 +6676,7 @@ pub enum UserLocationInformationW_AGF {
     Choice_Extensions(UserLocationInformationW_AGFchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct UserPlaneSecurityInformation {
     pub security_result: SecurityResult,
@@ -6686,7 +6685,7 @@ pub struct UserPlaneSecurityInformation {
     pub ie_extensions: Option<UserPlaneSecurityInformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct VehicleUE(pub u8);
 impl VehicleUE {
@@ -6694,7 +6693,7 @@ impl VehicleUE {
     pub const NOT_AUTHORIZED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct VolumeTimedReport_Item {
     pub start_time_stamp: OCTET_STRING_89,
@@ -6705,11 +6704,11 @@ pub struct VolumeTimedReport_Item {
     pub ie_extensions: Option<VolumeTimedReport_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct VolumeTimedReportList(pub Vec<VolumeTimedReport_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "1", extensible = false)]
 pub enum W_AGF_ID {
     #[asn(key = 0, extended = false)]
@@ -6718,14 +6717,14 @@ pub enum W_AGF_ID {
     Choice_Extensions(W_AGF_IDchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct WLANMeasConfig(pub u8);
 impl WLANMeasConfig {
     pub const SETUP: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct WLANMeasConfigNameItem {
     pub wlan_name: WLANName,
@@ -6733,11 +6732,11 @@ pub struct WLANMeasConfigNameItem {
     pub ie_extensions: Option<WLANMeasConfigNameItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "4")]
 pub struct WLANMeasConfigNameList(pub Vec<WLANMeasConfigNameItem>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 4)]
 pub struct WLANMeasurementConfiguration {
     pub wlan_meas_config: WLANMeasConfig,
@@ -6751,7 +6750,7 @@ pub struct WLANMeasurementConfiguration {
     pub ie_extensions: Option<WLANMeasurementConfigurationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -6760,7 +6759,7 @@ pub struct WLANMeasurementConfiguration {
 )]
 pub struct WLANName(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 1)]
 pub struct WUS_Assistance_Information {
     pub paging_probability_information: PagingProbabilityInformation,
@@ -6768,7 +6767,7 @@ pub struct WUS_Assistance_Information {
     pub ie_extensions: Option<WUS_Assistance_InformationIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -6777,7 +6776,7 @@ pub struct WUS_Assistance_Information {
 )]
 pub struct WarningAreaCoordinates(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "CHOICE", lb = "0", ub = "4", extensible = false)]
 pub enum WarningAreaList {
     #[asn(key = 0, extended = false)]
@@ -6792,7 +6791,7 @@ pub enum WarningAreaList {
     Choice_Extensions(WarningAreaListchoice_Extensions),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -6801,7 +6800,7 @@ pub enum WarningAreaList {
 )]
 pub struct WarningMessageContents(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "OCTET-STRING",
     sz_extensible = false,
@@ -6810,23 +6809,23 @@ pub struct WarningMessageContents(pub Vec<u8>);
 )]
 pub struct WarningSecurityInfo(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "2", sz_ub = "2")]
 pub struct WarningType(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct WriteReplaceWarningRequest {
     pub protocol_i_es: WriteReplaceWarningRequestProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true)]
 pub struct WriteReplaceWarningResponse {
     pub protocol_i_es: WriteReplaceWarningResponseProtocolIEs,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 3)]
 pub struct XnExtTLA_Item {
     #[asn(optional_idx = 0)]
@@ -6837,19 +6836,19 @@ pub struct XnExtTLA_Item {
     pub ie_extensions: Option<XnExtTLA_ItemIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct XnExtTLAs(pub Vec<XnExtTLA_Item>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "16")]
 pub struct XnGTP_TLAs(pub Vec<TransportLayerAddress>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE-OF", sz_extensible = false, sz_lb = "1", sz_ub = "2")]
 pub struct XnTLAs(pub Vec<TransportLayerAddress>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = true, optional_fields = 2)]
 pub struct XnTNLConfigurationInfo {
     pub xn_transport_layer_addresses: XnTLAs,
@@ -6859,11 +6858,11 @@ pub struct XnTNLConfigurationInfo {
     pub ie_extensions: Option<XnTNLConfigurationInfoIE_Extensions>,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMF_TNLAssociationSetupItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6874,11 +6873,11 @@ pub struct AMF_TNLAssociationSetupItemIE_Extensions(
     pub Vec<AMF_TNLAssociationSetupItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMF_TNLAssociationToAddItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6889,14 +6888,14 @@ pub struct AMF_TNLAssociationToAddItemIE_Extensions(
     pub Vec<AMF_TNLAssociationToAddItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AMF_TNLAssociationToRemoveItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 168)]
     Id_TNLAssociationTransportLayerAddressNGRAN(CPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMF_TNLAssociationToRemoveItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -6905,7 +6904,7 @@ pub struct AMF_TNLAssociationToRemoveItemIE_Extensions_Entry {
     pub extension_value: AMF_TNLAssociationToRemoveItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6916,11 +6915,11 @@ pub struct AMF_TNLAssociationToRemoveItemIE_Extensions(
     pub Vec<AMF_TNLAssociationToRemoveItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMF_TNLAssociationToUpdateItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6931,7 +6930,7 @@ pub struct AMF_TNLAssociationToUpdateItemIE_Extensions(
     pub Vec<AMF_TNLAssociationToUpdateItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AMFCPRelocationIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -6944,7 +6943,7 @@ pub enum AMFCPRelocationIndicationProtocolIEs_EntryValue {
     Id_S_NSSAI(S_NSSAI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMFCPRelocationIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6953,7 +6952,7 @@ pub struct AMFCPRelocationIndicationProtocolIEs_Entry {
     pub value: AMFCPRelocationIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -6964,7 +6963,7 @@ pub struct AMFCPRelocationIndicationProtocolIEs(
     pub Vec<AMFCPRelocationIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AMFConfigurationUpdateProtocolIEs_EntryValue {
     #[asn(key = 6)]
@@ -6985,7 +6984,7 @@ pub enum AMFConfigurationUpdateProtocolIEs_EntryValue {
     Id_ServedGUAMIList(ServedGUAMIList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMFConfigurationUpdateProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -6994,7 +6993,7 @@ pub struct AMFConfigurationUpdateProtocolIEs_Entry {
     pub value: AMFConfigurationUpdateProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7003,7 +7002,7 @@ pub struct AMFConfigurationUpdateProtocolIEs_Entry {
 )]
 pub struct AMFConfigurationUpdateProtocolIEs(pub Vec<AMFConfigurationUpdateProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AMFConfigurationUpdateAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 4)]
@@ -7014,7 +7013,7 @@ pub enum AMFConfigurationUpdateAcknowledgeProtocolIEs_EntryValue {
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMFConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7023,7 +7022,7 @@ pub struct AMFConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     pub value: AMFConfigurationUpdateAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7034,7 +7033,7 @@ pub struct AMFConfigurationUpdateAcknowledgeProtocolIEs(
     pub Vec<AMFConfigurationUpdateAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AMFConfigurationUpdateFailureProtocolIEs_EntryValue {
     #[asn(key = 15)]
@@ -7045,7 +7044,7 @@ pub enum AMFConfigurationUpdateFailureProtocolIEs_EntryValue {
     Id_TimeToWait(TimeToWait),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMFConfigurationUpdateFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7054,7 +7053,7 @@ pub struct AMFConfigurationUpdateFailureProtocolIEs_Entry {
     pub value: AMFConfigurationUpdateFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7065,18 +7064,18 @@ pub struct AMFConfigurationUpdateFailureProtocolIEs(
     pub Vec<AMFConfigurationUpdateFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMFPagingTargetchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AMFStatusIndicationProtocolIEs_EntryValue {
     #[asn(key = 120)]
     Id_UnavailableGUAMIList(UnavailableGUAMIList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AMFStatusIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7085,7 +7084,7 @@ pub struct AMFStatusIndicationProtocolIEs_Entry {
     pub value: AMFStatusIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7094,14 +7093,14 @@ pub struct AMFStatusIndicationProtocolIEs_Entry {
 )]
 pub struct AMFStatusIndicationProtocolIEs(pub Vec<AMFStatusIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AdditionalDLUPTNLInformationForHOItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 183)]
     Id_AdditionalRedundantDL_NGU_UP_TNLInformation(UPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AdditionalDLUPTNLInformationForHOItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -7110,7 +7109,7 @@ pub struct AdditionalDLUPTNLInformationForHOItemIE_Extensions_Entry {
     pub extension_value: AdditionalDLUPTNLInformationForHOItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7121,11 +7120,11 @@ pub struct AdditionalDLUPTNLInformationForHOItemIE_Extensions(
     pub Vec<AdditionalDLUPTNLInformationForHOItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AllocationAndRetentionPriorityIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7136,7 +7135,7 @@ pub struct AllocationAndRetentionPriorityIE_Extensions(
     pub Vec<AllocationAndRetentionPriorityIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_2(pub u8);
 impl ENUMERATED_2 {
@@ -7144,11 +7143,11 @@ impl ENUMERATED_2 {
     pub const NOT_RESTRICTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Allowed_PNI_NPN_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7157,11 +7156,11 @@ pub struct Allowed_PNI_NPN_ItemIE_Extensions_Entry {}
 )]
 pub struct Allowed_PNI_NPN_ItemIE_Extensions(pub Vec<Allowed_PNI_NPN_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AllowedNSSAI_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7170,11 +7169,11 @@ pub struct AllowedNSSAI_ItemIE_Extensions_Entry {}
 )]
 pub struct AllowedNSSAI_ItemIE_Extensions(pub Vec<AllowedNSSAI_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AlternativeQoSParaSetItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7185,11 +7184,11 @@ pub struct AlternativeQoSParaSetItemIE_Extensions(
     pub Vec<AlternativeQoSParaSetItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaOfInterestIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7198,11 +7197,11 @@ pub struct AreaOfInterestIE_Extensions_Entry {}
 )]
 pub struct AreaOfInterestIE_Extensions(pub Vec<AreaOfInterestIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaOfInterestCellItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7211,11 +7210,11 @@ pub struct AreaOfInterestCellItemIE_Extensions_Entry {}
 )]
 pub struct AreaOfInterestCellItemIE_Extensions(pub Vec<AreaOfInterestCellItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaOfInterestItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7224,11 +7223,11 @@ pub struct AreaOfInterestItemIE_Extensions_Entry {}
 )]
 pub struct AreaOfInterestItemIE_Extensions(pub Vec<AreaOfInterestItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaOfInterestRANNodeItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7239,11 +7238,11 @@ pub struct AreaOfInterestRANNodeItemIE_Extensions(
     pub Vec<AreaOfInterestRANNodeItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaOfInterestTAIItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7252,27 +7251,27 @@ pub struct AreaOfInterestTAIItemIE_Extensions_Entry {}
 )]
 pub struct AreaOfInterestTAIItemIE_Extensions(pub Vec<AreaOfInterestTAIItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_3;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaScopeOfMDT_EUTRAchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_4;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaScopeOfMDT_NRchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AreaScopeOfNeighCellsItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7283,7 +7282,7 @@ pub struct AreaScopeOfNeighCellsItemIE_Extensions(
     pub Vec<AreaScopeOfNeighCellsItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AssistanceDataForPagingIE_Extensions_EntryExtensionValue {
     #[asn(key = 260)]
@@ -7292,7 +7291,7 @@ pub enum AssistanceDataForPagingIE_Extensions_EntryExtensionValue {
     Id_PagingAssisDataforCEcapabUE(PagingAssisDataforCEcapabUE),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AssistanceDataForPagingIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -7301,7 +7300,7 @@ pub struct AssistanceDataForPagingIE_Extensions_Entry {
     pub extension_value: AssistanceDataForPagingIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7312,11 +7311,11 @@ pub struct AssistanceDataForPagingIE_Extensions(
     pub Vec<AssistanceDataForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AssistanceDataForRecommendedCellsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7327,7 +7326,7 @@ pub struct AssistanceDataForRecommendedCellsIE_Extensions(
     pub Vec<AssistanceDataForRecommendedCellsIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_5(pub u8);
 impl ENUMERATED_5 {
@@ -7335,14 +7334,14 @@ impl ENUMERATED_5 {
     pub const DL: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum AssociatedQosFlowItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 221)]
     Id_CurrentQoSParaSetIndex(AlternativeQoSParaSetIndex),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct AssociatedQosFlowItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -7351,7 +7350,7 @@ pub struct AssociatedQosFlowItemIE_Extensions_Entry {
     pub extension_value: AssociatedQosFlowItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7360,11 +7359,11 @@ pub struct AssociatedQosFlowItemIE_Extensions_Entry {
 )]
 pub struct AssociatedQosFlowItemIE_Extensions(pub Vec<AssociatedQosFlowItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct BluetoothMeasConfigNameItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7375,18 +7374,18 @@ pub struct BluetoothMeasConfigNameItemIE_Extensions(
     pub Vec<BluetoothMeasConfigNameItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_6(pub u8);
 impl ENUMERATED_6 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct BluetoothMeasurementConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7397,15 +7396,15 @@ pub struct BluetoothMeasurementConfigurationIE_Extensions(
     pub Vec<BluetoothMeasurementConfigurationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct BroadcastCancelledAreaListchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct BroadcastCompletedAreaListchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum BroadcastPLMNItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 271)]
@@ -7414,7 +7413,7 @@ pub enum BroadcastPLMNItemIE_Extensions_EntryExtensionValue {
     Id_NPN_Support(NPN_Support),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct BroadcastPLMNItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -7423,7 +7422,7 @@ pub struct BroadcastPLMNItemIE_Extensions_Entry {
     pub extension_value: BroadcastPLMNItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7432,11 +7431,11 @@ pub struct BroadcastPLMNItemIE_Extensions_Entry {
 )]
 pub struct BroadcastPLMNItemIE_Extensions(pub Vec<BroadcastPLMNItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CNAssistedRANTuningIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7445,7 +7444,7 @@ pub struct CNAssistedRANTuningIE_Extensions_Entry {}
 )]
 pub struct CNAssistedRANTuningIE_Extensions(pub Vec<CNAssistedRANTuningIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_7(pub u8);
 impl ENUMERATED_7 {
@@ -7453,11 +7452,11 @@ impl ENUMERATED_7 {
     pub const FIVE_GC_FORBIDDEN: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CNTypeRestrictionsForEquivalentItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7468,19 +7467,19 @@ pub struct CNTypeRestrictionsForEquivalentItemIE_Extensions(
     pub Vec<CNTypeRestrictionsForEquivalentItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct INTEGER_8(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1048575")]
 pub struct INTEGER_9(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct COUNTValueForPDCP_SN12IE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7489,19 +7488,19 @@ pub struct COUNTValueForPDCP_SN12IE_Extensions_Entry {}
 )]
 pub struct COUNTValueForPDCP_SN12IE_Extensions(pub Vec<COUNTValueForPDCP_SN12IE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "262143")]
 pub struct INTEGER_10(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "16383")]
 pub struct INTEGER_11(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct COUNTValueForPDCP_SN18IE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7510,14 +7509,14 @@ pub struct COUNTValueForPDCP_SN18IE_Extensions_Entry {}
 )]
 pub struct COUNTValueForPDCP_SN18IE_Extensions(pub Vec<COUNTValueForPDCP_SN18IE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CPTransportLayerInformationchoice_ExtensionsValue {
     #[asn(key = 169)]
     Id_EndpointIPAddressAndPort(EndpointIPAddressAndPort),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CPTransportLayerInformationchoice_Extensions {
     #[asn(key_field = true)]
@@ -7526,11 +7525,11 @@ pub struct CPTransportLayerInformationchoice_Extensions {
     pub value: CPTransportLayerInformationchoice_ExtensionsValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CancelledCellsInEAI_EUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7541,11 +7540,11 @@ pub struct CancelledCellsInEAI_EUTRA_ItemIE_Extensions(
     pub Vec<CancelledCellsInEAI_EUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CancelledCellsInEAI_NR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7556,11 +7555,11 @@ pub struct CancelledCellsInEAI_NR_ItemIE_Extensions(
     pub Vec<CancelledCellsInEAI_NR_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CancelledCellsInTAI_EUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7571,11 +7570,11 @@ pub struct CancelledCellsInTAI_EUTRA_ItemIE_Extensions(
     pub Vec<CancelledCellsInTAI_EUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CancelledCellsInTAI_NR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7586,15 +7585,15 @@ pub struct CancelledCellsInTAI_NR_ItemIE_Extensions(
     pub Vec<CancelledCellsInTAI_NR_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CandidateCellchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CandidateCellIDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7603,11 +7602,11 @@ pub struct CandidateCellIDIE_Extensions_Entry {}
 )]
 pub struct CandidateCellIDIE_Extensions(pub Vec<CandidateCellIDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CandidateCellItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7616,19 +7615,19 @@ pub struct CandidateCellItemIE_Extensions_Entry {}
 )]
 pub struct CandidateCellItemIE_Extensions(pub Vec<CandidateCellItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "1007", extensible = true)]
 pub struct INTEGER_12(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "3279165")]
 pub struct INTEGER_13(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CandidatePCIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7637,15 +7636,15 @@ pub struct CandidatePCIIE_Extensions_Entry {}
 )]
 pub struct CandidatePCIIE_Extensions(pub Vec<CandidatePCIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Causechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Cell_CAGInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7654,11 +7653,11 @@ pub struct Cell_CAGInformationIE_Extensions_Entry {}
 )]
 pub struct Cell_CAGInformationIE_Extensions(pub Vec<Cell_CAGInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellBasedMDT_EUTRAIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7667,11 +7666,11 @@ pub struct CellBasedMDT_EUTRAIE_Extensions_Entry {}
 )]
 pub struct CellBasedMDT_EUTRAIE_Extensions(pub Vec<CellBasedMDT_EUTRAIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellBasedMDT_NRIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7680,11 +7679,11 @@ pub struct CellBasedMDT_NRIE_Extensions_Entry {}
 )]
 pub struct CellBasedMDT_NRIE_Extensions(pub Vec<CellBasedMDT_NRIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellIDBroadcastEUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7695,11 +7694,11 @@ pub struct CellIDBroadcastEUTRA_ItemIE_Extensions(
     pub Vec<CellIDBroadcastEUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellIDBroadcastNR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7708,11 +7707,11 @@ pub struct CellIDBroadcastNR_ItemIE_Extensions_Entry {}
 )]
 pub struct CellIDBroadcastNR_ItemIE_Extensions(pub Vec<CellIDBroadcastNR_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellIDCancelledEUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7723,11 +7722,11 @@ pub struct CellIDCancelledEUTRA_ItemIE_Extensions(
     pub Vec<CellIDCancelledEUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellIDCancelledNR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7736,11 +7735,11 @@ pub struct CellIDCancelledNR_ItemIE_Extensions_Entry {}
 )]
 pub struct CellIDCancelledNR_ItemIE_Extensions(pub Vec<CellIDCancelledNR_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellIDListForRestartchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CellTrafficTraceProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -7759,7 +7758,7 @@ pub enum CellTrafficTraceProtocolIEs_EntryValue {
     Id_TraceCollectionEntityURI(URI_address),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellTrafficTraceProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7768,7 +7767,7 @@ pub struct CellTrafficTraceProtocolIEs_Entry {
     pub value: CellTrafficTraceProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7777,11 +7776,11 @@ pub struct CellTrafficTraceProtocolIEs_Entry {
 )]
 pub struct CellTrafficTraceProtocolIEs(pub Vec<CellTrafficTraceProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CellTypeIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7790,11 +7789,11 @@ pub struct CellTypeIE_Extensions_Entry {}
 )]
 pub struct CellTypeIE_Extensions(pub Vec<CellTypeIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CompletedCellsInEAI_EUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7805,11 +7804,11 @@ pub struct CompletedCellsInEAI_EUTRA_ItemIE_Extensions(
     pub Vec<CompletedCellsInEAI_EUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CompletedCellsInEAI_NR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7820,11 +7819,11 @@ pub struct CompletedCellsInEAI_NR_ItemIE_Extensions(
     pub Vec<CompletedCellsInEAI_NR_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CompletedCellsInTAI_EUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7835,11 +7834,11 @@ pub struct CompletedCellsInTAI_EUTRA_ItemIE_Extensions(
     pub Vec<CompletedCellsInTAI_EUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CompletedCellsInTAI_NR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7850,7 +7849,7 @@ pub struct CompletedCellsInTAI_NR_ItemIE_Extensions(
     pub Vec<CompletedCellsInTAI_NR_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ConnectionEstablishmentIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -7879,7 +7878,7 @@ pub enum ConnectionEstablishmentIndicationProtocolIEs_EntryValue {
     Id_UERadioCapabilityID(UERadioCapabilityID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ConnectionEstablishmentIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -7888,7 +7887,7 @@ pub struct ConnectionEstablishmentIndicationProtocolIEs_Entry {
     pub value: ConnectionEstablishmentIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7899,7 +7898,7 @@ pub struct ConnectionEstablishmentIndicationProtocolIEs(
     pub Vec<ConnectionEstablishmentIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum CoreNetworkAssistanceInformationForInactiveIE_Extensions_EntryExtensionValue {
     #[asn(key = 280)]
@@ -7910,7 +7909,7 @@ pub enum CoreNetworkAssistanceInformationForInactiveIE_Extensions_EntryExtension
     Id_UERadioCapabilityForPaging(UERadioCapabilityForPaging),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CoreNetworkAssistanceInformationForInactiveIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -7920,7 +7919,7 @@ pub struct CoreNetworkAssistanceInformationForInactiveIE_Extensions_Entry {
         CoreNetworkAssistanceInformationForInactiveIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7931,11 +7930,11 @@ pub struct CoreNetworkAssistanceInformationForInactiveIE_Extensions(
     pub Vec<CoreNetworkAssistanceInformationForInactiveIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CriticalityDiagnosticsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7944,11 +7943,11 @@ pub struct CriticalityDiagnosticsIE_Extensions_Entry {}
 )]
 pub struct CriticalityDiagnosticsIE_Extensions(pub Vec<CriticalityDiagnosticsIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct CriticalityDiagnostics_IE_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7959,18 +7958,18 @@ pub struct CriticalityDiagnostics_IE_ItemIE_Extensions(
     pub Vec<CriticalityDiagnostics_IE_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_14(pub u8);
 impl ENUMERATED_14 {
     pub const DAPS_HO_REQUIRED: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DAPSRequestInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -7979,7 +7978,7 @@ pub struct DAPSRequestInfoIE_Extensions_Entry {}
 )]
 pub struct DAPSRequestInfoIE_Extensions(pub Vec<DAPSRequestInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_15(pub u8);
 impl ENUMERATED_15 {
@@ -7987,11 +7986,11 @@ impl ENUMERATED_15 {
     pub const DAPS_HO_NOT_ACCEPTED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DAPSResponseInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8000,11 +7999,11 @@ pub struct DAPSResponseInfoIE_Extensions_Entry {}
 )]
 pub struct DAPSResponseInfoIE_Extensions(pub Vec<DAPSResponseInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DAPSResponseInfoItemIE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8013,11 +8012,11 @@ pub struct DAPSResponseInfoItemIE_Extension_Entry {}
 )]
 pub struct DAPSResponseInfoItemIE_Extension(pub Vec<DAPSResponseInfoItemIE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DL_CP_SecurityInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8028,15 +8027,15 @@ pub struct DL_CP_SecurityInformationIE_Extensions(
     pub Vec<DL_CP_SecurityInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBStatusDLchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBStatusDL12IE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8045,11 +8044,11 @@ pub struct DRBStatusDL12IE_Extension_Entry {}
 )]
 pub struct DRBStatusDL12IE_Extension(pub Vec<DRBStatusDL12IE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBStatusDL18IE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8058,19 +8057,19 @@ pub struct DRBStatusDL18IE_Extension_Entry {}
 )]
 pub struct DRBStatusDL18IE_Extension(pub Vec<DRBStatusDL18IE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBStatusULchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "1", sz_ub = "2048")]
 pub struct BIT_STRING_16(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBStatusUL12IE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8079,7 +8078,7 @@ pub struct DRBStatusUL12IE_Extension_Entry {}
 )]
 pub struct DRBStatusUL12IE_Extension(pub Vec<DRBStatusUL12IE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "BITSTRING",
     sz_extensible = false,
@@ -8088,11 +8087,11 @@ pub struct DRBStatusUL12IE_Extension(pub Vec<DRBStatusUL12IE_Extension_Entry>);
 )]
 pub struct BIT_STRING_17(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBStatusUL18IE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8101,11 +8100,11 @@ pub struct DRBStatusUL18IE_Extension_Entry {}
 )]
 pub struct DRBStatusUL18IE_Extension(pub Vec<DRBStatusUL18IE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBsSubjectToEarlyStatusTransfer_ItemIE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8116,14 +8115,14 @@ pub struct DRBsSubjectToEarlyStatusTransfer_ItemIE_Extension(
     pub Vec<DRBsSubjectToEarlyStatusTransfer_ItemIE_Extension_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DRBsSubjectToStatusTransferItemIE_Extension_EntryExtensionValue {
     #[asn(key = 159)]
     Id_OldAssociatedQosFlowList_ULendmarkerexpected(AssociatedQosFlowList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBsSubjectToStatusTransferItemIE_Extension_Entry {
     #[asn(key_field = true)]
@@ -8132,7 +8131,7 @@ pub struct DRBsSubjectToStatusTransferItemIE_Extension_Entry {
     pub extension_value: DRBsSubjectToStatusTransferItemIE_Extension_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8143,14 +8142,14 @@ pub struct DRBsSubjectToStatusTransferItemIE_Extension(
     pub Vec<DRBsSubjectToStatusTransferItemIE_Extension_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DRBsToQosFlowsMappingItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 266)]
     Id_DAPSRequestInfo(DAPSRequestInfo),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DRBsToQosFlowsMappingItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8159,7 +8158,7 @@ pub struct DRBsToQosFlowsMappingItemIE_Extensions_Entry {
     pub extension_value: DRBsToQosFlowsMappingItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8170,11 +8169,11 @@ pub struct DRBsToQosFlowsMappingItemIE_Extensions(
     pub Vec<DRBsToQosFlowsMappingItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DataForwardingResponseDRBItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8185,11 +8184,11 @@ pub struct DataForwardingResponseDRBItemIE_Extensions(
     pub Vec<DataForwardingResponseDRBItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DataForwardingResponseERABListItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8200,7 +8199,7 @@ pub struct DataForwardingResponseERABListItemIE_Extensions(
     pub Vec<DataForwardingResponseERABListItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DeactivateTraceProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -8211,7 +8210,7 @@ pub enum DeactivateTraceProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DeactivateTraceProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8220,7 +8219,7 @@ pub struct DeactivateTraceProtocolIEs_Entry {
     pub value: DeactivateTraceProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8229,7 +8228,7 @@ pub struct DeactivateTraceProtocolIEs_Entry {
 )]
 pub struct DeactivateTraceProtocolIEs(pub Vec<DeactivateTraceProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkNASTransportProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -8270,7 +8269,7 @@ pub enum DownlinkNASTransportProtocolIEs_EntryValue {
     Id_UERadioCapabilityID(UERadioCapabilityID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkNASTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8279,7 +8278,7 @@ pub struct DownlinkNASTransportProtocolIEs_Entry {
     pub value: DownlinkNASTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8288,7 +8287,7 @@ pub struct DownlinkNASTransportProtocolIEs_Entry {
 )]
 pub struct DownlinkNASTransportProtocolIEs(pub Vec<DownlinkNASTransportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkNonUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 46)]
@@ -8297,7 +8296,7 @@ pub enum DownlinkNonUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     Id_RoutingID(RoutingID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkNonUEAssociatedNRPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8306,7 +8305,7 @@ pub struct DownlinkNonUEAssociatedNRPPaTransportProtocolIEs_Entry {
     pub value: DownlinkNonUEAssociatedNRPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8317,7 +8316,7 @@ pub struct DownlinkNonUEAssociatedNRPPaTransportProtocolIEs(
     pub Vec<DownlinkNonUEAssociatedNRPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkRANConfigurationTransferProtocolIEs_EntryValue {
     #[asn(key = 157)]
@@ -8328,7 +8327,7 @@ pub enum DownlinkRANConfigurationTransferProtocolIEs_EntryValue {
     Id_SONConfigurationTransferDL(SONConfigurationTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkRANConfigurationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8337,7 +8336,7 @@ pub struct DownlinkRANConfigurationTransferProtocolIEs_Entry {
     pub value: DownlinkRANConfigurationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8348,7 +8347,7 @@ pub struct DownlinkRANConfigurationTransferProtocolIEs(
     pub Vec<DownlinkRANConfigurationTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkRANEarlyStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -8359,7 +8358,7 @@ pub enum DownlinkRANEarlyStatusTransferProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkRANEarlyStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8368,7 +8367,7 @@ pub struct DownlinkRANEarlyStatusTransferProtocolIEs_Entry {
     pub value: DownlinkRANEarlyStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8379,7 +8378,7 @@ pub struct DownlinkRANEarlyStatusTransferProtocolIEs(
     pub Vec<DownlinkRANEarlyStatusTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkRANStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -8390,7 +8389,7 @@ pub enum DownlinkRANStatusTransferProtocolIEs_EntryValue {
     Id_RANStatusTransfer_TransparentContainer(RANStatusTransfer_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkRANStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8399,7 +8398,7 @@ pub struct DownlinkRANStatusTransferProtocolIEs_Entry {
     pub value: DownlinkRANStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8410,14 +8409,14 @@ pub struct DownlinkRANStatusTransferProtocolIEs(
     pub Vec<DownlinkRANStatusTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkRIMInformationTransferProtocolIEs_EntryValue {
     #[asn(key = 175)]
     Id_RIMInformationTransfer(RIMInformationTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkRIMInformationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8426,7 +8425,7 @@ pub struct DownlinkRIMInformationTransferProtocolIEs_Entry {
     pub value: DownlinkRIMInformationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8437,7 +8436,7 @@ pub struct DownlinkRIMInformationTransferProtocolIEs(
     pub Vec<DownlinkRIMInformationTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum DownlinkUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -8450,7 +8449,7 @@ pub enum DownlinkUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     Id_RoutingID(RoutingID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct DownlinkUEAssociatedNRPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8459,7 +8458,7 @@ pub struct DownlinkUEAssociatedNRPPaTransportProtocolIEs_Entry {
     pub value: DownlinkUEAssociatedNRPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8470,7 +8469,7 @@ pub struct DownlinkUEAssociatedNRPPaTransportProtocolIEs(
     pub Vec<DownlinkUEAssociatedNRPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum Dynamic5QIDescriptorIE_Extensions_EntryExtensionValue {
     #[asn(key = 187)]
@@ -8481,7 +8480,7 @@ pub enum Dynamic5QIDescriptorIE_Extensions_EntryExtensionValue {
     Id_ExtendedPacketDelayBudget(ExtendedPacketDelayBudget),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Dynamic5QIDescriptorIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8490,7 +8489,7 @@ pub struct Dynamic5QIDescriptorIE_Extensions_Entry {
     pub extension_value: Dynamic5QIDescriptorIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8499,11 +8498,11 @@ pub struct Dynamic5QIDescriptorIE_Extensions_Entry {
 )]
 pub struct Dynamic5QIDescriptorIE_Extensions(pub Vec<Dynamic5QIDescriptorIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct E_RABInformationItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8512,31 +8511,31 @@ pub struct E_RABInformationItemIE_Extensions_Entry {}
 )]
 pub struct E_RABInformationItemIE_Extensions(pub Vec<E_RABInformationItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "20", sz_ub = "20")]
 pub struct BIT_STRING_18(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "28", sz_ub = "28")]
 pub struct BIT_STRING_19(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "18", sz_ub = "18")]
 pub struct BIT_STRING_20(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "21", sz_ub = "21")]
 pub struct BIT_STRING_21(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ENB_IDchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EPS_TAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8545,11 +8544,11 @@ pub struct EPS_TAIIE_Extensions_Entry {}
 )]
 pub struct EPS_TAIIE_Extensions(pub Vec<EPS_TAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EUTRA_CGIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8558,11 +8557,11 @@ pub struct EUTRA_CGIIE_Extensions_Entry {}
 )]
 pub struct EUTRA_CGIIE_Extensions(pub Vec<EUTRA_CGIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EarlyStatusTransfer_TransparentContainerIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8573,11 +8572,11 @@ pub struct EarlyStatusTransfer_TransparentContainerIE_Extensions(
     pub Vec<EarlyStatusTransfer_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EmergencyAreaIDBroadcastEUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8588,11 +8587,11 @@ pub struct EmergencyAreaIDBroadcastEUTRA_ItemIE_Extensions(
     pub Vec<EmergencyAreaIDBroadcastEUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EmergencyAreaIDBroadcastNR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8603,11 +8602,11 @@ pub struct EmergencyAreaIDBroadcastNR_ItemIE_Extensions(
     pub Vec<EmergencyAreaIDBroadcastNR_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EmergencyAreaIDCancelledEUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8618,11 +8617,11 @@ pub struct EmergencyAreaIDCancelledEUTRA_ItemIE_Extensions(
     pub Vec<EmergencyAreaIDCancelledEUTRA_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EmergencyAreaIDCancelledNR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8633,11 +8632,11 @@ pub struct EmergencyAreaIDCancelledNR_ItemIE_Extensions(
     pub Vec<EmergencyAreaIDCancelledNR_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EmergencyFallbackIndicatorIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8648,11 +8647,11 @@ pub struct EmergencyFallbackIndicatorIE_Extensions(
     pub Vec<EmergencyFallbackIndicatorIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EndpointIPAddressAndPortIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8663,7 +8662,7 @@ pub struct EndpointIPAddressAndPortIE_Extensions(
     pub Vec<EndpointIPAddressAndPortIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ErrorIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -8678,7 +8677,7 @@ pub enum ErrorIndicationProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ErrorIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -8687,7 +8686,7 @@ pub struct ErrorIndicationProtocolIEs_Entry {
     pub value: ErrorIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8696,11 +8695,11 @@ pub struct ErrorIndicationProtocolIEs_Entry {
 )]
 pub struct ErrorIndicationProtocolIEs(pub Vec<ErrorIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EventL1LoggedMDTConfigIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8709,22 +8708,22 @@ pub struct EventL1LoggedMDTConfigIE_Extensions_Entry {}
 )]
 pub struct EventL1LoggedMDTConfigIE_Extensions(pub Vec<EventL1LoggedMDTConfigIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_22(pub u8);
 impl ENUMERATED_22 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct EventTriggerchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ExpectedUEActivityBehaviourIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8735,11 +8734,11 @@ pub struct ExpectedUEActivityBehaviourIE_Extensions(
     pub Vec<ExpectedUEActivityBehaviourIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ExpectedUEBehaviourIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8748,15 +8747,15 @@ pub struct ExpectedUEBehaviourIE_Extensions_Entry {}
 )]
 pub struct ExpectedUEBehaviourIE_Extensions(pub Vec<ExpectedUEBehaviourIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct INTEGER_23(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ExpectedUEMovingTrajectoryItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8767,11 +8766,11 @@ pub struct ExpectedUEMovingTrajectoryItemIE_Extensions(
     pub Vec<ExpectedUEMovingTrajectoryItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Extended_AMFNameIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8780,11 +8779,11 @@ pub struct Extended_AMFNameIE_Extensions_Entry {}
 )]
 pub struct Extended_AMFNameIE_Extensions(pub Vec<Extended_AMFNameIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct Extended_RANNodeNameIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8793,19 +8792,19 @@ pub struct Extended_RANNodeNameIE_Extensions_Entry {}
 )]
 pub struct Extended_RANNodeNameIE_Extensions(pub Vec<Extended_RANNodeNameIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "8", sz_ub = "8")]
 pub struct BIT_STRING_24(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "8", sz_ub = "8")]
 pub struct BIT_STRING_25(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ExtendedRATRestrictionInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8816,11 +8815,11 @@ pub struct ExtendedRATRestrictionInformationIE_Extensions(
     pub Vec<ExtendedRATRestrictionInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct FailureIndicationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8829,11 +8828,11 @@ pub struct FailureIndicationIE_Extensions_Entry {}
 )]
 pub struct FailureIndicationIE_Extensions(pub Vec<FailureIndicationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct FirstDLCountIE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8842,11 +8841,11 @@ pub struct FirstDLCountIE_Extension_Entry {}
 )]
 pub struct FirstDLCountIE_Extension(pub Vec<FirstDLCountIE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct FiveG_S_TMSIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8855,11 +8854,11 @@ pub struct FiveG_S_TMSIIE_Extensions_Entry {}
 )]
 pub struct FiveG_S_TMSIIE_Extensions(pub Vec<FiveG_S_TMSIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ForbiddenAreaInformation_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8870,11 +8869,11 @@ pub struct ForbiddenAreaInformation_ItemIE_Extensions(
     pub Vec<ForbiddenAreaInformation_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct FromEUTRANtoNGRANIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8883,11 +8882,11 @@ pub struct FromEUTRANtoNGRANIE_Extensions_Entry {}
 )]
 pub struct FromEUTRANtoNGRANIE_Extensions(pub Vec<FromEUTRANtoNGRANIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct FromNGRANtoEUTRANIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8896,14 +8895,14 @@ pub struct FromNGRANtoEUTRANIE_Extensions_Entry {}
 )]
 pub struct FromNGRANtoEUTRANIE_Extensions(pub Vec<FromNGRANtoEUTRANIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum GBR_QosInformationIE_Extensions_EntryExtensionValue {
     #[asn(key = 220)]
     Id_AlternativeQoSParaSetList(AlternativeQoSParaSetList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GBR_QosInformationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -8912,7 +8911,7 @@ pub struct GBR_QosInformationIE_Extensions_Entry {
     pub extension_value: GBR_QosInformationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8921,19 +8920,19 @@ pub struct GBR_QosInformationIE_Extensions_Entry {
 )]
 pub struct GBR_QosInformationIE_Extensions(pub Vec<GBR_QosInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "22", sz_ub = "32")]
 pub struct BIT_STRING_26(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GNB_IDchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GTPTunnelIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8942,11 +8941,11 @@ pub struct GTPTunnelIE_Extensions_Entry {}
 )]
 pub struct GTPTunnelIE_Extensions(pub Vec<GTPTunnelIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GUAMIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8955,11 +8954,11 @@ pub struct GUAMIIE_Extensions_Entry {}
 )]
 pub struct GUAMIIE_Extensions(pub Vec<GUAMIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalENB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8968,11 +8967,11 @@ pub struct GlobalENB_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalENB_IDIE_Extensions(pub Vec<GlobalENB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalGNB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8981,11 +8980,11 @@ pub struct GlobalGNB_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalGNB_IDIE_Extensions(pub Vec<GlobalGNB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalLine_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -8994,11 +8993,11 @@ pub struct GlobalLine_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalLine_IDIE_Extensions(pub Vec<GlobalLine_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalN3IWF_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9007,11 +9006,11 @@ pub struct GlobalN3IWF_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalN3IWF_IDIE_Extensions(pub Vec<GlobalN3IWF_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalNgENB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9020,7 +9019,7 @@ pub struct GlobalNgENB_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalNgENB_IDIE_Extensions(pub Vec<GlobalNgENB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum GlobalRANNodeIDchoice_ExtensionsValue {
     #[asn(key = 240)]
@@ -9031,7 +9030,7 @@ pub enum GlobalRANNodeIDchoice_ExtensionsValue {
     Id_GlobalW_AGF_ID(GlobalW_AGF_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalRANNodeIDchoice_Extensions {
     #[asn(key_field = true)]
@@ -9040,11 +9039,11 @@ pub struct GlobalRANNodeIDchoice_Extensions {
     pub value: GlobalRANNodeIDchoice_ExtensionsValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalTNGF_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9053,11 +9052,11 @@ pub struct GlobalTNGF_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalTNGF_IDIE_Extensions(pub Vec<GlobalTNGF_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalTWIF_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9066,11 +9065,11 @@ pub struct GlobalTWIF_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalTWIF_IDIE_Extensions(pub Vec<GlobalTWIF_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct GlobalW_AGF_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9079,7 +9078,7 @@ pub struct GlobalW_AGF_IDIE_Extensions_Entry {}
 )]
 pub struct GlobalW_AGF_IDIE_Extensions(pub Vec<GlobalW_AGF_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct ENUMERATED_27(pub u8);
 impl ENUMERATED_27 {
@@ -9088,15 +9087,15 @@ impl ENUMERATED_27 {
     pub const INTERSYSTEM_PING_PONG: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct BIT_STRING_28(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HOReportIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9105,7 +9104,7 @@ pub struct HOReportIE_Extensions_Entry {}
 )]
 pub struct HOReportIE_Extensions(pub Vec<HOReportIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverCancelProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9116,7 +9115,7 @@ pub enum HandoverCancelProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverCancelProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9125,7 +9124,7 @@ pub struct HandoverCancelProtocolIEs_Entry {
     pub value: HandoverCancelProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9134,7 +9133,7 @@ pub struct HandoverCancelProtocolIEs_Entry {
 )]
 pub struct HandoverCancelProtocolIEs(pub Vec<HandoverCancelProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverCancelAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9145,7 +9144,7 @@ pub enum HandoverCancelAcknowledgeProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverCancelAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9154,7 +9153,7 @@ pub struct HandoverCancelAcknowledgeProtocolIEs_Entry {
     pub value: HandoverCancelAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9165,7 +9164,7 @@ pub struct HandoverCancelAcknowledgeProtocolIEs(
     pub Vec<HandoverCancelAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverCommandProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9186,7 +9185,7 @@ pub enum HandoverCommandProtocolIEs_EntryValue {
     Id_TargetToSource_TransparentContainer(TargetToSource_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9195,7 +9194,7 @@ pub struct HandoverCommandProtocolIEs_Entry {
     pub value: HandoverCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9204,7 +9203,7 @@ pub struct HandoverCommandProtocolIEs_Entry {
 )]
 pub struct HandoverCommandProtocolIEs(pub Vec<HandoverCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverCommandTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 152)]
@@ -9217,7 +9216,7 @@ pub enum HandoverCommandTransferIE_Extensions_EntryExtensionValue {
     Id_ULForwardingUP_TNLInformation(UPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverCommandTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9226,7 +9225,7 @@ pub struct HandoverCommandTransferIE_Extensions_Entry {
     pub extension_value: HandoverCommandTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9237,7 +9236,7 @@ pub struct HandoverCommandTransferIE_Extensions(
     pub Vec<HandoverCommandTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverFailureProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9250,7 +9249,7 @@ pub enum HandoverFailureProtocolIEs_EntryValue {
     Id_TargettoSource_Failure_TransparentContainer(TargettoSource_Failure_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9259,7 +9258,7 @@ pub struct HandoverFailureProtocolIEs_Entry {
     pub value: HandoverFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9268,7 +9267,7 @@ pub struct HandoverFailureProtocolIEs_Entry {
 )]
 pub struct HandoverFailureProtocolIEs(pub Vec<HandoverFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverNotifyProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9281,7 +9280,7 @@ pub enum HandoverNotifyProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverNotifyProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9290,7 +9289,7 @@ pub struct HandoverNotifyProtocolIEs_Entry {
     pub value: HandoverNotifyProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9299,7 +9298,7 @@ pub struct HandoverNotifyProtocolIEs_Entry {
 )]
 pub struct HandoverNotifyProtocolIEs(pub Vec<HandoverNotifyProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverPreparationFailureProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9314,7 +9313,7 @@ pub enum HandoverPreparationFailureProtocolIEs_EntryValue {
     Id_TargettoSource_Failure_TransparentContainer(TargettoSource_Failure_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverPreparationFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9323,7 +9322,7 @@ pub struct HandoverPreparationFailureProtocolIEs_Entry {
     pub value: HandoverPreparationFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9334,11 +9333,11 @@ pub struct HandoverPreparationFailureProtocolIEs(
     pub Vec<HandoverPreparationFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverPreparationUnsuccessfulTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9349,7 +9348,7 @@ pub struct HandoverPreparationUnsuccessfulTransferIE_Extensions(
     pub Vec<HandoverPreparationUnsuccessfulTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9422,7 +9421,7 @@ pub enum HandoverRequestProtocolIEs_EntryValue {
     Id_UESecurityCapabilities(UESecurityCapabilities),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9431,7 +9430,7 @@ pub struct HandoverRequestProtocolIEs_Entry {
     pub value: HandoverRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9440,7 +9439,7 @@ pub struct HandoverRequestProtocolIEs_Entry {
 )]
 pub struct HandoverRequestProtocolIEs(pub Vec<HandoverRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRequestAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9457,7 +9456,7 @@ pub enum HandoverRequestAcknowledgeProtocolIEs_EntryValue {
     Id_TargetToSource_TransparentContainer(TargetToSource_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequestAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9466,7 +9465,7 @@ pub struct HandoverRequestAcknowledgeProtocolIEs_Entry {
     pub value: HandoverRequestAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9477,7 +9476,7 @@ pub struct HandoverRequestAcknowledgeProtocolIEs(
     pub Vec<HandoverRequestAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRequestAcknowledgeTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 153)]
@@ -9496,7 +9495,7 @@ pub enum HandoverRequestAcknowledgeTransferIE_Extensions_EntryExtensionValue {
     Id_UsedRSNInformation(RedundantPDUSessionInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequestAcknowledgeTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -9505,7 +9504,7 @@ pub struct HandoverRequestAcknowledgeTransferIE_Extensions_Entry {
     pub extension_value: HandoverRequestAcknowledgeTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9516,7 +9515,7 @@ pub struct HandoverRequestAcknowledgeTransferIE_Extensions(
     pub Vec<HandoverRequestAcknowledgeTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverRequiredProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9537,7 +9536,7 @@ pub enum HandoverRequiredProtocolIEs_EntryValue {
     Id_TargetID(TargetID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequiredProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9546,7 +9545,7 @@ pub struct HandoverRequiredProtocolIEs_Entry {
     pub value: HandoverRequiredProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9555,11 +9554,11 @@ pub struct HandoverRequiredProtocolIEs_Entry {
 )]
 pub struct HandoverRequiredProtocolIEs(pub Vec<HandoverRequiredProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverRequiredTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9570,11 +9569,11 @@ pub struct HandoverRequiredTransferIE_Extensions(
     pub Vec<HandoverRequiredTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverResourceAllocationUnsuccessfulTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9585,7 +9584,7 @@ pub struct HandoverResourceAllocationUnsuccessfulTransferIE_Extensions(
     pub Vec<HandoverResourceAllocationUnsuccessfulTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum HandoverSuccessProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9594,7 +9593,7 @@ pub enum HandoverSuccessProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct HandoverSuccessProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9603,7 +9602,7 @@ pub struct HandoverSuccessProtocolIEs_Entry {
     pub value: HandoverSuccessProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9612,11 +9611,11 @@ pub struct HandoverSuccessProtocolIEs_Entry {
 )]
 pub struct HandoverSuccessProtocolIEs(pub Vec<HandoverSuccessProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ImmediateMDTNrIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9625,11 +9624,11 @@ pub struct ImmediateMDTNrIE_Extensions_Entry {}
 )]
 pub struct ImmediateMDTNrIE_Extensions(pub Vec<ImmediateMDTNrIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InfoOnRecommendedCellsAndRANNodesForPagingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9640,7 +9639,7 @@ pub struct InfoOnRecommendedCellsAndRANNodesForPagingIE_Extensions(
     pub Vec<InfoOnRecommendedCellsAndRANNodesForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialContextSetupFailureProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9655,7 +9654,7 @@ pub enum InitialContextSetupFailureProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialContextSetupFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9664,7 +9663,7 @@ pub struct InitialContextSetupFailureProtocolIEs_Entry {
     pub value: InitialContextSetupFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9675,7 +9674,7 @@ pub struct InitialContextSetupFailureProtocolIEs(
     pub Vec<InitialContextSetupFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialContextSetupRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9754,7 +9753,7 @@ pub enum InitialContextSetupRequestProtocolIEs_EntryValue {
     Id_UESecurityCapabilities(UESecurityCapabilities),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialContextSetupRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9763,7 +9762,7 @@ pub struct InitialContextSetupRequestProtocolIEs_Entry {
     pub value: InitialContextSetupRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9774,7 +9773,7 @@ pub struct InitialContextSetupRequestProtocolIEs(
     pub Vec<InitialContextSetupRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialContextSetupResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -9789,7 +9788,7 @@ pub enum InitialContextSetupResponseProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialContextSetupResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9798,7 +9797,7 @@ pub struct InitialContextSetupResponseProtocolIEs_Entry {
     pub value: InitialContextSetupResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9809,7 +9808,7 @@ pub struct InitialContextSetupResponseProtocolIEs(
     pub Vec<InitialContextSetupResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitialUEMessageProtocolIEs_EntryValue {
     #[asn(key = 3)]
@@ -9846,7 +9845,7 @@ pub enum InitialUEMessageProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InitialUEMessageProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -9855,7 +9854,7 @@ pub struct InitialUEMessageProtocolIEs_Entry {
     pub value: InitialUEMessageProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -9864,7 +9863,7 @@ pub struct InitialUEMessageProtocolIEs_Entry {
 )]
 pub struct InitialUEMessageProtocolIEs(pub Vec<InitialUEMessageProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum InitiatingMessageValue {
     #[asn(key = 64)]
@@ -10001,11 +10000,11 @@ pub enum InitiatingMessageValue {
     Id_WriteReplaceWarning(WriteReplaceWarningRequest),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InterSystemFailureIndicationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10016,11 +10015,11 @@ pub struct InterSystemFailureIndicationIE_Extensions(
     pub Vec<InterSystemFailureIndicationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InterSystemHOReportIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10029,15 +10028,15 @@ pub struct InterSystemHOReportIE_Extensions_Entry {}
 )]
 pub struct InterSystemHOReportIE_Extensions(pub Vec<InterSystemHOReportIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct InterSystemHandoverReportTypechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemSONConfigurationTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10048,19 +10047,19 @@ pub struct IntersystemSONConfigurationTransferIE_Extensions(
     pub Vec<IntersystemSONConfigurationTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemSONInformationchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemSONInformationReportchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemSONNGRANnodeIDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10071,15 +10070,15 @@ pub struct IntersystemSONNGRANnodeIDIE_Extensions(
     pub Vec<IntersystemSONNGRANnodeIDIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemSONTransferTypechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemSONeNBIDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10088,7 +10087,7 @@ pub struct IntersystemSONeNBIDIE_Extensions_Entry {}
 )]
 pub struct IntersystemSONeNBIDIE_Extensions(pub Vec<IntersystemSONeNBIDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_29(pub u8);
 impl ENUMERATED_29 {
@@ -10096,11 +10095,11 @@ impl ENUMERATED_29 {
     pub const FALSE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct IntersystemUnnecessaryHOIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10111,11 +10110,11 @@ pub struct IntersystemUnnecessaryHOIE_Extensions(
     pub Vec<IntersystemUnnecessaryHOIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10124,11 +10123,11 @@ pub struct LAIIE_Extensions_Entry {}
 )]
 pub struct LAIIE_Extensions(pub Vec<LAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LTEUESidelinkAggregateMaximumBitrateIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10139,11 +10138,11 @@ pub struct LTEUESidelinkAggregateMaximumBitrateIE_Extensions(
     pub Vec<LTEUESidelinkAggregateMaximumBitrateIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LTEV2XServicesAuthorizedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10154,15 +10153,15 @@ pub struct LTEV2XServicesAuthorizedIE_Extensions(
     pub Vec<LTEV2XServicesAuthorizedIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LastVisitedCellInformationchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LastVisitedCellItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10171,11 +10170,11 @@ pub struct LastVisitedCellItemIE_Extensions_Entry {}
 )]
 pub struct LastVisitedCellItemIE_Extensions(pub Vec<LastVisitedCellItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LastVisitedNGRANCellInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10186,7 +10185,7 @@ pub struct LastVisitedNGRANCellInformationIE_Extensions(
     pub Vec<LastVisitedNGRANCellInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -10201,7 +10200,7 @@ pub enum LocationReportProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10210,7 +10209,7 @@ pub struct LocationReportProtocolIEs_Entry {
     pub value: LocationReportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10219,7 +10218,7 @@ pub struct LocationReportProtocolIEs_Entry {
 )]
 pub struct LocationReportProtocolIEs(pub Vec<LocationReportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportingControlProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -10230,7 +10229,7 @@ pub enum LocationReportingControlProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingControlProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10239,7 +10238,7 @@ pub struct LocationReportingControlProtocolIEs_Entry {
     pub value: LocationReportingControlProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10248,7 +10247,7 @@ pub struct LocationReportingControlProtocolIEs_Entry {
 )]
 pub struct LocationReportingControlProtocolIEs(pub Vec<LocationReportingControlProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportingFailureIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -10259,7 +10258,7 @@ pub enum LocationReportingFailureIndicationProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingFailureIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10268,7 +10267,7 @@ pub struct LocationReportingFailureIndicationProtocolIEs_Entry {
     pub value: LocationReportingFailureIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10279,14 +10278,14 @@ pub struct LocationReportingFailureIndicationProtocolIEs(
     pub Vec<LocationReportingFailureIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum LocationReportingRequestTypeIE_Extensions_EntryExtensionValue {
     #[asn(key = 170)]
     Id_LocationReportingAdditionalInfo(LocationReportingAdditionalInfo),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LocationReportingRequestTypeIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10295,7 +10294,7 @@ pub struct LocationReportingRequestTypeIE_Extensions_Entry {
     pub extension_value: LocationReportingRequestTypeIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10306,11 +10305,11 @@ pub struct LocationReportingRequestTypeIE_Extensions(
     pub Vec<LocationReportingRequestTypeIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LoggedMDTNrIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10319,19 +10318,19 @@ pub struct LoggedMDTNrIE_Extensions_Entry {}
 )]
 pub struct LoggedMDTNrIE_Extensions(pub Vec<LoggedMDTNrIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "NULL")]
 pub struct NULL_30;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct LoggedMDTTriggerchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M1ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10340,11 +10339,11 @@ pub struct M1ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M1ConfigurationIE_Extensions(pub Vec<M1ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M1PeriodicReportingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10353,11 +10352,11 @@ pub struct M1PeriodicReportingIE_Extensions_Entry {}
 )]
 pub struct M1PeriodicReportingIE_Extensions(pub Vec<M1PeriodicReportingIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M1ThresholdEventA2IE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10366,15 +10365,15 @@ pub struct M1ThresholdEventA2IE_Extensions_Entry {}
 )]
 pub struct M1ThresholdEventA2IE_Extensions(pub Vec<M1ThresholdEventA2IE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M1ThresholdTypechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M4ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10383,11 +10382,11 @@ pub struct M4ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M4ConfigurationIE_Extensions(pub Vec<M4ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M5ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10396,11 +10395,11 @@ pub struct M5ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M5ConfigurationIE_Extensions(pub Vec<M5ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M6ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10409,11 +10408,11 @@ pub struct M6ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M6ConfigurationIE_Extensions(pub Vec<M6ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct M7ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10422,11 +10421,11 @@ pub struct M7ConfigurationIE_Extensions_Entry {}
 )]
 pub struct M7ConfigurationIE_Extensions(pub Vec<M7ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDT_ConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10435,11 +10434,11 @@ pub struct MDT_ConfigurationIE_Extensions_Entry {}
 )]
 pub struct MDT_ConfigurationIE_Extensions(pub Vec<MDT_ConfigurationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDT_Configuration_EUTRAIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10450,11 +10449,11 @@ pub struct MDT_Configuration_EUTRAIE_Extensions(
     pub Vec<MDT_Configuration_EUTRAIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDT_Configuration_NRIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10463,11 +10462,11 @@ pub struct MDT_Configuration_NRIE_Extensions_Entry {}
 )]
 pub struct MDT_Configuration_NRIE_Extensions(pub Vec<MDT_Configuration_NRIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDT_Location_InfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10476,15 +10475,15 @@ pub struct MDT_Location_InfoIE_Extensions_Entry {}
 )]
 pub struct MDT_Location_InfoIE_Extensions(pub Vec<MDT_Location_InfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MDTModeNrchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MeasurementThresholdL1LoggedMDTchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum MobilityRestrictionListIE_Extensions_EntryExtensionValue {
     #[asn(key = 160)]
@@ -10497,7 +10496,7 @@ pub enum MobilityRestrictionListIE_Extensions_EntryExtensionValue {
     Id_NPN_MobilityInformation(NPN_MobilityInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct MobilityRestrictionListIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10506,7 +10505,7 @@ pub struct MobilityRestrictionListIE_Extensions_Entry {
     pub extension_value: MobilityRestrictionListIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10517,15 +10516,15 @@ pub struct MobilityRestrictionListIE_Extensions(
     pub Vec<MobilityRestrictionListIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "16", sz_ub = "16")]
 pub struct BIT_STRING_31(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct N3IWF_IDchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NASNonDeliveryIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -10538,7 +10537,7 @@ pub enum NASNonDeliveryIndicationProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NASNonDeliveryIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10547,7 +10546,7 @@ pub struct NASNonDeliveryIndicationProtocolIEs_Entry {
     pub value: NASNonDeliveryIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10556,11 +10555,11 @@ pub struct NASNonDeliveryIndicationProtocolIEs_Entry {
 )]
 pub struct NASNonDeliveryIndicationProtocolIEs(pub Vec<NASNonDeliveryIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NB_IoT_Paging_eDRXInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10569,15 +10568,15 @@ pub struct NB_IoT_Paging_eDRXInfoIE_Extensions_Entry {}
 )]
 pub struct NB_IoT_Paging_eDRXInfoIE_Extensions(pub Vec<NB_IoT_Paging_eDRXInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NGRAN_CGIchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NGRAN_TNLAssociationToRemoveItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10588,7 +10587,7 @@ pub struct NGRAN_TNLAssociationToRemoveItemIE_Extensions(
     pub Vec<NGRAN_TNLAssociationToRemoveItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NGResetProtocolIEs_EntryValue {
     #[asn(key = 15)]
@@ -10597,7 +10596,7 @@ pub enum NGResetProtocolIEs_EntryValue {
     Id_ResetType(ResetType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NGResetProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10606,7 +10605,7 @@ pub struct NGResetProtocolIEs_Entry {
     pub value: NGResetProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10615,7 +10614,7 @@ pub struct NGResetProtocolIEs_Entry {
 )]
 pub struct NGResetProtocolIEs(pub Vec<NGResetProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NGResetAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 19)]
@@ -10624,7 +10623,7 @@ pub enum NGResetAcknowledgeProtocolIEs_EntryValue {
     Id_UE_associatedLogicalNG_connectionList(UE_associatedLogicalNG_connectionList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NGResetAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10633,7 +10632,7 @@ pub struct NGResetAcknowledgeProtocolIEs_Entry {
     pub value: NGResetAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10642,7 +10641,7 @@ pub struct NGResetAcknowledgeProtocolIEs_Entry {
 )]
 pub struct NGResetAcknowledgeProtocolIEs(pub Vec<NGResetAcknowledgeProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NGSetupFailureProtocolIEs_EntryValue {
     #[asn(key = 15)]
@@ -10653,7 +10652,7 @@ pub enum NGSetupFailureProtocolIEs_EntryValue {
     Id_TimeToWait(TimeToWait),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NGSetupFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10662,7 +10661,7 @@ pub struct NGSetupFailureProtocolIEs_Entry {
     pub value: NGSetupFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10671,7 +10670,7 @@ pub struct NGSetupFailureProtocolIEs_Entry {
 )]
 pub struct NGSetupFailureProtocolIEs(pub Vec<NGSetupFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NGSetupRequestProtocolIEs_EntryValue {
     #[asn(key = 21)]
@@ -10690,7 +10689,7 @@ pub enum NGSetupRequestProtocolIEs_EntryValue {
     Id_UERetentionInformation(UERetentionInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NGSetupRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10699,7 +10698,7 @@ pub struct NGSetupRequestProtocolIEs_Entry {
     pub value: NGSetupRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10708,7 +10707,7 @@ pub struct NGSetupRequestProtocolIEs_Entry {
 )]
 pub struct NGSetupRequestProtocolIEs(pub Vec<NGSetupRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NGSetupResponseProtocolIEs_EntryValue {
     #[asn(key = 1)]
@@ -10729,7 +10728,7 @@ pub enum NGSetupResponseProtocolIEs_EntryValue {
     Id_UERetentionInformation(UERetentionInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NGSetupResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10738,7 +10737,7 @@ pub struct NGSetupResponseProtocolIEs_Entry {
     pub value: NGSetupResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10747,27 +10746,27 @@ pub struct NGSetupResponseProtocolIEs_Entry {
 )]
 pub struct NGSetupResponseProtocolIEs(pub Vec<NGSetupResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NPN_AccessInformationchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NPN_MobilityInformationchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NPN_PagingAssistanceInformationchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NPN_Supportchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NR_CGIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10776,11 +10775,11 @@ pub struct NR_CGIIE_Extensions_Entry {}
 )]
 pub struct NR_CGIIE_Extensions(pub Vec<NR_CGIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NRFrequencyBandItemIE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10789,11 +10788,11 @@ pub struct NRFrequencyBandItemIE_Extension_Entry {}
 )]
 pub struct NRFrequencyBandItemIE_Extension(pub Vec<NRFrequencyBandItemIE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NRFrequencyInfoIE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10802,11 +10801,11 @@ pub struct NRFrequencyInfoIE_Extension_Entry {}
 )]
 pub struct NRFrequencyInfoIE_Extension(pub Vec<NRFrequencyInfoIE_Extension_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NRUESidelinkAggregateMaximumBitrateIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10817,11 +10816,11 @@ pub struct NRUESidelinkAggregateMaximumBitrateIE_Extensions(
     pub Vec<NRUESidelinkAggregateMaximumBitrateIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NRV2XServicesAuthorizedIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10832,23 +10831,23 @@ pub struct NRV2XServicesAuthorizedIE_Extensions(
     pub Vec<NRV2XServicesAuthorizedIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "20", sz_ub = "20")]
 pub struct BIT_STRING_32(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "18", sz_ub = "18")]
 pub struct BIT_STRING_33(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "21", sz_ub = "21")]
 pub struct BIT_STRING_34(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NgENB_IDchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum NonDynamic5QIDescriptorIE_Extensions_EntryExtensionValue {
     #[asn(key = 187)]
@@ -10857,7 +10856,7 @@ pub enum NonDynamic5QIDescriptorIE_Extensions_EntryExtensionValue {
     Id_CNPacketDelayBudgetUL(ExtendedPacketDelayBudget),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct NonDynamic5QIDescriptorIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -10866,7 +10865,7 @@ pub struct NonDynamic5QIDescriptorIE_Extensions_Entry {
     pub extension_value: NonDynamic5QIDescriptorIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10877,11 +10876,11 @@ pub struct NonDynamic5QIDescriptorIE_Extensions(
     pub Vec<NonDynamic5QIDescriptorIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadResponsechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum OverloadStartProtocolIEs_EntryValue {
     #[asn(key = 2)]
@@ -10892,7 +10891,7 @@ pub enum OverloadStartProtocolIEs_EntryValue {
     Id_OverloadStartNSSAIList(OverloadStartNSSAIList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadStartProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -10901,7 +10900,7 @@ pub struct OverloadStartProtocolIEs_Entry {
     pub value: OverloadStartProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10910,11 +10909,11 @@ pub struct OverloadStartProtocolIEs_Entry {
 )]
 pub struct OverloadStartProtocolIEs(pub Vec<OverloadStartProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadStartNSSAIItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10923,11 +10922,11 @@ pub struct OverloadStartNSSAIItemIE_Extensions_Entry {}
 )]
 pub struct OverloadStartNSSAIItemIE_Extensions(pub Vec<OverloadStartNSSAIItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct OverloadStopProtocolIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10936,11 +10935,11 @@ pub struct OverloadStopProtocolIEs_Entry {}
 )]
 pub struct OverloadStopProtocolIEs(pub Vec<OverloadStopProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PC5FlowBitRatesIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10949,11 +10948,11 @@ pub struct PC5FlowBitRatesIE_Extensions_Entry {}
 )]
 pub struct PC5FlowBitRatesIE_Extensions(pub Vec<PC5FlowBitRatesIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PC5QoSFlowItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10962,11 +10961,11 @@ pub struct PC5QoSFlowItemIE_Extensions_Entry {}
 )]
 pub struct PC5QoSFlowItemIE_Extensions(pub Vec<PC5QoSFlowItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PC5QoSParametersIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10975,11 +10974,11 @@ pub struct PC5QoSParametersIE_Extensions_Entry {}
 )]
 pub struct PC5QoSParametersIE_Extensions(pub Vec<PC5QoSParametersIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionAggregateMaximumBitRateIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -10990,15 +10989,15 @@ pub struct PDUSessionAggregateMaximumBitRateIE_Extensions(
     pub Vec<PDUSessionAggregateMaximumBitRateIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_35(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceAdmittedItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11009,15 +11008,15 @@ pub struct PDUSessionResourceAdmittedItemIE_Extensions(
     pub Vec<PDUSessionResourceAdmittedItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_36(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToModifyItemModCfmIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11028,15 +11027,15 @@ pub struct PDUSessionResourceFailedToModifyItemModCfmIE_Extensions(
     pub Vec<PDUSessionResourceFailedToModifyItemModCfmIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_37(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToModifyItemModResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11047,11 +11046,11 @@ pub struct PDUSessionResourceFailedToModifyItemModResIE_Extensions(
     pub Vec<PDUSessionResourceFailedToModifyItemModResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToResumeItemRESReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11062,11 +11061,11 @@ pub struct PDUSessionResourceFailedToResumeItemRESReqIE_Extensions(
     pub Vec<PDUSessionResourceFailedToResumeItemRESReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToResumeItemRESResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11077,15 +11076,15 @@ pub struct PDUSessionResourceFailedToResumeItemRESResIE_Extensions(
     pub Vec<PDUSessionResourceFailedToResumeItemRESResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_38(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToSetupItemCxtFailIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11096,15 +11095,15 @@ pub struct PDUSessionResourceFailedToSetupItemCxtFailIE_Extensions(
     pub Vec<PDUSessionResourceFailedToSetupItemCxtFailIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_39(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToSetupItemCxtResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11115,15 +11114,15 @@ pub struct PDUSessionResourceFailedToSetupItemCxtResIE_Extensions(
     pub Vec<PDUSessionResourceFailedToSetupItemCxtResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_40(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToSetupItemHOAckIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11134,15 +11133,15 @@ pub struct PDUSessionResourceFailedToSetupItemHOAckIE_Extensions(
     pub Vec<PDUSessionResourceFailedToSetupItemHOAckIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_41(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToSetupItemPSReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11153,15 +11152,15 @@ pub struct PDUSessionResourceFailedToSetupItemPSReqIE_Extensions(
     pub Vec<PDUSessionResourceFailedToSetupItemPSReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_42(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceFailedToSetupItemSUResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11172,15 +11171,15 @@ pub struct PDUSessionResourceFailedToSetupItemSUResIE_Extensions(
     pub Vec<PDUSessionResourceFailedToSetupItemSUResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_43(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceHandoverItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11191,11 +11190,11 @@ pub struct PDUSessionResourceHandoverItemIE_Extensions(
     pub Vec<PDUSessionResourceHandoverItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceInformationItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11206,11 +11205,11 @@ pub struct PDUSessionResourceInformationItemIE_Extensions(
     pub Vec<PDUSessionResourceInformationItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceItemCxtRelCplIE_Extensions_EntryExtensionValue {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceItemCxtRelCplIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11219,7 +11218,7 @@ pub struct PDUSessionResourceItemCxtRelCplIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceItemCxtRelCplIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11230,11 +11229,11 @@ pub struct PDUSessionResourceItemCxtRelCplIE_Extensions(
     pub Vec<PDUSessionResourceItemCxtRelCplIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceItemCxtRelReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11245,15 +11244,15 @@ pub struct PDUSessionResourceItemCxtRelReqIE_Extensions(
     pub Vec<PDUSessionResourceItemCxtRelReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_44(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceItemHORqdIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11264,7 +11263,7 @@ pub struct PDUSessionResourceItemHORqdIE_Extensions(
     pub Vec<PDUSessionResourceItemHORqdIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyConfirmProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -11279,7 +11278,7 @@ pub enum PDUSessionResourceModifyConfirmProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyConfirmProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11288,7 +11287,7 @@ pub struct PDUSessionResourceModifyConfirmProtocolIEs_Entry {
     pub value: PDUSessionResourceModifyConfirmProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11299,7 +11298,7 @@ pub struct PDUSessionResourceModifyConfirmProtocolIEs(
     pub Vec<PDUSessionResourceModifyConfirmProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyConfirmTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 185)]
@@ -11308,7 +11307,7 @@ pub enum PDUSessionResourceModifyConfirmTransferIE_Extensions_EntryExtensionValu
     Id_RedundantUL_NGU_UP_TNLInformation(UPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyConfirmTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11317,7 +11316,7 @@ pub struct PDUSessionResourceModifyConfirmTransferIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceModifyConfirmTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11328,7 +11327,7 @@ pub struct PDUSessionResourceModifyConfirmTransferIE_Extensions(
     pub Vec<PDUSessionResourceModifyConfirmTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -11341,7 +11340,7 @@ pub enum PDUSessionResourceModifyIndicationProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11350,7 +11349,7 @@ pub struct PDUSessionResourceModifyIndicationProtocolIEs_Entry {
     pub value: PDUSessionResourceModifyIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11361,7 +11360,7 @@ pub struct PDUSessionResourceModifyIndicationProtocolIEs(
     pub Vec<PDUSessionResourceModifyIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyIndicationTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 184)]
@@ -11376,7 +11375,7 @@ pub enum PDUSessionResourceModifyIndicationTransferIE_Extensions_EntryExtensionV
     Id_SecurityResult(SecurityResult),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyIndicationTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11386,7 +11385,7 @@ pub struct PDUSessionResourceModifyIndicationTransferIE_Extensions_Entry {
         PDUSessionResourceModifyIndicationTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11397,11 +11396,11 @@ pub struct PDUSessionResourceModifyIndicationTransferIE_Extensions(
     pub Vec<PDUSessionResourceModifyIndicationTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyIndicationUnsuccessfulTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11412,15 +11411,15 @@ pub struct PDUSessionResourceModifyIndicationUnsuccessfulTransferIE_Extensions(
     pub Vec<PDUSessionResourceModifyIndicationUnsuccessfulTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_45(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyItemModCfmIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11431,15 +11430,15 @@ pub struct PDUSessionResourceModifyItemModCfmIE_Extensions(
     pub Vec<PDUSessionResourceModifyItemModCfmIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_46(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyItemModIndIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11450,18 +11449,18 @@ pub struct PDUSessionResourceModifyItemModIndIE_Extensions(
     pub Vec<PDUSessionResourceModifyItemModIndIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_47(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyItemModReqIE_Extensions_EntryExtensionValue {
     #[asn(key = 148)]
     Id_S_NSSAI(S_NSSAI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyItemModReqIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11470,7 +11469,7 @@ pub struct PDUSessionResourceModifyItemModReqIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceModifyItemModReqIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11481,15 +11480,15 @@ pub struct PDUSessionResourceModifyItemModReqIE_Extensions(
     pub Vec<PDUSessionResourceModifyItemModReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_48(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyItemModResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11500,7 +11499,7 @@ pub struct PDUSessionResourceModifyItemModResIE_Extensions(
     pub Vec<PDUSessionResourceModifyItemModResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -11513,7 +11512,7 @@ pub enum PDUSessionResourceModifyRequestProtocolIEs_EntryValue {
     Id_RANPagingPriority(RANPagingPriority),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11522,7 +11521,7 @@ pub struct PDUSessionResourceModifyRequestProtocolIEs_Entry {
     pub value: PDUSessionResourceModifyRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11533,7 +11532,7 @@ pub struct PDUSessionResourceModifyRequestProtocolIEs(
     pub Vec<PDUSessionResourceModifyRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyRequestTransferProtocolIEs_EntryValue {
     #[asn(key = 186)]
@@ -11560,7 +11559,7 @@ pub enum PDUSessionResourceModifyRequestTransferProtocolIEs_EntryValue {
     Id_UL_NGU_UP_TNLModifyList(UL_NGU_UP_TNLModifyList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyRequestTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11569,7 +11568,7 @@ pub struct PDUSessionResourceModifyRequestTransferProtocolIEs_Entry {
     pub value: PDUSessionResourceModifyRequestTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11580,7 +11579,7 @@ pub struct PDUSessionResourceModifyRequestTransferProtocolIEs(
     pub Vec<PDUSessionResourceModifyRequestTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -11597,7 +11596,7 @@ pub enum PDUSessionResourceModifyResponseProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11606,7 +11605,7 @@ pub struct PDUSessionResourceModifyResponseProtocolIEs_Entry {
     pub value: PDUSessionResourceModifyResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11617,7 +11616,7 @@ pub struct PDUSessionResourceModifyResponseProtocolIEs(
     pub Vec<PDUSessionResourceModifyResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceModifyResponseTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 154)]
@@ -11632,7 +11631,7 @@ pub enum PDUSessionResourceModifyResponseTransferIE_Extensions_EntryExtensionVal
     Id_RedundantUL_NGU_UP_TNLInformation(UPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyResponseTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11641,7 +11640,7 @@ pub struct PDUSessionResourceModifyResponseTransferIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceModifyResponseTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11652,11 +11651,11 @@ pub struct PDUSessionResourceModifyResponseTransferIE_Extensions(
     pub Vec<PDUSessionResourceModifyResponseTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceModifyUnsuccessfulTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11667,7 +11666,7 @@ pub struct PDUSessionResourceModifyUnsuccessfulTransferIE_Extensions(
     pub Vec<PDUSessionResourceModifyUnsuccessfulTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceNotifyProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -11682,7 +11681,7 @@ pub enum PDUSessionResourceNotifyProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceNotifyProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11691,7 +11690,7 @@ pub struct PDUSessionResourceNotifyProtocolIEs_Entry {
     pub value: PDUSessionResourceNotifyProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11700,15 +11699,15 @@ pub struct PDUSessionResourceNotifyProtocolIEs_Entry {
 )]
 pub struct PDUSessionResourceNotifyProtocolIEs(pub Vec<PDUSessionResourceNotifyProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_49(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceNotifyItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11719,14 +11718,14 @@ pub struct PDUSessionResourceNotifyItemIE_Extensions(
     pub Vec<PDUSessionResourceNotifyItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceNotifyReleasedTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 144)]
     Id_SecondaryRATUsageInformation(SecondaryRATUsageInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceNotifyReleasedTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11735,7 +11734,7 @@ pub struct PDUSessionResourceNotifyReleasedTransferIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceNotifyReleasedTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11746,7 +11745,7 @@ pub struct PDUSessionResourceNotifyReleasedTransferIE_Extensions(
     pub Vec<PDUSessionResourceNotifyReleasedTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceNotifyTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 278)]
@@ -11755,7 +11754,7 @@ pub enum PDUSessionResourceNotifyTransferIE_Extensions_EntryExtensionValue {
     Id_SecondaryRATUsageInformation(SecondaryRATUsageInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceNotifyTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11764,7 +11763,7 @@ pub struct PDUSessionResourceNotifyTransferIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceNotifyTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11775,7 +11774,7 @@ pub struct PDUSessionResourceNotifyTransferIE_Extensions(
     pub Vec<PDUSessionResourceNotifyTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceReleaseCommandProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -11790,7 +11789,7 @@ pub enum PDUSessionResourceReleaseCommandProtocolIEs_EntryValue {
     Id_RANPagingPriority(RANPagingPriority),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleaseCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11799,7 +11798,7 @@ pub struct PDUSessionResourceReleaseCommandProtocolIEs_Entry {
     pub value: PDUSessionResourceReleaseCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11810,11 +11809,11 @@ pub struct PDUSessionResourceReleaseCommandProtocolIEs(
     pub Vec<PDUSessionResourceReleaseCommandProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleaseCommandTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11825,7 +11824,7 @@ pub struct PDUSessionResourceReleaseCommandTransferIE_Extensions(
     pub Vec<PDUSessionResourceReleaseCommandTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceReleaseResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -11840,7 +11839,7 @@ pub enum PDUSessionResourceReleaseResponseProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleaseResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -11849,7 +11848,7 @@ pub struct PDUSessionResourceReleaseResponseProtocolIEs_Entry {
     pub value: PDUSessionResourceReleaseResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11860,14 +11859,14 @@ pub struct PDUSessionResourceReleaseResponseProtocolIEs(
     pub Vec<PDUSessionResourceReleaseResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceReleaseResponseTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 144)]
     Id_SecondaryRATUsageInformation(SecondaryRATUsageInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleaseResponseTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -11876,7 +11875,7 @@ pub struct PDUSessionResourceReleaseResponseTransferIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceReleaseResponseTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11887,15 +11886,15 @@ pub struct PDUSessionResourceReleaseResponseTransferIE_Extensions(
     pub Vec<PDUSessionResourceReleaseResponseTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_50(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleasedItemNotIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11906,15 +11905,15 @@ pub struct PDUSessionResourceReleasedItemNotIE_Extensions(
     pub Vec<PDUSessionResourceReleasedItemNotIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_51(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleasedItemPSAckIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11925,15 +11924,15 @@ pub struct PDUSessionResourceReleasedItemPSAckIE_Extensions(
     pub Vec<PDUSessionResourceReleasedItemPSAckIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_52(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleasedItemPSFailIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11944,15 +11943,15 @@ pub struct PDUSessionResourceReleasedItemPSFailIE_Extensions(
     pub Vec<PDUSessionResourceReleasedItemPSFailIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_53(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceReleasedItemRelResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11963,15 +11962,15 @@ pub struct PDUSessionResourceReleasedItemRelResIE_Extensions(
     pub Vec<PDUSessionResourceReleasedItemRelResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_54(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceResumeItemRESReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -11982,15 +11981,15 @@ pub struct PDUSessionResourceResumeItemRESReqIE_Extensions(
     pub Vec<PDUSessionResourceResumeItemRESReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_55(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceResumeItemRESResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12001,15 +12000,15 @@ pub struct PDUSessionResourceResumeItemRESResIE_Extensions(
     pub Vec<PDUSessionResourceResumeItemRESResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_56(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSecondaryRATUsageItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12020,15 +12019,15 @@ pub struct PDUSessionResourceSecondaryRATUsageItemIE_Extensions(
     pub Vec<PDUSessionResourceSecondaryRATUsageItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_57(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupItemCxtReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12039,15 +12038,15 @@ pub struct PDUSessionResourceSetupItemCxtReqIE_Extensions(
     pub Vec<PDUSessionResourceSetupItemCxtReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_58(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupItemCxtResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12058,15 +12057,15 @@ pub struct PDUSessionResourceSetupItemCxtResIE_Extensions(
     pub Vec<PDUSessionResourceSetupItemCxtResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_59(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupItemHOReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12077,15 +12076,15 @@ pub struct PDUSessionResourceSetupItemHOReqIE_Extensions(
     pub Vec<PDUSessionResourceSetupItemHOReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_60(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupItemSUReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12096,15 +12095,15 @@ pub struct PDUSessionResourceSetupItemSUReqIE_Extensions(
     pub Vec<PDUSessionResourceSetupItemSUReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_61(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupItemSUResIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12115,7 +12114,7 @@ pub struct PDUSessionResourceSetupItemSUResIE_Extensions(
     pub Vec<PDUSessionResourceSetupItemSUResIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceSetupRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -12132,7 +12131,7 @@ pub enum PDUSessionResourceSetupRequestProtocolIEs_EntryValue {
     Id_UEAggregateMaximumBitRate(UEAggregateMaximumBitRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12141,7 +12140,7 @@ pub struct PDUSessionResourceSetupRequestProtocolIEs_Entry {
     pub value: PDUSessionResourceSetupRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12152,7 +12151,7 @@ pub struct PDUSessionResourceSetupRequestProtocolIEs(
     pub Vec<PDUSessionResourceSetupRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceSetupRequestTransferProtocolIEs_EntryValue {
     #[asn(key = 186)]
@@ -12185,7 +12184,7 @@ pub enum PDUSessionResourceSetupRequestTransferProtocolIEs_EntryValue {
     Id_UL_NGU_UP_TNLInformation(UPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupRequestTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12194,7 +12193,7 @@ pub struct PDUSessionResourceSetupRequestTransferProtocolIEs_Entry {
     pub value: PDUSessionResourceSetupRequestTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12205,7 +12204,7 @@ pub struct PDUSessionResourceSetupRequestTransferProtocolIEs(
     pub Vec<PDUSessionResourceSetupRequestTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceSetupResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -12220,7 +12219,7 @@ pub enum PDUSessionResourceSetupResponseProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12229,7 +12228,7 @@ pub struct PDUSessionResourceSetupResponseProtocolIEs_Entry {
     pub value: PDUSessionResourceSetupResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12240,7 +12239,7 @@ pub struct PDUSessionResourceSetupResponseProtocolIEs(
     pub Vec<PDUSessionResourceSetupResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PDUSessionResourceSetupResponseTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 184)]
@@ -12253,7 +12252,7 @@ pub enum PDUSessionResourceSetupResponseTransferIE_Extensions_EntryExtensionValu
     Id_UsedRSNInformation(RedundantPDUSessionInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupResponseTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12262,7 +12261,7 @@ pub struct PDUSessionResourceSetupResponseTransferIE_Extensions_Entry {
     pub extension_value: PDUSessionResourceSetupResponseTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12273,11 +12272,11 @@ pub struct PDUSessionResourceSetupResponseTransferIE_Extensions(
     pub Vec<PDUSessionResourceSetupResponseTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSetupUnsuccessfulTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12288,15 +12287,15 @@ pub struct PDUSessionResourceSetupUnsuccessfulTransferIE_Extensions(
     pub Vec<PDUSessionResourceSetupUnsuccessfulTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_62(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSuspendItemSUSReqIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12307,15 +12306,15 @@ pub struct PDUSessionResourceSuspendItemSUSReqIE_Extensions(
     pub Vec<PDUSessionResourceSuspendItemSUSReqIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_63(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceSwitchedItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12326,15 +12325,15 @@ pub struct PDUSessionResourceSwitchedItemIE_Extensions(
     pub Vec<PDUSessionResourceSwitchedItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_64(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceToBeSwitchedDLItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12345,15 +12344,15 @@ pub struct PDUSessionResourceToBeSwitchedDLItemIE_Extensions(
     pub Vec<PDUSessionResourceToBeSwitchedDLItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_65(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceToReleaseItemHOCmdIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12364,15 +12363,15 @@ pub struct PDUSessionResourceToReleaseItemHOCmdIE_Extensions(
     pub Vec<PDUSessionResourceToReleaseItemHOCmdIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING")]
 pub struct OCTET_STRING_66(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionResourceToReleaseItemRelCmdIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12383,7 +12382,7 @@ pub struct PDUSessionResourceToReleaseItemRelCmdIE_Extensions(
     pub Vec<PDUSessionResourceToReleaseItemRelCmdIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_67(pub u8);
 impl ENUMERATED_67 {
@@ -12391,11 +12390,11 @@ impl ENUMERATED_67 {
     pub const EUTRA: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PDUSessionUsageReportIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12404,7 +12403,7 @@ pub struct PDUSessionUsageReportIE_Extensions_Entry {}
 )]
 pub struct PDUSessionUsageReportIE_Extensions(pub Vec<PDUSessionUsageReportIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PLMNSupportItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 270)]
@@ -12413,7 +12412,7 @@ pub enum PLMNSupportItemIE_Extensions_EntryExtensionValue {
     Id_NPN_Support(NPN_Support),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PLMNSupportItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12422,7 +12421,7 @@ pub struct PLMNSupportItemIE_Extensions_Entry {
     pub extension_value: PLMNSupportItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12431,11 +12430,11 @@ pub struct PLMNSupportItemIE_Extensions_Entry {
 )]
 pub struct PLMNSupportItemIE_Extensions(pub Vec<PLMNSupportItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PNI_NPN_MobilityInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12446,7 +12445,7 @@ pub struct PNI_NPN_MobilityInformationIE_Extensions(
     pub Vec<PNI_NPN_MobilityInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PWSCancelRequestProtocolIEs_EntryValue {
     #[asn(key = 14)]
@@ -12459,7 +12458,7 @@ pub enum PWSCancelRequestProtocolIEs_EntryValue {
     Id_WarningAreaList(WarningAreaList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PWSCancelRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12468,7 +12467,7 @@ pub struct PWSCancelRequestProtocolIEs_Entry {
     pub value: PWSCancelRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12477,7 +12476,7 @@ pub struct PWSCancelRequestProtocolIEs_Entry {
 )]
 pub struct PWSCancelRequestProtocolIEs(pub Vec<PWSCancelRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PWSCancelResponseProtocolIEs_EntryValue {
     #[asn(key = 12)]
@@ -12490,7 +12489,7 @@ pub enum PWSCancelResponseProtocolIEs_EntryValue {
     Id_SerialNumber(SerialNumber),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PWSCancelResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12499,7 +12498,7 @@ pub struct PWSCancelResponseProtocolIEs_Entry {
     pub value: PWSCancelResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12508,11 +12507,11 @@ pub struct PWSCancelResponseProtocolIEs_Entry {
 )]
 pub struct PWSCancelResponseProtocolIEs(pub Vec<PWSCancelResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PWSFailedCellIDListchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PWSFailureIndicationProtocolIEs_EntryValue {
     #[asn(key = 27)]
@@ -12521,7 +12520,7 @@ pub enum PWSFailureIndicationProtocolIEs_EntryValue {
     Id_PWSFailedCellIDList(PWSFailedCellIDList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PWSFailureIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12530,7 +12529,7 @@ pub struct PWSFailureIndicationProtocolIEs_Entry {
     pub value: PWSFailureIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12539,7 +12538,7 @@ pub struct PWSFailureIndicationProtocolIEs_Entry {
 )]
 pub struct PWSFailureIndicationProtocolIEs(pub Vec<PWSFailureIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PWSRestartIndicationProtocolIEs_EntryValue {
     #[asn(key = 16)]
@@ -12552,7 +12551,7 @@ pub enum PWSRestartIndicationProtocolIEs_EntryValue {
     Id_TAIListForRestart(TAIListForRestart),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PWSRestartIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12561,7 +12560,7 @@ pub struct PWSRestartIndicationProtocolIEs_Entry {
     pub value: PWSRestartIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12570,19 +12569,19 @@ pub struct PWSRestartIndicationProtocolIEs_Entry {
 )]
 pub struct PWSRestartIndicationProtocolIEs(pub Vec<PWSRestartIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "9", extensible = true)]
 pub struct INTEGER_68(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "9", extensible = true)]
 pub struct INTEGER_69(pub u8);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PacketErrorRateIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12591,7 +12590,7 @@ pub struct PacketErrorRateIE_Extensions_Entry {}
 )]
 pub struct PacketErrorRateIE_Extensions(pub Vec<PacketErrorRateIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PagingProtocolIEs_EntryValue {
     #[asn(key = 11)]
@@ -12622,7 +12621,7 @@ pub enum PagingProtocolIEs_EntryValue {
     Id_WUS_Assistance_Information(WUS_Assistance_Information),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12631,7 +12630,7 @@ pub struct PagingProtocolIEs_Entry {
     pub value: PagingProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12640,11 +12639,11 @@ pub struct PagingProtocolIEs_Entry {
 )]
 pub struct PagingProtocolIEs(pub Vec<PagingProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingAssisDataforCEcapabUEIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12655,11 +12654,11 @@ pub struct PagingAssisDataforCEcapabUEIE_Extensions(
     pub Vec<PagingAssisDataforCEcapabUEIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingAttemptInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12670,11 +12669,11 @@ pub struct PagingAttemptInformationIE_Extensions(
     pub Vec<PagingAttemptInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PagingeDRXInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12683,7 +12682,7 @@ pub struct PagingeDRXInformationIE_Extensions_Entry {}
 )]
 pub struct PagingeDRXInformationIE_Extensions(pub Vec<PagingeDRXInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestProtocolIEs_EntryValue {
     #[asn(key = 57)]
@@ -12702,7 +12701,7 @@ pub enum PathSwitchRequestProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12711,7 +12710,7 @@ pub struct PathSwitchRequestProtocolIEs_Entry {
     pub value: PathSwitchRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12720,7 +12719,7 @@ pub struct PathSwitchRequestProtocolIEs_Entry {
 )]
 pub struct PathSwitchRequestProtocolIEs(pub Vec<PathSwitchRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -12775,7 +12774,7 @@ pub enum PathSwitchRequestAcknowledgeProtocolIEs_EntryValue {
     Id_UESecurityCapabilities(UESecurityCapabilities),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12784,7 +12783,7 @@ pub struct PathSwitchRequestAcknowledgeProtocolIEs_Entry {
     pub value: PathSwitchRequestAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12795,7 +12794,7 @@ pub struct PathSwitchRequestAcknowledgeProtocolIEs(
     pub Vec<PathSwitchRequestAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestAcknowledgeTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 154)]
@@ -12808,7 +12807,7 @@ pub enum PathSwitchRequestAcknowledgeTransferIE_Extensions_EntryExtensionValue {
     Id_RedundantUL_NGU_UP_TNLInformation(UPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestAcknowledgeTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12817,7 +12816,7 @@ pub struct PathSwitchRequestAcknowledgeTransferIE_Extensions_Entry {
     pub extension_value: PathSwitchRequestAcknowledgeTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12828,7 +12827,7 @@ pub struct PathSwitchRequestAcknowledgeTransferIE_Extensions(
     pub Vec<PathSwitchRequestAcknowledgeTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestFailureProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -12841,7 +12840,7 @@ pub enum PathSwitchRequestFailureProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -12850,7 +12849,7 @@ pub struct PathSwitchRequestFailureProtocolIEs_Entry {
     pub value: PathSwitchRequestFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12859,11 +12858,11 @@ pub struct PathSwitchRequestFailureProtocolIEs_Entry {
 )]
 pub struct PathSwitchRequestFailureProtocolIEs(pub Vec<PathSwitchRequestFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestSetupFailedTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12874,7 +12873,7 @@ pub struct PathSwitchRequestSetupFailedTransferIE_Extensions(
     pub Vec<PathSwitchRequestSetupFailedTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum PathSwitchRequestTransferIE_Extensions_EntryExtensionValue {
     #[asn(key = 155)]
@@ -12891,7 +12890,7 @@ pub enum PathSwitchRequestTransferIE_Extensions_EntryExtensionValue {
     Id_UsedRSNInformation(RedundantPDUSessionInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestTransferIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12900,7 +12899,7 @@ pub struct PathSwitchRequestTransferIE_Extensions_Entry {
     pub extension_value: PathSwitchRequestTransferIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12911,11 +12910,11 @@ pub struct PathSwitchRequestTransferIE_Extensions(
     pub Vec<PathSwitchRequestTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PathSwitchRequestUnsuccessfulTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12926,19 +12925,19 @@ pub struct PathSwitchRequestUnsuccessfulTransferIE_Extensions(
     pub Vec<PathSwitchRequestUnsuccessfulTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "65535")]
 pub struct INTEGER_70(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OBJECT-IDENTIFIER")]
 pub struct OBJECT_IDENTIFIER_71;
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct PrivateMessagePrivateIEs_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12947,11 +12946,11 @@ pub struct PrivateMessagePrivateIEs_Entry {}
 )]
 pub struct PrivateMessagePrivateIEs(pub Vec<PrivateMessagePrivateIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ProcedureStageChoicechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_72(pub u8);
 impl ENUMERATED_72 {
@@ -12959,11 +12958,11 @@ impl ENUMERATED_72 {
     pub const EUTRA: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QoSFlowsUsageReport_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -12974,18 +12973,18 @@ pub struct QoSFlowsUsageReport_ItemIE_Extensions(
     pub Vec<QoSFlowsUsageReport_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosCharacteristicschoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowAcceptedItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 221)]
     Id_CurrentQoSParaSetIndex(AlternativeQoSParaSetIndex),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowAcceptedItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -12994,7 +12993,7 @@ pub struct QosFlowAcceptedItemIE_Extensions_Entry {
     pub extension_value: QosFlowAcceptedItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13003,7 +13002,7 @@ pub struct QosFlowAcceptedItemIE_Extensions_Entry {
 )]
 pub struct QosFlowAcceptedItemIE_Extensions(pub Vec<QosFlowAcceptedItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowAddOrModifyRequestItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 194)]
@@ -13012,7 +13011,7 @@ pub enum QosFlowAddOrModifyRequestItemIE_Extensions_EntryExtensionValue {
     Id_TSCTrafficCharacteristics(TSCTrafficCharacteristics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowAddOrModifyRequestItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13021,7 +13020,7 @@ pub struct QosFlowAddOrModifyRequestItemIE_Extensions_Entry {
     pub extension_value: QosFlowAddOrModifyRequestItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13032,14 +13031,14 @@ pub struct QosFlowAddOrModifyRequestItemIE_Extensions(
     pub Vec<QosFlowAddOrModifyRequestItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowAddOrModifyResponseItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 221)]
     Id_CurrentQoSParaSetIndex(AlternativeQoSParaSetIndex),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowAddOrModifyResponseItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13048,7 +13047,7 @@ pub struct QosFlowAddOrModifyResponseItemIE_Extensions_Entry {
     pub extension_value: QosFlowAddOrModifyResponseItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13059,11 +13058,11 @@ pub struct QosFlowAddOrModifyResponseItemIE_Extensions(
     pub Vec<QosFlowAddOrModifyResponseItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowFeedbackItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13072,14 +13071,14 @@ pub struct QosFlowFeedbackItemIE_Extensions_Entry {}
 )]
 pub struct QosFlowFeedbackItemIE_Extensions(pub Vec<QosFlowFeedbackItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowInformationItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 163)]
     Id_ULForwarding(ULForwarding),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowInformationItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13088,7 +13087,7 @@ pub struct QosFlowInformationItemIE_Extensions_Entry {
     pub extension_value: QosFlowInformationItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13097,14 +13096,14 @@ pub struct QosFlowInformationItemIE_Extensions_Entry {
 )]
 pub struct QosFlowInformationItemIE_Extensions(pub Vec<QosFlowInformationItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowItemWithDataForwardingIE_Extensions_EntryExtensionValue {
     #[asn(key = 221)]
     Id_CurrentQoSParaSetIndex(AlternativeQoSParaSetIndex),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowItemWithDataForwardingIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13113,7 +13112,7 @@ pub struct QosFlowItemWithDataForwardingIE_Extensions_Entry {
     pub extension_value: QosFlowItemWithDataForwardingIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13124,7 +13123,7 @@ pub struct QosFlowItemWithDataForwardingIE_Extensions(
     pub Vec<QosFlowItemWithDataForwardingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowLevelQosParametersIE_Extensions_EntryExtensionValue {
     #[asn(key = 276)]
@@ -13133,7 +13132,7 @@ pub enum QosFlowLevelQosParametersIE_Extensions_EntryExtensionValue {
     Id_QosMonitoringRequest(QosMonitoringRequest),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowLevelQosParametersIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13142,7 +13141,7 @@ pub struct QosFlowLevelQosParametersIE_Extensions_Entry {
     pub extension_value: QosFlowLevelQosParametersIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13153,11 +13152,11 @@ pub struct QosFlowLevelQosParametersIE_Extensions(
     pub Vec<QosFlowLevelQosParametersIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowModifyConfirmItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13168,14 +13167,14 @@ pub struct QosFlowModifyConfirmItemIE_Extensions(
     pub Vec<QosFlowModifyConfirmItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowNotifyItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 221)]
     Id_CurrentQoSParaSetIndex(AlternativeQoSParaSetNotifyIndex),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowNotifyItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13184,7 +13183,7 @@ pub struct QosFlowNotifyItemIE_Extensions_Entry {
     pub extension_value: QosFlowNotifyItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13193,7 +13192,7 @@ pub struct QosFlowNotifyItemIE_Extensions_Entry {
 )]
 pub struct QosFlowNotifyItemIE_Extensions(pub Vec<QosFlowNotifyItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowParametersItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 279)]
@@ -13204,7 +13203,7 @@ pub enum QosFlowParametersItemIE_Extensions_EntryExtensionValue {
     Id_CNPacketDelayBudgetUL(ExtendedPacketDelayBudget),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowParametersItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13213,7 +13212,7 @@ pub struct QosFlowParametersItemIE_Extensions_Entry {
     pub extension_value: QosFlowParametersItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13222,11 +13221,11 @@ pub struct QosFlowParametersItemIE_Extensions_Entry {
 )]
 pub struct QosFlowParametersItemIE_Extensions(pub Vec<QosFlowParametersItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowPerTNLInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13237,11 +13236,11 @@ pub struct QosFlowPerTNLInformationIE_Extensions(
     pub Vec<QosFlowPerTNLInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowPerTNLInformationItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13252,7 +13251,7 @@ pub struct QosFlowPerTNLInformationItemIE_Extensions(
     pub Vec<QosFlowPerTNLInformationItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum QosFlowSetupRequestItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 194)]
@@ -13261,7 +13260,7 @@ pub enum QosFlowSetupRequestItemIE_Extensions_EntryExtensionValue {
     Id_TSCTrafficCharacteristics(TSCTrafficCharacteristics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowSetupRequestItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13270,7 +13269,7 @@ pub struct QosFlowSetupRequestItemIE_Extensions_Entry {
     pub extension_value: QosFlowSetupRequestItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13281,11 +13280,11 @@ pub struct QosFlowSetupRequestItemIE_Extensions(
     pub Vec<QosFlowSetupRequestItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowToBeForwardedItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13296,11 +13295,11 @@ pub struct QosFlowToBeForwardedItemIE_Extensions(
     pub Vec<QosFlowToBeForwardedItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct QosFlowWithCauseItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13309,7 +13308,7 @@ pub struct QosFlowWithCauseItemIE_Extensions_Entry {}
 )]
 pub struct QosFlowWithCauseItemIE_Extensions(pub Vec<QosFlowWithCauseItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANCPRelocationIndicationProtocolIEs_EntryValue {
     #[asn(key = 25)]
@@ -13324,7 +13323,7 @@ pub enum RANCPRelocationIndicationProtocolIEs_EntryValue {
     Id_UL_CP_SecurityInformation(UL_CP_SecurityInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANCPRelocationIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13333,7 +13332,7 @@ pub struct RANCPRelocationIndicationProtocolIEs_Entry {
     pub value: RANCPRelocationIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13344,7 +13343,7 @@ pub struct RANCPRelocationIndicationProtocolIEs(
     pub Vec<RANCPRelocationIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANConfigurationUpdateProtocolIEs_EntryValue {
     #[asn(key = 21)]
@@ -13363,7 +13362,7 @@ pub enum RANConfigurationUpdateProtocolIEs_EntryValue {
     Id_SupportedTAList(SupportedTAList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANConfigurationUpdateProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13372,7 +13371,7 @@ pub struct RANConfigurationUpdateProtocolIEs_Entry {
     pub value: RANConfigurationUpdateProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13381,14 +13380,14 @@ pub struct RANConfigurationUpdateProtocolIEs_Entry {
 )]
 pub struct RANConfigurationUpdateProtocolIEs(pub Vec<RANConfigurationUpdateProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANConfigurationUpdateAcknowledgeProtocolIEs_EntryValue {
     #[asn(key = 19)]
     Id_CriticalityDiagnostics(CriticalityDiagnostics),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13397,7 +13396,7 @@ pub struct RANConfigurationUpdateAcknowledgeProtocolIEs_Entry {
     pub value: RANConfigurationUpdateAcknowledgeProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13408,7 +13407,7 @@ pub struct RANConfigurationUpdateAcknowledgeProtocolIEs(
     pub Vec<RANConfigurationUpdateAcknowledgeProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RANConfigurationUpdateFailureProtocolIEs_EntryValue {
     #[asn(key = 15)]
@@ -13419,7 +13418,7 @@ pub enum RANConfigurationUpdateFailureProtocolIEs_EntryValue {
     Id_TimeToWait(TimeToWait),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANConfigurationUpdateFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13428,7 +13427,7 @@ pub struct RANConfigurationUpdateFailureProtocolIEs_Entry {
     pub value: RANConfigurationUpdateFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13439,11 +13438,11 @@ pub struct RANConfigurationUpdateFailureProtocolIEs(
     pub Vec<RANConfigurationUpdateFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RANStatusTransfer_TransparentContainerIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13454,14 +13453,14 @@ pub struct RANStatusTransfer_TransparentContainerIE_Extensions(
     pub Vec<RANStatusTransfer_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RATRestrictions_ItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 180)]
     Id_ExtendedRATRestrictionInformation(ExtendedRATRestrictionInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RATRestrictions_ItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13470,7 +13469,7 @@ pub struct RATRestrictions_ItemIE_Extensions_Entry {
     pub extension_value: RATRestrictions_ItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13479,7 +13478,7 @@ pub struct RATRestrictions_ItemIE_Extensions_Entry {
 )]
 pub struct RATRestrictions_ItemIE_Extensions(pub Vec<RATRestrictions_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_73(pub u8);
 impl ENUMERATED_73 {
@@ -13487,11 +13486,11 @@ impl ENUMERATED_73 {
     pub const RS_DISAPPEARED: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RIMInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13500,11 +13499,11 @@ pub struct RIMInformationIE_Extensions_Entry {}
 )]
 pub struct RIMInformationIE_Extensions(pub Vec<RIMInformationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RIMInformationTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13513,7 +13512,7 @@ pub struct RIMInformationTransferIE_Extensions_Entry {}
 )]
 pub struct RIMInformationTransferIE_Extensions(pub Vec<RIMInformationTransferIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RRCInactiveTransitionReportProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -13526,7 +13525,7 @@ pub enum RRCInactiveTransitionReportProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RRCInactiveTransitionReportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13535,7 +13534,7 @@ pub struct RRCInactiveTransitionReportProtocolIEs_Entry {
     pub value: RRCInactiveTransitionReportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13546,15 +13545,15 @@ pub struct RRCInactiveTransitionReportProtocolIEs(
     pub Vec<RRCInactiveTransitionReportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "4095")]
 pub struct INTEGER_74(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedCellItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13563,11 +13562,11 @@ pub struct RecommendedCellItemIE_Extensions_Entry {}
 )]
 pub struct RecommendedCellItemIE_Extensions(pub Vec<RecommendedCellItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedCellsForPagingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13578,11 +13577,11 @@ pub struct RecommendedCellsForPagingIE_Extensions(
     pub Vec<RecommendedCellsForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedRANNodeItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13591,11 +13590,11 @@ pub struct RecommendedRANNodeItemIE_Extensions_Entry {}
 )]
 pub struct RecommendedRANNodeItemIE_Extensions(pub Vec<RecommendedRANNodeItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RecommendedRANNodesForPagingIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13606,11 +13605,11 @@ pub struct RecommendedRANNodesForPagingIE_Extensions(
     pub Vec<RecommendedRANNodesForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RedundantPDUSessionInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13621,7 +13620,7 @@ pub struct RedundantPDUSessionInformationIE_Extensions(
     pub Vec<RedundantPDUSessionInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RerouteNASRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -13636,7 +13635,7 @@ pub enum RerouteNASRequestProtocolIEs_EntryValue {
     Id_SourceToTarget_AMFInformationReroute(SourceToTarget_AMFInformationReroute),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RerouteNASRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13645,7 +13644,7 @@ pub struct RerouteNASRequestProtocolIEs_Entry {
     pub value: RerouteNASRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13654,18 +13653,18 @@ pub struct RerouteNASRequestProtocolIEs_Entry {
 )]
 pub struct RerouteNASRequestProtocolIEs(pub Vec<RerouteNASRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ResetTypechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum RetrieveUEInformationProtocolIEs_EntryValue {
     #[asn(key = 26)]
     Id_FiveG_S_TMSI(FiveG_S_TMSI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct RetrieveUEInformationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13674,7 +13673,7 @@ pub struct RetrieveUEInformationProtocolIEs_Entry {
     pub value: RetrieveUEInformationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13683,11 +13682,11 @@ pub struct RetrieveUEInformationProtocolIEs_Entry {
 )]
 pub struct RetrieveUEInformationProtocolIEs(pub Vec<RetrieveUEInformationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct S_NSSAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13696,11 +13695,11 @@ pub struct S_NSSAIIE_Extensions_Entry {}
 )]
 pub struct S_NSSAIIE_Extensions(pub Vec<S_NSSAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SNPN_MobilityInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13711,11 +13710,11 @@ pub struct SNPN_MobilityInformationIE_Extensions(
     pub Vec<SNPN_MobilityInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SONConfigurationTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13726,14 +13725,14 @@ pub struct SONConfigurationTransferIE_Extensions(
     pub Vec<SONConfigurationTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SONInformationchoice_ExtensionsValue {
     #[asn(key = 252)]
     Id_SONInformationReport(SONInformationReport),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SONInformationchoice_Extensions {
     #[asn(key_field = true)]
@@ -13742,11 +13741,11 @@ pub struct SONInformationchoice_Extensions {
     pub value: SONInformationchoice_ExtensionsValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SONInformationReplyIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13755,27 +13754,27 @@ pub struct SONInformationReplyIE_Extensions_Entry {}
 )]
 pub struct SONInformationReplyIE_Extensions(pub Vec<SONInformationReplyIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SONInformationReportchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "7", sz_ub = "7")]
 pub struct BIT_STRING_75(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "86399", extensible = true)]
 pub struct INTEGER_76(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "86399", extensible = true)]
 pub struct INTEGER_77(pub u32);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ScheduledCommunicationTimeIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13786,7 +13785,7 @@ pub struct ScheduledCommunicationTimeIE_Extensions(
     pub Vec<ScheduledCommunicationTimeIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SecondaryRATDataUsageReportProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -13801,7 +13800,7 @@ pub enum SecondaryRATDataUsageReportProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecondaryRATDataUsageReportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -13810,7 +13809,7 @@ pub struct SecondaryRATDataUsageReportProtocolIEs_Entry {
     pub value: SecondaryRATDataUsageReportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13821,11 +13820,11 @@ pub struct SecondaryRATDataUsageReportProtocolIEs(
     pub Vec<SecondaryRATDataUsageReportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecondaryRATDataUsageReportTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13836,11 +13835,11 @@ pub struct SecondaryRATDataUsageReportTransferIE_Extensions(
     pub Vec<SecondaryRATDataUsageReportTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecondaryRATUsageInformationIE_Extension_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13851,11 +13850,11 @@ pub struct SecondaryRATUsageInformationIE_Extension(
     pub Vec<SecondaryRATUsageInformationIE_Extension_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityContextIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13864,14 +13863,14 @@ pub struct SecurityContextIE_Extensions_Entry {}
 )]
 pub struct SecurityContextIE_Extensions(pub Vec<SecurityContextIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SecurityIndicationIE_Extensions_EntryExtensionValue {
     #[asn(key = 151)]
     Id_MaximumIntegrityProtectedDataRate_DL(MaximumIntegrityProtectedDataRate),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityIndicationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13880,7 +13879,7 @@ pub struct SecurityIndicationIE_Extensions_Entry {
     pub extension_value: SecurityIndicationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13889,11 +13888,11 @@ pub struct SecurityIndicationIE_Extensions_Entry {
 )]
 pub struct SecurityIndicationIE_Extensions(pub Vec<SecurityIndicationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SecurityResultIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13902,11 +13901,11 @@ pub struct SecurityResultIE_Extensions_Entry {}
 )]
 pub struct SecurityResultIE_Extensions(pub Vec<SecurityResultIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SensorMeasConfigNameItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13917,11 +13916,11 @@ pub struct SensorMeasConfigNameItemIE_Extensions(
     pub Vec<SensorMeasConfigNameItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SensorMeasurementConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13932,39 +13931,39 @@ pub struct SensorMeasurementConfigurationIE_Extensions(
     pub Vec<SensorMeasurementConfigurationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_78(pub u8);
 impl ENUMERATED_78 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_79(pub u8);
 impl ENUMERATED_79 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_80(pub u8);
 impl ENUMERATED_80 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SensorNameConfigchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum ServedGUAMIItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 176)]
     Id_GUAMIType(GUAMIType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ServedGUAMIItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -13973,7 +13972,7 @@ pub struct ServedGUAMIItemIE_Extensions_Entry {
     pub extension_value: ServedGUAMIItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13982,11 +13981,11 @@ pub struct ServedGUAMIItemIE_Extensions_Entry {
 )]
 pub struct ServedGUAMIItemIE_Extensions(pub Vec<ServedGUAMIItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct ServiceAreaInformation_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -13997,11 +13996,11 @@ pub struct ServiceAreaInformation_ItemIE_Extensions(
     pub Vec<ServiceAreaInformation_ItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SliceOverloadItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14010,11 +14009,11 @@ pub struct SliceOverloadItemIE_Extensions_Entry {}
 )]
 pub struct SliceOverloadItemIE_Extensions(pub Vec<SliceOverloadItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SliceSupportItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14023,7 +14022,7 @@ pub struct SliceSupportItemIE_Extensions_Entry {}
 )]
 pub struct SliceSupportItemIE_Extensions(pub Vec<SliceSupportItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions_EntryExtensionValue {
     #[asn(key = 182)]
@@ -14032,7 +14031,7 @@ pub enum SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions_Ent
     Id_UEHistoryInformationFromTheUE(UEHistoryInformationFromTheUE),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -14042,7 +14041,7 @@ pub struct SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions_E
         SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14053,11 +14052,11 @@ pub struct SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions(
     pub Vec<SourceNGRANNode_ToTargetNGRANNode_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceRANNodeIDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14066,11 +14065,11 @@ pub struct SourceRANNodeIDIE_Extensions_Entry {}
 )]
 pub struct SourceRANNodeIDIE_Extensions(pub Vec<SourceRANNodeIDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SourceToTarget_AMFInformationRerouteIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14081,7 +14080,7 @@ pub struct SourceToTarget_AMFInformationRerouteIE_Extensions(
     pub Vec<SourceToTarget_AMFInformationRerouteIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SuccessfulOutcomeValue {
     #[asn(key = 0)]
@@ -14128,7 +14127,7 @@ pub enum SuccessfulOutcomeValue {
     Id_WriteReplaceWarning(WriteReplaceWarningResponse),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum SupportedTAItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 272)]
@@ -14137,7 +14136,7 @@ pub enum SupportedTAItemIE_Extensions_EntryExtensionValue {
     Id_RAT_Information(RAT_Information),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct SupportedTAItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -14146,7 +14145,7 @@ pub struct SupportedTAItemIE_Extensions_Entry {
     pub extension_value: SupportedTAItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14155,11 +14154,11 @@ pub struct SupportedTAItemIE_Extensions_Entry {
 )]
 pub struct SupportedTAItemIE_Extensions(pub Vec<SupportedTAItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TABasedMDTIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14168,11 +14167,11 @@ pub struct TABasedMDTIE_Extensions_Entry {}
 )]
 pub struct TABasedMDTIE_Extensions(pub Vec<TABasedMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14181,11 +14180,11 @@ pub struct TAIIE_Extensions_Entry {}
 )]
 pub struct TAIIE_Extensions(pub Vec<TAIIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIBasedMDTIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14194,11 +14193,11 @@ pub struct TAIBasedMDTIE_Extensions_Entry {}
 )]
 pub struct TAIBasedMDTIE_Extensions(pub Vec<TAIBasedMDTIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIBroadcastEUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14207,11 +14206,11 @@ pub struct TAIBroadcastEUTRA_ItemIE_Extensions_Entry {}
 )]
 pub struct TAIBroadcastEUTRA_ItemIE_Extensions(pub Vec<TAIBroadcastEUTRA_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIBroadcastNR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14220,11 +14219,11 @@ pub struct TAIBroadcastNR_ItemIE_Extensions_Entry {}
 )]
 pub struct TAIBroadcastNR_ItemIE_Extensions(pub Vec<TAIBroadcastNR_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAICancelledEUTRA_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14233,11 +14232,11 @@ pub struct TAICancelledEUTRA_ItemIE_Extensions_Entry {}
 )]
 pub struct TAICancelledEUTRA_ItemIE_Extensions(pub Vec<TAICancelledEUTRA_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAICancelledNR_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14246,11 +14245,11 @@ pub struct TAICancelledNR_ItemIE_Extensions_Entry {}
 )]
 pub struct TAICancelledNR_ItemIE_Extensions(pub Vec<TAICancelledNR_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIListForInactiveItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14259,11 +14258,11 @@ pub struct TAIListForInactiveItemIE_Extensions_Entry {}
 )]
 pub struct TAIListForInactiveItemIE_Extensions(pub Vec<TAIListForInactiveItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TAIListForPagingItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14272,19 +14271,19 @@ pub struct TAIListForPagingItemIE_Extensions_Entry {}
 )]
 pub struct TAIListForPagingItemIE_Extensions(pub Vec<TAIListForPagingItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "32", sz_ub = "32")]
 pub struct BIT_STRING_81(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TNGF_IDchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TNLAssociationItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14293,11 +14292,11 @@ pub struct TNLAssociationItemIE_Extensions_Entry {}
 )]
 pub struct TNLAssociationItemIE_Extensions(pub Vec<TNLAssociationItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TSCAssistanceInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14308,11 +14307,11 @@ pub struct TSCAssistanceInformationIE_Extensions(
     pub Vec<TSCAssistanceInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TSCTrafficCharacteristicsIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14323,22 +14322,22 @@ pub struct TSCTrafficCharacteristicsIE_Extensions(
     pub Vec<TSCTrafficCharacteristicsIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "32", sz_ub = "32")]
 pub struct BIT_STRING_82(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TWIF_IDchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TargetIDchoice_ExtensionsValue {
     #[asn(key = 178)]
     Id_TargetRNC_ID(TargetRNC_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetIDchoice_Extensions {
     #[asn(key_field = true)]
@@ -14347,11 +14346,11 @@ pub struct TargetIDchoice_Extensions {
     pub value: TargetIDchoice_ExtensionsValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetNGRANNode_ToSourceNGRANNode_FailureTransparentContainerIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14362,14 +14361,14 @@ pub struct TargetNGRANNode_ToSourceNGRANNode_FailureTransparentContainerIE_Exten
     pub Vec<TargetNGRANNode_ToSourceNGRANNode_FailureTransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TargetNGRANNode_ToSourceNGRANNode_TransparentContainerIE_Extensions_EntryExtensionValue {
     #[asn(key = 267)]
     Id_DAPSResponseInfoList(DAPSResponseInfoList),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetNGRANNode_ToSourceNGRANNode_TransparentContainerIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -14379,7 +14378,7 @@ pub struct TargetNGRANNode_ToSourceNGRANNode_TransparentContainerIE_Extensions_E
         TargetNGRANNode_ToSourceNGRANNode_TransparentContainerIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14390,11 +14389,11 @@ pub struct TargetNGRANNode_ToSourceNGRANNode_TransparentContainerIE_Extensions(
     pub Vec<TargetNGRANNode_ToSourceNGRANNode_TransparentContainerIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetRANNodeIDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14403,11 +14402,11 @@ pub struct TargetRANNodeIDIE_Extensions_Entry {}
 )]
 pub struct TargetRANNodeIDIE_Extensions(pub Vec<TargetRANNodeIDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargetRNC_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14416,11 +14415,11 @@ pub struct TargetRNC_IDIE_Extensions_Entry {}
 )]
 pub struct TargetRNC_IDIE_Extensions(pub Vec<TargetRNC_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TargeteNB_IDIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14429,11 +14428,11 @@ pub struct TargeteNB_IDIE_Extensions_Entry {}
 )]
 pub struct TargeteNB_IDIE_Extensions(pub Vec<TargeteNB_IDIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TooearlyIntersystemHOIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14442,7 +14441,7 @@ pub struct TooearlyIntersystemHOIE_Extensions_Entry {}
 )]
 pub struct TooearlyIntersystemHOIE_Extensions(pub Vec<TooearlyIntersystemHOIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TraceActivationIE_Extensions_EntryExtensionValue {
     #[asn(key = 255)]
@@ -14451,7 +14450,7 @@ pub enum TraceActivationIE_Extensions_EntryExtensionValue {
     Id_TraceCollectionEntityURI(URI_address),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceActivationIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -14460,7 +14459,7 @@ pub struct TraceActivationIE_Extensions_Entry {
     pub extension_value: TraceActivationIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14469,7 +14468,7 @@ pub struct TraceActivationIE_Extensions_Entry {
 )]
 pub struct TraceActivationIE_Extensions(pub Vec<TraceActivationIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TraceFailureIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14482,7 +14481,7 @@ pub enum TraceFailureIndicationProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceFailureIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14491,7 +14490,7 @@ pub struct TraceFailureIndicationProtocolIEs_Entry {
     pub value: TraceFailureIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14500,7 +14499,7 @@ pub struct TraceFailureIndicationProtocolIEs_Entry {
 )]
 pub struct TraceFailureIndicationProtocolIEs(pub Vec<TraceFailureIndicationProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum TraceStartProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14511,7 +14510,7 @@ pub enum TraceStartProtocolIEs_EntryValue {
     Id_TraceActivation(TraceActivation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct TraceStartProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14520,7 +14519,7 @@ pub struct TraceStartProtocolIEs_Entry {
     pub value: TraceStartProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14529,7 +14528,7 @@ pub struct TraceStartProtocolIEs_Entry {
 )]
 pub struct TraceStartProtocolIEs(pub Vec<TraceStartProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_83(pub u8);
 impl ENUMERATED_83 {
@@ -14537,11 +14536,11 @@ impl ENUMERATED_83 {
     pub const ONDEMAND: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "1", ub = "3600", extensible = true)]
 pub struct INTEGER_84(pub u16);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "1")]
 pub struct ENUMERATED_85(pub u8);
 impl ENUMERATED_85 {
@@ -14549,7 +14548,7 @@ impl ENUMERATED_85 {
     pub const MOBILE: u8 = 1u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct ENUMERATED_86(pub u8);
 impl ENUMERATED_86 {
@@ -14558,7 +14557,7 @@ impl ENUMERATED_86 {
     pub const MULTIPLE_PACKETS: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "2")]
 pub struct ENUMERATED_87(pub u8);
 impl ENUMERATED_87 {
@@ -14567,11 +14566,11 @@ impl ENUMERATED_87 {
     pub const NOT_BATTERY_POWERED: u8 = 2u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_DifferentiationInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14580,11 +14579,11 @@ pub struct UE_DifferentiationInfoIE_Extensions_Entry {}
 )]
 pub struct UE_DifferentiationInfoIE_Extensions(pub Vec<UE_DifferentiationInfoIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_NGAP_ID_pairIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14593,15 +14592,15 @@ pub struct UE_NGAP_ID_pairIE_Extensions_Entry {}
 )]
 pub struct UE_NGAP_ID_pairIE_Extensions(pub Vec<UE_NGAP_ID_pairIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_NGAP_IDschoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UE_associatedLogicalNG_connectionItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14612,11 +14611,11 @@ pub struct UE_associatedLogicalNG_connectionItemIE_Extensions(
     pub Vec<UE_associatedLogicalNG_connectionItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEAggregateMaximumBitRateIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14627,7 +14626,7 @@ pub struct UEAggregateMaximumBitRateIE_Extensions(
     pub Vec<UEAggregateMaximumBitRateIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationFailureProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14640,7 +14639,7 @@ pub enum UEContextModificationFailureProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14649,7 +14648,7 @@ pub struct UEContextModificationFailureProtocolIEs_Entry {
     pub value: UEContextModificationFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14660,7 +14659,7 @@ pub struct UEContextModificationFailureProtocolIEs(
     pub Vec<UEContextModificationFailureProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14709,7 +14708,7 @@ pub enum UEContextModificationRequestProtocolIEs_EntryValue {
     Id_UESecurityCapabilities(UESecurityCapabilities),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14718,7 +14717,7 @@ pub struct UEContextModificationRequestProtocolIEs_Entry {
     pub value: UEContextModificationRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14729,7 +14728,7 @@ pub struct UEContextModificationRequestProtocolIEs(
     pub Vec<UEContextModificationRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextModificationResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14744,7 +14743,7 @@ pub enum UEContextModificationResponseProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextModificationResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14753,7 +14752,7 @@ pub struct UEContextModificationResponseProtocolIEs_Entry {
     pub value: UEContextModificationResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14764,7 +14763,7 @@ pub struct UEContextModificationResponseProtocolIEs(
     pub Vec<UEContextModificationResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextReleaseCommandProtocolIEs_EntryValue {
     #[asn(key = 15)]
@@ -14773,7 +14772,7 @@ pub enum UEContextReleaseCommandProtocolIEs_EntryValue {
     Id_UE_NGAP_IDs(UE_NGAP_IDs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextReleaseCommandProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14782,7 +14781,7 @@ pub struct UEContextReleaseCommandProtocolIEs_Entry {
     pub value: UEContextReleaseCommandProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14791,7 +14790,7 @@ pub struct UEContextReleaseCommandProtocolIEs_Entry {
 )]
 pub struct UEContextReleaseCommandProtocolIEs(pub Vec<UEContextReleaseCommandProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextReleaseCompleteProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14810,7 +14809,7 @@ pub enum UEContextReleaseCompleteProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextReleaseCompleteProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14819,7 +14818,7 @@ pub struct UEContextReleaseCompleteProtocolIEs_Entry {
     pub value: UEContextReleaseCompleteProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14828,7 +14827,7 @@ pub struct UEContextReleaseCompleteProtocolIEs_Entry {
 )]
 pub struct UEContextReleaseCompleteProtocolIEs(pub Vec<UEContextReleaseCompleteProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextReleaseRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14841,7 +14840,7 @@ pub enum UEContextReleaseRequestProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextReleaseRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14850,7 +14849,7 @@ pub struct UEContextReleaseRequestProtocolIEs_Entry {
     pub value: UEContextReleaseRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14859,7 +14858,7 @@ pub struct UEContextReleaseRequestProtocolIEs_Entry {
 )]
 pub struct UEContextReleaseRequestProtocolIEs(pub Vec<UEContextReleaseRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextResumeFailureProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14872,7 +14871,7 @@ pub enum UEContextResumeFailureProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14881,7 +14880,7 @@ pub struct UEContextResumeFailureProtocolIEs_Entry {
     pub value: UEContextResumeFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14890,7 +14889,7 @@ pub struct UEContextResumeFailureProtocolIEs_Entry {
 )]
 pub struct UEContextResumeFailureProtocolIEs(pub Vec<UEContextResumeFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextResumeRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14911,7 +14910,7 @@ pub enum UEContextResumeRequestProtocolIEs_EntryValue {
     Id_Suspend_Request_Indication(Suspend_Request_Indication),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14920,7 +14919,7 @@ pub struct UEContextResumeRequestProtocolIEs_Entry {
     pub value: UEContextResumeRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14929,11 +14928,11 @@ pub struct UEContextResumeRequestProtocolIEs_Entry {
 )]
 pub struct UEContextResumeRequestProtocolIEs(pub Vec<UEContextResumeRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeRequestTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14944,7 +14943,7 @@ pub struct UEContextResumeRequestTransferIE_Extensions(
     pub Vec<UEContextResumeRequestTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextResumeResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -14965,7 +14964,7 @@ pub enum UEContextResumeResponseProtocolIEs_EntryValue {
     Id_Suspend_Response_Indication(Suspend_Response_Indication),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -14974,7 +14973,7 @@ pub struct UEContextResumeResponseProtocolIEs_Entry {
     pub value: UEContextResumeResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14983,11 +14982,11 @@ pub struct UEContextResumeResponseProtocolIEs_Entry {
 )]
 pub struct UEContextResumeResponseProtocolIEs(pub Vec<UEContextResumeResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextResumeResponseTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -14998,7 +14997,7 @@ pub struct UEContextResumeResponseTransferIE_Extensions(
     pub Vec<UEContextResumeResponseTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextSuspendFailureProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15011,7 +15010,7 @@ pub enum UEContextSuspendFailureProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextSuspendFailureProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15020,7 +15019,7 @@ pub struct UEContextSuspendFailureProtocolIEs_Entry {
     pub value: UEContextSuspendFailureProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15029,7 +15028,7 @@ pub struct UEContextSuspendFailureProtocolIEs_Entry {
 )]
 pub struct UEContextSuspendFailureProtocolIEs(pub Vec<UEContextSuspendFailureProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextSuspendRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15044,7 +15043,7 @@ pub enum UEContextSuspendRequestProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextSuspendRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15053,7 +15052,7 @@ pub struct UEContextSuspendRequestProtocolIEs_Entry {
     pub value: UEContextSuspendRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15062,11 +15061,11 @@ pub struct UEContextSuspendRequestProtocolIEs_Entry {
 )]
 pub struct UEContextSuspendRequestProtocolIEs(pub Vec<UEContextSuspendRequestProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextSuspendRequestTransferIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15077,7 +15076,7 @@ pub struct UEContextSuspendRequestTransferIE_Extensions(
     pub Vec<UEContextSuspendRequestTransferIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEContextSuspendResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15090,7 +15089,7 @@ pub enum UEContextSuspendResponseProtocolIEs_EntryValue {
     Id_SecurityContext(SecurityContext),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEContextSuspendResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15099,7 +15098,7 @@ pub struct UEContextSuspendResponseProtocolIEs_Entry {
     pub value: UEContextSuspendResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15108,19 +15107,19 @@ pub struct UEContextSuspendResponseProtocolIEs_Entry {
 )]
 pub struct UEContextSuspendResponseProtocolIEs(pub Vec<UEContextSuspendResponseProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEHistoryInformationFromTheUEchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = false, sz_lb = "10", sz_ub = "10")]
 pub struct BIT_STRING_88(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEIdentityIndexValuechoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UEInformationTransferProtocolIEs_EntryValue {
     #[asn(key = 0)]
@@ -15137,7 +15136,7 @@ pub enum UEInformationTransferProtocolIEs_EntryValue {
     Id_UERadioCapability(UERadioCapability),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEInformationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15146,7 +15145,7 @@ pub struct UEInformationTransferProtocolIEs_Entry {
     pub value: UEInformationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15155,15 +15154,15 @@ pub struct UEInformationTransferProtocolIEs_Entry {
 )]
 pub struct UEInformationTransferProtocolIEs(pub Vec<UEInformationTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEPagingIdentitychoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UEPresenceInAreaOfInterestItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15174,11 +15173,11 @@ pub struct UEPresenceInAreaOfInterestItemIE_Extensions(
     pub Vec<UEPresenceInAreaOfInterestItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERLFReportContainerchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityCheckRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15191,7 +15190,7 @@ pub enum UERadioCapabilityCheckRequestProtocolIEs_EntryValue {
     Id_UERadioCapabilityID(UERadioCapabilityID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityCheckRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15200,7 +15199,7 @@ pub struct UERadioCapabilityCheckRequestProtocolIEs_Entry {
     pub value: UERadioCapabilityCheckRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15211,7 +15210,7 @@ pub struct UERadioCapabilityCheckRequestProtocolIEs(
     pub Vec<UERadioCapabilityCheckRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityCheckResponseProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15224,7 +15223,7 @@ pub enum UERadioCapabilityCheckResponseProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityCheckResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15233,7 +15232,7 @@ pub struct UERadioCapabilityCheckResponseProtocolIEs_Entry {
     pub value: UERadioCapabilityCheckResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15244,14 +15243,14 @@ pub struct UERadioCapabilityCheckResponseProtocolIEs(
     pub Vec<UERadioCapabilityCheckResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityForPagingIE_Extensions_EntryExtensionValue {
     #[asn(key = 214)]
     Id_UERadioCapabilityForPagingOfNB_IoT(UERadioCapabilityForPagingOfNB_IoT),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityForPagingIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -15260,7 +15259,7 @@ pub struct UERadioCapabilityForPagingIE_Extensions_Entry {
     pub extension_value: UERadioCapabilityForPagingIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15271,14 +15270,14 @@ pub struct UERadioCapabilityForPagingIE_Extensions(
     pub Vec<UERadioCapabilityForPagingIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityIDMappingRequestProtocolIEs_EntryValue {
     #[asn(key = 264)]
     Id_UERadioCapabilityID(UERadioCapabilityID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityIDMappingRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15287,7 +15286,7 @@ pub struct UERadioCapabilityIDMappingRequestProtocolIEs_Entry {
     pub value: UERadioCapabilityIDMappingRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15298,7 +15297,7 @@ pub struct UERadioCapabilityIDMappingRequestProtocolIEs(
     pub Vec<UERadioCapabilityIDMappingRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityIDMappingResponseProtocolIEs_EntryValue {
     #[asn(key = 19)]
@@ -15309,7 +15308,7 @@ pub enum UERadioCapabilityIDMappingResponseProtocolIEs_EntryValue {
     Id_UERadioCapabilityID(UERadioCapabilityID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityIDMappingResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15318,7 +15317,7 @@ pub struct UERadioCapabilityIDMappingResponseProtocolIEs_Entry {
     pub value: UERadioCapabilityIDMappingResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15329,7 +15328,7 @@ pub struct UERadioCapabilityIDMappingResponseProtocolIEs(
     pub Vec<UERadioCapabilityIDMappingResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UERadioCapabilityInfoIndicationProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15344,7 +15343,7 @@ pub enum UERadioCapabilityInfoIndicationProtocolIEs_EntryValue {
     Id_UERadioCapabilityForPaging(UERadioCapabilityForPaging),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UERadioCapabilityInfoIndicationProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15353,7 +15352,7 @@ pub struct UERadioCapabilityInfoIndicationProtocolIEs_Entry {
     pub value: UERadioCapabilityInfoIndicationProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15364,11 +15363,11 @@ pub struct UERadioCapabilityInfoIndicationProtocolIEs(
     pub Vec<UERadioCapabilityInfoIndicationProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UESecurityCapabilitiesIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15377,7 +15376,7 @@ pub struct UESecurityCapabilitiesIE_Extensions_Entry {}
 )]
 pub struct UESecurityCapabilitiesIE_Extensions(pub Vec<UESecurityCapabilitiesIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UETNLABindingReleaseRequestProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15386,7 +15385,7 @@ pub enum UETNLABindingReleaseRequestProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UETNLABindingReleaseRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15395,7 +15394,7 @@ pub struct UETNLABindingReleaseRequestProtocolIEs_Entry {
     pub value: UETNLABindingReleaseRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15406,11 +15405,11 @@ pub struct UETNLABindingReleaseRequestProtocolIEs(
     pub Vec<UETNLABindingReleaseRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UL_CP_SecurityInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15421,7 +15420,7 @@ pub struct UL_CP_SecurityInformationIE_Extensions(
     pub Vec<UL_CP_SecurityInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UL_NGU_UP_TNLModifyItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 192)]
@@ -15430,7 +15429,7 @@ pub enum UL_NGU_UP_TNLModifyItemIE_Extensions_EntryExtensionValue {
     Id_RedundantUL_NGU_UP_TNLInformation(UPTransportLayerInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UL_NGU_UP_TNLModifyItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -15439,7 +15438,7 @@ pub struct UL_NGU_UP_TNLModifyItemIE_Extensions_Entry {
     pub extension_value: UL_NGU_UP_TNLModifyItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15450,15 +15449,15 @@ pub struct UL_NGU_UP_TNLModifyItemIE_Extensions(
     pub Vec<UL_NGU_UP_TNLModifyItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UPTransportLayerInformationchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UPTransportLayerInformationItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15469,11 +15468,11 @@ pub struct UPTransportLayerInformationItemIE_Extensions(
     pub Vec<UPTransportLayerInformationItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UPTransportLayerInformationPairItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15484,11 +15483,11 @@ pub struct UPTransportLayerInformationPairItemIE_Extensions(
     pub Vec<UPTransportLayerInformationPairItemIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UnavailableGUAMIItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15497,7 +15496,7 @@ pub struct UnavailableGUAMIItemIE_Extensions_Entry {}
 )]
 pub struct UnavailableGUAMIItemIE_Extensions(pub Vec<UnavailableGUAMIItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UnsuccessfulOutcomeValue {
     #[asn(key = 0)]
@@ -15522,7 +15521,7 @@ pub enum UnsuccessfulOutcomeValue {
     Id_UEContextSuspend(UEContextSuspendFailure),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkNASTransportProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15535,7 +15534,7 @@ pub enum UplinkNASTransportProtocolIEs_EntryValue {
     Id_UserLocationInformation(UserLocationInformation),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkNASTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15544,7 +15543,7 @@ pub struct UplinkNASTransportProtocolIEs_Entry {
     pub value: UplinkNASTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15553,7 +15552,7 @@ pub struct UplinkNASTransportProtocolIEs_Entry {
 )]
 pub struct UplinkNASTransportProtocolIEs(pub Vec<UplinkNASTransportProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkNonUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 46)]
@@ -15562,7 +15561,7 @@ pub enum UplinkNonUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     Id_RoutingID(RoutingID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkNonUEAssociatedNRPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15571,7 +15570,7 @@ pub struct UplinkNonUEAssociatedNRPPaTransportProtocolIEs_Entry {
     pub value: UplinkNonUEAssociatedNRPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15582,7 +15581,7 @@ pub struct UplinkNonUEAssociatedNRPPaTransportProtocolIEs(
     pub Vec<UplinkNonUEAssociatedNRPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkRANConfigurationTransferProtocolIEs_EntryValue {
     #[asn(key = 158)]
@@ -15593,7 +15592,7 @@ pub enum UplinkRANConfigurationTransferProtocolIEs_EntryValue {
     Id_SONConfigurationTransferUL(SONConfigurationTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkRANConfigurationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15602,7 +15601,7 @@ pub struct UplinkRANConfigurationTransferProtocolIEs_Entry {
     pub value: UplinkRANConfigurationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15613,7 +15612,7 @@ pub struct UplinkRANConfigurationTransferProtocolIEs(
     pub Vec<UplinkRANConfigurationTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkRANEarlyStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15624,7 +15623,7 @@ pub enum UplinkRANEarlyStatusTransferProtocolIEs_EntryValue {
     Id_RAN_UE_NGAP_ID(RAN_UE_NGAP_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkRANEarlyStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15633,7 +15632,7 @@ pub struct UplinkRANEarlyStatusTransferProtocolIEs_Entry {
     pub value: UplinkRANEarlyStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15644,7 +15643,7 @@ pub struct UplinkRANEarlyStatusTransferProtocolIEs(
     pub Vec<UplinkRANEarlyStatusTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkRANStatusTransferProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15655,7 +15654,7 @@ pub enum UplinkRANStatusTransferProtocolIEs_EntryValue {
     Id_RANStatusTransfer_TransparentContainer(RANStatusTransfer_TransparentContainer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkRANStatusTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15664,7 +15663,7 @@ pub struct UplinkRANStatusTransferProtocolIEs_Entry {
     pub value: UplinkRANStatusTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15673,14 +15672,14 @@ pub struct UplinkRANStatusTransferProtocolIEs_Entry {
 )]
 pub struct UplinkRANStatusTransferProtocolIEs(pub Vec<UplinkRANStatusTransferProtocolIEs_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkRIMInformationTransferProtocolIEs_EntryValue {
     #[asn(key = 175)]
     Id_RIMInformationTransfer(RIMInformationTransfer),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkRIMInformationTransferProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15689,7 +15688,7 @@ pub struct UplinkRIMInformationTransferProtocolIEs_Entry {
     pub value: UplinkRIMInformationTransferProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15700,7 +15699,7 @@ pub struct UplinkRIMInformationTransferProtocolIEs(
     pub Vec<UplinkRIMInformationTransferProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UplinkUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     #[asn(key = 10)]
@@ -15713,7 +15712,7 @@ pub enum UplinkUEAssociatedNRPPaTransportProtocolIEs_EntryValue {
     Id_RoutingID(RoutingID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UplinkUEAssociatedNRPPaTransportProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -15722,7 +15721,7 @@ pub struct UplinkUEAssociatedNRPPaTransportProtocolIEs_Entry {
     pub value: UplinkUEAssociatedNRPPaTransportProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15733,7 +15732,7 @@ pub struct UplinkUEAssociatedNRPPaTransportProtocolIEs(
     pub Vec<UplinkUEAssociatedNRPPaTransportProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UserLocationInformationchoice_ExtensionsValue {
     #[asn(key = 244)]
@@ -15744,7 +15743,7 @@ pub enum UserLocationInformationchoice_ExtensionsValue {
     Id_UserLocationInformationW_AGF(UserLocationInformationW_AGF),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationchoice_Extensions {
     #[asn(key_field = true)]
@@ -15753,14 +15752,14 @@ pub struct UserLocationInformationchoice_Extensions {
     pub value: UserLocationInformationchoice_ExtensionsValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UserLocationInformationEUTRAIE_Extensions_EntryExtensionValue {
     #[asn(key = 149)]
     Id_PSCellInformation(NGRAN_CGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationEUTRAIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -15769,7 +15768,7 @@ pub struct UserLocationInformationEUTRAIE_Extensions_Entry {
     pub extension_value: UserLocationInformationEUTRAIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15780,11 +15779,11 @@ pub struct UserLocationInformationEUTRAIE_Extensions(
     pub Vec<UserLocationInformationEUTRAIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationN3IWFIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15795,7 +15794,7 @@ pub struct UserLocationInformationN3IWFIE_Extensions(
     pub Vec<UserLocationInformationN3IWFIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UserLocationInformationNRIE_Extensions_EntryExtensionValue {
     #[asn(key = 263)]
@@ -15804,7 +15803,7 @@ pub enum UserLocationInformationNRIE_Extensions_EntryExtensionValue {
     Id_PSCellInformation(NGRAN_CGI),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationNRIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -15813,7 +15812,7 @@ pub struct UserLocationInformationNRIE_Extensions_Entry {
     pub extension_value: UserLocationInformationNRIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15824,11 +15823,11 @@ pub struct UserLocationInformationNRIE_Extensions(
     pub Vec<UserLocationInformationNRIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationTNGFIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15839,11 +15838,11 @@ pub struct UserLocationInformationTNGFIE_Extensions(
     pub Vec<UserLocationInformationTNGFIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationTWIFIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15854,14 +15853,14 @@ pub struct UserLocationInformationTWIFIE_Extensions(
     pub Vec<UserLocationInformationTWIFIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum UserLocationInformationW_AGFchoice_ExtensionsValue {
     #[asn(key = 275)]
     Id_GlobalCable_ID(GlobalCable_ID),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserLocationInformationW_AGFchoice_Extensions {
     #[asn(key_field = true)]
@@ -15870,11 +15869,11 @@ pub struct UserLocationInformationW_AGFchoice_Extensions {
     pub value: UserLocationInformationW_AGFchoice_ExtensionsValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct UserPlaneSecurityInformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15885,27 +15884,27 @@ pub struct UserPlaneSecurityInformationIE_Extensions(
     pub Vec<UserPlaneSecurityInformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct OCTET_STRING_89(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OCTET-STRING", sz_extensible = false, sz_lb = "4", sz_ub = "4")]
 pub struct OCTET_STRING_90(pub Vec<u8>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "18446744073709551615")]
 pub struct INTEGER_91(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "INTEGER", lb = "0", ub = "18446744073709551615")]
 pub struct INTEGER_92(pub u64);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct VolumeTimedReport_ItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15914,19 +15913,19 @@ pub struct VolumeTimedReport_ItemIE_Extensions_Entry {}
 )]
 pub struct VolumeTimedReport_ItemIE_Extensions(pub Vec<VolumeTimedReport_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "BITSTRING", sz_extensible = true, sz_lb = "16", sz_ub = "16")]
 pub struct BIT_STRING_93(pub BitVec<u8, Msb0>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct W_AGF_IDchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WLANMeasConfigNameItemIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15935,25 +15934,25 @@ pub struct WLANMeasConfigNameItemIE_Extensions_Entry {}
 )]
 pub struct WLANMeasConfigNameItemIE_Extensions(pub Vec<WLANMeasConfigNameItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_94(pub u8);
 impl ENUMERATED_94 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "ENUMERATED", extensible = true, lb = "0", ub = "0")]
 pub struct ENUMERATED_95(pub u8);
 impl ENUMERATED_95 {
     pub const TRUE: u8 = 0u8;
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WLANMeasurementConfigurationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15964,11 +15963,11 @@ pub struct WLANMeasurementConfigurationIE_Extensions(
     pub Vec<WLANMeasurementConfigurationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WUS_Assistance_InformationIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -15979,11 +15978,11 @@ pub struct WUS_Assistance_InformationIE_Extensions(
     pub Vec<WUS_Assistance_InformationIE_Extensions_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WarningAreaListchoice_Extensions {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum WriteReplaceWarningRequestProtocolIEs_EntryValue {
     #[asn(key = 17)]
@@ -16010,7 +16009,7 @@ pub enum WriteReplaceWarningRequestProtocolIEs_EntryValue {
     Id_WarningType(WarningType),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WriteReplaceWarningRequestProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -16019,7 +16018,7 @@ pub struct WriteReplaceWarningRequestProtocolIEs_Entry {
     pub value: WriteReplaceWarningRequestProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -16030,7 +16029,7 @@ pub struct WriteReplaceWarningRequestProtocolIEs(
     pub Vec<WriteReplaceWarningRequestProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum WriteReplaceWarningResponseProtocolIEs_EntryValue {
     #[asn(key = 13)]
@@ -16043,7 +16042,7 @@ pub enum WriteReplaceWarningResponseProtocolIEs_EntryValue {
     Id_SerialNumber(SerialNumber),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct WriteReplaceWarningResponseProtocolIEs_Entry {
     #[asn(key_field = true)]
@@ -16052,7 +16051,7 @@ pub struct WriteReplaceWarningResponseProtocolIEs_Entry {
     pub value: WriteReplaceWarningResponseProtocolIEs_EntryValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -16063,14 +16062,14 @@ pub struct WriteReplaceWarningResponseProtocolIEs(
     pub Vec<WriteReplaceWarningResponseProtocolIEs_Entry>,
 );
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "OPEN")]
 pub enum XnExtTLA_ItemIE_Extensions_EntryExtensionValue {
     #[asn(key = 173)]
     Id_SCTP_TLAs(SCTP_TLAs),
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct XnExtTLA_ItemIE_Extensions_Entry {
     #[asn(key_field = true)]
@@ -16079,7 +16078,7 @@ pub struct XnExtTLA_ItemIE_Extensions_Entry {
     pub extension_value: XnExtTLA_ItemIE_Extensions_EntryExtensionValue,
 }
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,
@@ -16088,11 +16087,11 @@ pub struct XnExtTLA_ItemIE_Extensions_Entry {
 )]
 pub struct XnExtTLA_ItemIE_Extensions(pub Vec<XnExtTLA_ItemIE_Extensions_Entry>);
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(type = "SEQUENCE", extensible = false)]
 pub struct XnTNLConfigurationInfoIE_Extensions_Entry {}
 
-#[derive(Debug, AperCodec)]
+#[derive(asn1_codecs_derive :: AperCodec, serde :: Serialize, serde :: Deserialize, Debug)]
 #[asn(
     type = "SEQUENCE-OF",
     sz_extensible = false,


### PR DESCRIPTION
- Supports only Aper Codec as of now
- Support for `Debug`, `serde::Serialize` and `serde::Deserialize` codecs
- Updated the dev dependencies
- Now using generated files with codecs and derives to test