### PR TITLE
Minor update to `build.rs` and a new crate version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ Currently specifications from the `specs/` directory can be compiled into respec
 
 ## Getting Started
 
-The simplest way to try out this in action is - `cargo run --release specs/ngap/NGAP-*  > ngap.rs` and then take a look at generated `ngap` module. (Better CLI support is coming soon.)
-
-### Running Test Cases
-
-1. Test cases can be run through `cargo test`.
-
-
 ### `build.rs` Support
 
 Typically the compiler can be invoked also using `build.rs` mechanism. An example `build.rs` is provided in the `examples/` sub project. And the code generated through this `build.rs` can be integrated into your project. Examples of that is provided in `examples/tests/` directory.
@@ -34,4 +27,8 @@ Typically the compiler can be invoked also using `build.rs` mechanism. An exampl
 ### Using CLI tool
 
 A tool `hampi-rs-asn1c` can be installed using `cargo install hampi-rs-asn1c` and then following the CLI usage.
+
+### Running Test Cases
+
+1. Test cases can be run through `cargo test`.
 

--- a/asn-compiler/Cargo.toml
+++ b/asn-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-compiler"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "ASN.1 Compiler in Rust."

--- a/codecs/Cargo.toml
+++ b/codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-codecs"
-version = "0.3.0"
+version = "0.3.1"
 description = "ASN.1 Codecs for Rust Types representing ASN.1 Types."
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 keywords = ["asn1", "per", "decoder", "encoder"]

--- a/codecs_derive/Cargo.toml
+++ b/codecs_derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "asn1_codecs_derive"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 description = "ASN.1 Codecs derive Macros"
 keywords = ["asn1", "per"]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 license-file = "LICENSE"
 repository = "https://github.com/gabhijit/hampi.git"
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 log = { version = "0.4" }
-asn1-codecs = { path = "../codecs" , version = "=0.3.0"}
+asn1-codecs = { path = "../codecs" , version = "=0.3.1"}
 bitvec = { version = "1.0" }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "hampi-examples"
-version = "0.2.0"
+version = "0.3.1"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "Examples for usage of ASN.1 Compiler and Codecs."
 publish = false
 
 [build-dependencies]
-asn1-compiler = { path = "../asn-compiler", version = "=0.3.0" }
+asn1-compiler = { path = "../asn-compiler", version = "=0.3.1" }
 
 [dev-dependencies]
-asn1-codecs = { path = "../codecs", version = "=0.3.0" }
-asn1_codecs_derive = { path = "../codecs_derive", version = "=0.3.0" }
+asn1-codecs = { path = "../codecs", version = "=0.3.1" }
+asn1_codecs_derive = { path = "../codecs_derive", version = "=0.3.1" }
 trybuild = { version = "1.0" }
 hex = { version = "0.4" }
 bitvec = { version = "1.0" , features = ["serde"]}


### PR DESCRIPTION
Updated a `build.rs` to use slightly cleaner code to generate the bindings. Removed the old documentation that referred to running the code and updated crate versions everywhere to 0.3.1