### PR TITLE
Fix for #48 - UTCTime and GeneralizedTime supported in parser

### DIFF
--- a/asn-compiler/Cargo.toml
+++ b/asn-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-compiler"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "ASN.1 Compiler in Rust."

--- a/asn-compiler/src/parser/asn/types/int.rs
+++ b/asn-compiler/src/parser/asn/types/int.rs
@@ -77,8 +77,11 @@ pub(crate) fn parse_type(tokens: &[Token]) -> Result<(Asn1Type, usize), Error> {
         }
 
         "BOOLEAN" => (Asn1TypeKind::Builtin(Asn1BuiltinType::Boolean), 1),
+
         "NULL" => (Asn1TypeKind::Builtin(Asn1BuiltinType::Null), 1),
-        "VisibleString" | "UTF8String" | "IA5String" | "PrintableString" => (
+
+        "VisibleString" | "UTF8String" | "IA5String" | "PrintableString" | "UTCTime"
+        | "GeneralizedTime" => (
             Asn1TypeKind::Builtin(Asn1BuiltinType::CharacterString {
                 str_type: typestr.to_string(),
             }),
@@ -92,6 +95,7 @@ pub(crate) fn parse_type(tokens: &[Token]) -> Result<(Asn1Type, usize), Error> {
                 choice_type_consumed,
             )
         }
+
         "SEQUENCE" => parse_seq_or_seq_of_type(tokens)?,
 
         "RELATIVE-OID" => (Asn1TypeKind::Builtin(Asn1BuiltinType::RelativeOid), 1),
@@ -256,6 +260,11 @@ mod tests {
                 input: "SEQUENCE SIZE (1.. 1024) OF ReportData",
                 success: true,
                 consumed: 9,
+            },
+            ParseTypeTestCase {
+                input: "CHOICE { absoluteTime  UTCTime, relativeTime  INTEGER (0..31536000)}",
+                success: true,
+                consumed: 13,
             },
         ];
 

--- a/asn-compiler/src/tokenizer/mod.rs
+++ b/asn-compiler/src/tokenizer/mod.rs
@@ -102,6 +102,8 @@ const BASE_TYPES: &[&str] = &[
     "IA5String",
     "PrintableString",
     "VisibleString",
+    "UTCTime",
+    "GeneralizedTime",
     // Spliced types (Note: actual ASN.1 Type names are different.
     "OBJECT",
     "OCTET",

--- a/codecs/Cargo.toml
+++ b/codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-codecs"
-version = "0.4.0"
+version = "0.4.1"
 description = "ASN.1 Codecs for Rust Types representing ASN.1 Types."
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 keywords = ["asn1", "per", "decoder", "encoder"]

--- a/codecs_derive/Cargo.toml
+++ b/codecs_derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "asn1_codecs_derive"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 description = "ASN.1 Codecs derive Macros"
 keywords = ["asn1", "per"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 license-file = "LICENSE"
 repository = "https://github.com/gabhijit/hampi.git"
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 log = { version = "0.4" }
-asn1-codecs = { path = "../codecs" , version = "=0.4.0"}
+asn1-codecs = { path = "../codecs" , version = "=0.4.1"}
 bitvec = { version = "1.0" }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "hampi-examples"
-version = "0.3.1"
+version = "0.4.1"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "Examples for usage of ASN.1 Compiler and Codecs."
 publish = false
 
 [build-dependencies]
-asn1-compiler = { path = "../asn-compiler", version = "=0.4.0" }
+asn1-compiler = { path = "../asn-compiler", version = "=0.4.1" }
 
 [dev-dependencies]
-asn1-codecs = { path = "../codecs", version = "=0.4.0" }
-asn1_codecs_derive = { path = "../codecs_derive", version = "=0.4.0" }
+asn1-codecs = { path = "../codecs", version = "=0.4.1" }
+asn1_codecs_derive = { path = "../codecs_derive", version = "=0.4.1" }
 trybuild = { version = "1.0" }
 hex = { version = "0.4" }
 bitvec = { version = "1.0" , features = ["serde"]}

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -41,8 +41,8 @@ fn get_specs_files(
 }
 
 fn main() -> std::io::Result<()> {
-    let specs = vec!["ranap", "s1ap", "ngap", "e2ap"];
-    let modules = vec!["ranap.rs", "s1ap.rs", "ngap.rs", "e2ap.rs"];
+    let specs = vec!["ranap", "s1ap", "ngap", "e2ap", "supl"];
+    let modules = vec!["ranap.rs", "s1ap.rs", "ngap.rs", "e2ap.rs", "supl.rs"];
 
     for (spec, module) in std::iter::zip(specs, modules) {
         let specs_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())

--- a/examples/specs/supl/SUPL-ULP-Components.asn
+++ b/examples/specs/supl/SUPL-ULP-Components.asn
@@ -1,0 +1,754 @@
+-- ULP-Components.asn
+-- $Id$
+-- From OMA UserPlane Location Protocol Candidate Version 2.0 06 Aug 2010
+-- OMA-TS-ULP-V2_0-20100806-D
+--
+-- 11.5	Common elements (SUPL Version 1)
+--
+
+ULP-Components DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Version, SessionID, IPAddress, SLPAddress, LocationId, Position, StatusCode, Velocity, QoP, PosMethod, Ver, SETId, PrimaryCPICH-Info, CellParametersID, FQDN;
+
+IMPORTS
+	Ver2-CellInfo-extension
+FROM Ver2-ULP-Components;
+
+-- protocol version expressed as x.y.z (e.g., 5.1.0)--
+Version ::= SEQUENCE {
+  maj      INTEGER(0..255),
+  min      INTEGER(0..255),
+  servind  INTEGER(0..255)}
+
+SessionID ::= SEQUENCE {
+  setSessionID  SetSessionID OPTIONAL, -- the semantics of OPTIONAL applies to the encoding only. The parameter itself is MANDATORY. This is introduced only to minimize bandwidth for the SUPL INIT message. Since the setSessionID is allocated by the SET, there is no setSessionID to be transmitted in the SUPL INIT message.
+  slpSessionID  SlpSessionID OPTIONAL -- the semantics of OPTIONAL applies to the encoding only. The parameter itself is MANDATORY. This is introduced only to minimize bandwidth for the SUPL START, SUPL TRIGGERED START and SUPL SET INIT messages. Since the slpSessionID is allocated by the SLP, there is no slpSessionID to be transmitted in these messages (with the exception described in section 10.14).--
+}
+
+SetSessionID ::= SEQUENCE {sessionId  INTEGER(0..65535),
+                           setId      SETId}
+
+SETId ::= CHOICE {
+  msisdn     OCTET STRING(SIZE (8)),
+  mdn        OCTET STRING(SIZE (8)),
+  min        BIT STRING(SIZE (34)), -- coded according to TIA-553
+  imsi       OCTET STRING(SIZE (8)),
+  nai        IA5String(SIZE (1..1000)),
+  iPAddress  IPAddress,
+  ...}
+-- msisdn, mnd and imsi are a BCD (Binary Coded Decimal) string
+-- represent digits from 0 through 9,
+-- two digits per octet, each digit encoded 0000 to 1001 (0 to 9)
+-- bits 8765 of octet n encoding digit 2n
+-- bits 4321 of octet n encoding digit 2(n-1) +1
+-- not used digits in the string shall be filled with 1111
+
+SlpSessionID ::= SEQUENCE {
+  sessionID  OCTET STRING(SIZE (4)),
+  slpId      SLPAddress}
+
+IPAddress ::= CHOICE {
+  ipv4Address  OCTET STRING(SIZE (4)),
+  ipv6Address  OCTET STRING(SIZE (16))}
+
+SLPAddress ::= CHOICE {iPAddress  IPAddress,
+                       fQDN       FQDN,
+                       ...}
+
+FQDN ::=
+  VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" |".-"))(SIZE (1..255))
+
+Ver ::= BIT STRING(SIZE (64))
+
+LocationId ::= SEQUENCE {cellInfo  CellInfo,
+                         status    Status,
+                         ...}
+
+Status ::= ENUMERATED {stale(0), current(1), unknown(2), ...}
+
+CellInfo ::= CHOICE {
+  gsmCell    GsmCellInformation,
+  wcdmaCell  WcdmaCellInformation, --WCDMA Cell Information/TD-SCDMA Cell Information
+  cdmaCell   CdmaCellInformation,
+  ...,
+  ver2-CellInfo-extension	Ver2-CellInfo-extension}
+
+Position ::= SEQUENCE {
+  timestamp         UTCTime, -- shall include seconds and shall use UTC time.
+  positionEstimate  PositionEstimate,
+  velocity          Velocity OPTIONAL,
+  ...}
+
+PositionEstimate ::= SEQUENCE {
+  latitudeSign  ENUMERATED {north, south},
+  latitude      INTEGER(0..8388607),
+  longitude     INTEGER(-8388608..8388607),
+  uncertainty
+    SEQUENCE {uncertaintySemiMajor  INTEGER(0..127),
+              uncertaintySemiMinor  INTEGER(0..127),
+              orientationMajorAxis  INTEGER(0..180)} OPTIONAL, -- angle in degree between major axis and North
+  confidence    INTEGER(0..100) OPTIONAL,
+  altitudeInfo  AltitudeInfo OPTIONAL,
+  ...} -- Coding as in [3GPP GAD]
+
+AltitudeInfo ::= SEQUENCE {
+  altitudeDirection  ENUMERATED {height, depth},
+  altitude           INTEGER(0..32767),
+  altUncertainty     INTEGER(0..127),
+  ... } -- based on [3GPP GAD]
+
+CdmaCellInformation ::= SEQUENCE {
+  refNID         INTEGER(0..65535), -- Network Id
+  refSID         INTEGER(0..32767), -- System Id
+  refBASEID      INTEGER(0..65535), -- Base Station Id
+  refBASELAT     INTEGER(0..4194303), -- Base Station Latitude
+  reBASELONG     INTEGER(0..8388607), -- Base Station Longitude
+  refREFPN       INTEGER(0..511), -- Base Station PN Code
+  refWeekNumber  INTEGER(0..65535), -- GPS Week Number
+  refSeconds     INTEGER(0..4194303), -- GPS Seconds --
+  ...}
+
+GsmCellInformation ::= SEQUENCE {
+  refMCC  INTEGER(0..999), -- Mobile Country Code
+  refMNC  INTEGER(0..999), -- Mobile Network Code
+  refLAC  INTEGER(0..65535), -- Location area code
+  refCI   INTEGER(0..65535), -- Cell identity
+  nMR     NMR OPTIONAL,
+  tA      INTEGER(0..255) OPTIONAL, --Timing Advance
+  ...}
+
+WcdmaCellInformation ::= SEQUENCE {
+  refMCC                 INTEGER(0..999), -- Mobile Country Code
+  refMNC                 INTEGER(0..999), -- Mobile Network Code
+  refUC                  INTEGER(0..268435455), -- Cell identity
+  frequencyInfo          FrequencyInfo OPTIONAL,
+  primaryScramblingCode  INTEGER(0..511) OPTIONAL, -- Not applicable for TDD
+  measuredResultsList    MeasuredResultsList OPTIONAL,
+  ...,
+  cellParametersId       INTEGER(0..127) OPTIONAL, -- Not applicable for FDD
+  timingAdvance	   TimingAdvance OPTIONAL -- Not applicable for FDD
+}
+
+TimingAdvance ::= SEQUENCE {
+ tA	INTEGER (0..8191),
+ tAResolution    TAResolution OPTIONAL, --If missing, resolution is 0.125 chips
+ chipRate        ChipRate OPTIONAL, --If missing, chip rate is 1.28 Mchip/s
+...}
+
+TAResolution ::= ENUMERATED {res10chip(0),res05chip(1),res0125chip(2), ...} -- Corresponding to 1.0-chip, 0.5-chip and 0.125-chip resolutions, respectively
+
+ChipRate ::= ENUMERATED {tdd128(0),tdd384(1), tdd768(2), ...} --Corresponding to 1.28-Mchips/s, 3.84-Mchips/s and 7.68-Mchips/s chip rates, respectively
+
+
+FrequencyInfo ::= SEQUENCE {
+  modeSpecificInfo  CHOICE {fdd  FrequencyInfoFDD,
+                            tdd  FrequencyInfoTDD,
+                            ...},
+  ...}
+
+FrequencyInfoFDD ::= SEQUENCE {
+  uarfcn-UL  UARFCN OPTIONAL,
+  uarfcn-DL  UARFCN,
+  ...}
+
+FrequencyInfoTDD ::= SEQUENCE {uarfcn-Nt  UARFCN,
+                               ...}
+
+UARFCN ::= INTEGER(0..16383)
+
+NMR ::= SEQUENCE (SIZE (1..15)) OF NMRelement
+
+NMRelement ::= SEQUENCE {
+  aRFCN  INTEGER(0..1023),
+  bSIC   INTEGER(0..63),
+  rxLev  INTEGER(0..63),
+  ...}
+
+MeasuredResultsList ::= SEQUENCE (SIZE (1..maxFreq)) OF MeasuredResults
+
+MeasuredResults ::= SEQUENCE {
+  frequencyInfo            FrequencyInfo OPTIONAL,
+  utra-CarrierRSSI         UTRA-CarrierRSSI OPTIONAL,
+  cellMeasuredResultsList  CellMeasuredResultsList OPTIONAL}
+
+CellMeasuredResultsList ::=
+  SEQUENCE (SIZE (1..maxCellMeas)) OF CellMeasuredResults
+
+-- SPARE: UTRA-CarrierRSSI, Max = 76
+-- Values above Max are spare
+UTRA-CarrierRSSI ::= INTEGER(0..127)
+
+CellMeasuredResults ::= SEQUENCE {
+  cellIdentity      INTEGER(0..268435455) OPTIONAL,
+  modeSpecificInfo
+    CHOICE {fdd
+              SEQUENCE {primaryCPICH-Info  PrimaryCPICH-Info,
+                        cpich-Ec-N0        CPICH-Ec-N0 OPTIONAL,
+                        cpich-RSCP         CPICH-RSCP OPTIONAL,
+                        pathloss           Pathloss OPTIONAL},
+            tdd
+              SEQUENCE {cellParametersID   CellParametersID,
+                        proposedTGSN       TGSN OPTIONAL,
+                        primaryCCPCH-RSCP  PrimaryCCPCH-RSCP OPTIONAL,
+                        pathloss           Pathloss OPTIONAL,
+                        timeslotISCP-List  TimeslotISCP-List OPTIONAL --NOTE: TimeSlotISCP measurement list cannot be interpreted without the knowledge of Cell Info as defined in [3GPP RRC]
+}}}
+
+CellParametersID ::= INTEGER(0..127)
+
+TGSN ::= INTEGER(0..14)
+
+PrimaryCCPCH-RSCP ::= INTEGER(0..127)
+
+-- SPARE: TimeslotISCP, Max = 91
+-- Values above Max are spare
+TimeslotISCP ::= INTEGER(0..127)
+
+TimeslotISCP-List ::= SEQUENCE (SIZE (1..maxTS)) OF TimeslotISCP
+
+PrimaryCPICH-Info ::= SEQUENCE {primaryScramblingCode  INTEGER(0..511)}
+
+-- SPARE: CPICH-Ec-No, Max = 49
+-- Values above Max are spare
+CPICH-Ec-N0 ::= INTEGER(0..63)
+
+-- SPARE: CPICH- RSCP, data range from 0 to 91 and from 123 to 127.
+-- Values from 92 to 122 are spare
+-- the encoding of cpich-RSCP is (as per [3GPP RRC] V5.11.0)
+
+-- cpich-RSCP = 123    CPICH RSCP <-120 dBm
+-- cpich-RSCP = 124    -120 = CPICH RSCP < -119 dBm
+-- cpich-RSCP = 125    -119 = CPICH RSCP < -118 dBm
+-- cpich-RSCP = 126    -118 = CPICH RSCP < -117 dBm
+-- cpich-RSCP = 127    -117 = CPICH RSCP < -116 dBm
+-- cpich-RSCP = 0      -116 = CPICH RSCP < -115 dBm
+-- cpich-RSCP = 1      -115 = CPICH RSCP < -114 dBm
+-- ?      ?     ?
+-- cpich-RSCP = 89     -27 = CPICH RSCP < -26 dBm
+-- cpich-RSCP = 90     -26 = CPICH RSCP < -25 dBm
+-- cpich-RSCP = 91     -25 = CPICH RSCP       dBm
+
+CPICH-RSCP ::= INTEGER(0..127)
+
+-- SPARE: Pathloss, Max = 158
+-- Values above Max are spare
+Pathloss ::= INTEGER(46..173)
+
+maxCellMeas INTEGER ::= 32
+
+maxFreq INTEGER ::= 8
+
+maxTS INTEGER ::= 14
+
+StatusCode ::= ENUMERATED {
+  unspecified(0), systemFailure(1), unexpectedMessage(2), protocolError(3),
+  dataMissing(4), unexpectedDataValue(5), posMethodFailure(6),
+  posMethodMismatch(7), posProtocolMismatch(8), targetSETnotReachable(9),
+  versionNotSupported(10), resourceShortage(11), invalidSessionId(12),
+  nonProxyModeNotSupported(13), proxyModeNotSupported(14),
+  positioningNotPermitted(15), authNetFailure(16), authSuplinitFailure(17), consentDeniedByUser(100), consentGrantedByUser(101), ..., ver2-incompatibleProtectionLevel(18), ver2-serviceNotSupported(19), ver2-insufficientInterval(20), ver2-noSUPLCoverage(21), ver2-sessionStopped(102)}
+
+QoP ::= SEQUENCE {
+  horacc     INTEGER(0..127),
+  veracc     INTEGER(0..127) OPTIONAL, -- as defined in [3GPP GAD] "uncertainty altitude"--
+  maxLocAge  INTEGER(0..65535) OPTIONAL,
+  delay      INTEGER(0..7) OPTIONAL, -- as defined in [3GPP RRLP]
+  ...}
+
+Velocity ::= CHOICE { -- velocity definition as per [3GPP GAD]
+  horvel           Horvel,
+  horandvervel     Horandvervel,
+  horveluncert     Horveluncert,
+  horandveruncert  Horandveruncert,
+  ...}
+
+Horvel ::= SEQUENCE {
+  bearing   BIT STRING(SIZE (9)),
+  horspeed  BIT STRING(SIZE (16)),
+  ...}
+
+Horandvervel ::= SEQUENCE {
+  verdirect  BIT STRING(SIZE (1)),
+  bearing    BIT STRING(SIZE (9)),
+  horspeed   BIT STRING(SIZE (16)),
+  verspeed   BIT STRING(SIZE (8)),
+  ...}
+
+Horveluncert ::= SEQUENCE {
+  bearing      BIT STRING(SIZE (9)),
+  horspeed     BIT STRING(SIZE (16)),
+  uncertspeed  BIT STRING(SIZE (8)),
+  ...}
+
+Horandveruncert ::= SEQUENCE {
+  verdirect       BIT STRING(SIZE (1)),
+  bearing         BIT STRING(SIZE (9)),
+  horspeed        BIT STRING(SIZE (16)),
+  verspeed        BIT STRING(SIZE (8)),
+  horuncertspeed  BIT STRING(SIZE (8)),
+  veruncertspeed  BIT STRING(SIZE (8)),
+  ...}
+
+PosMethod ::= ENUMERATED {
+agpsSETassisted(0), agpsSETbased(1), agpsSETassistedpref(2), agpsSETbasedpref(3), autonomousGPS(4), aFLT(5), eCID(6), eOTD(7), oTDOA(8), noPosition(9), ..., ver2-historicalDataRetrieval(10), ver2-agnssSETassisted(11), ver2-agnssSETbased(12), ver2-agnssSETassistedpref(13), ver2-agnssSETbasedpref(14), ver2-autonomousGNSS(15), ver2-sessioninfoquery(16)}
+
+END
+
+--
+-- 11.6	Common elements (SUPL Version 2)
+--
+
+Ver2-ULP-Components DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-CellInfo-extension, MultipleLocationIds, SupportedNetworkInformation, CauseCode, UTRAN-GPSReferenceTimeAssistance, UTRAN-GPSReferenceTimeResult, SPCSETKey, SPCTID, SPCSETKeylifetime, UTRAN-GANSSReferenceTimeAssistance, UTRAN-GANSSReferenceTimeResult, GNSSPosTechnology, GANSSSignals, ThirdParty, ApplicationID, ReportingCap, Coordinate, CircularArea, EllipticalArea, PolygonArea;
+
+IMPORTS
+	LocationId, PrimaryCPICH-Info, CellParametersID, FQDN
+FROM ULP-Components;
+
+MultipleLocationIds ::= SEQUENCE SIZE (1..maxLidSize) OF LocationIdData
+
+LocationIdData ::= SEQUENCE {
+locationId	LocationId,
+relativetimestamp	RelativeTime OPTIONAL, -- if relativetimestamp is present, then data represents historical measurement, if absent, data represents current measurements
+servingFlag  	BOOLEAN, -- if "true?measurements represent serving cell
+...}
+
+RelativeTime ::= INTEGER (0..65535) -- relative time to "current?Location Id in multiples of 0.01sec
+
+maxLidSize	INTEGER ::= 64
+
+SupportedNetworkInformation ::= SEQUENCE {
+  wLAN             		BOOLEAN,
+  supportedWLANInfo  		SupportedWLANInfo OPTIONAL,
+  supportedWLANApsList  	SupportedWLANApsList OPTIONAL,
+  gSM              		BOOLEAN,
+  wCDMA            		BOOLEAN,
+  supportedWCDMAInfo  	SupportedWCDMAInfo OPTIONAL,
+  cDMA             		BOOLEAN,
+  hRDP             		BOOLEAN,
+  uMB             		BOOLEAN,
+  lTE             		BOOLEAN,
+  wIMAX            		BOOLEAN,
+  historic         		BOOLEAN,
+  nonServing      		BOOLEAN,
+  uTRANGPSReferenceTime  	BOOLEAN,
+  uTRANGANSSReferenceTime  	BOOLEAN,
+  ...}
+
+SupportedWLANInfo ::= SEQUENCE {
+  apTP        BOOLEAN, -- AP transmit power
+  apAG        BOOLEAN, -- AP antenna gain
+  apSN        BOOLEAN, -- AP S/N received at SET
+  apDevType   BOOLEAN, -- Device type
+  apRSSI      BOOLEAN, -- AP signal strength at SET
+  apChanFreq  BOOLEAN, -- AP channel/frequency of Tx/Rx
+  apRTD       BOOLEAN, -- Round Trip Delay between SET and AP
+  setTP       BOOLEAN, -- SET transmit power
+  setAG       BOOLEAN, -- SET antenna gain
+  setSN       BOOLEAN, -- SET S/N received at AP
+  setRSSI     BOOLEAN, -- SET signal strength at AP
+  apRepLoc    BOOLEAN, -- AP Location as reported by AP
+  ...}
+
+maxWLANApDataSize    INTEGER ::= 128
+
+SupportedWLANApsList ::= SEQUENCE {
+ supportedWLANApDataList     SEQUENCE (SIZE (1..maxWLANApDataSize)) OF SupportedWLANApData,
+ supportedWLANapsChannel11a  SupportedWLANApsChannel11a  OPTIONAL,
+ supportedWLANapsChannel11bg SupportedWLANApsChannel11bg OPTIONAL,
+ ...
+}
+
+SupportedWLANApsChannel11a ::= SEQUENCE {
+ ch34 	BOOLEAN,
+ ch36 	BOOLEAN,
+ ch38 	BOOLEAN,
+ ch40 	BOOLEAN,
+ ch42 	BOOLEAN,
+ ch44 	BOOLEAN,
+ ch46 	BOOLEAN,
+ ch48 	BOOLEAN,
+ ch52 	BOOLEAN,
+ ch56 	BOOLEAN,
+ ch60 	BOOLEAN,
+ ch64  	BOOLEAN,
+ ch149 	BOOLEAN,
+ ch153 	BOOLEAN,
+ ch157 	BOOLEAN,
+ ch161 	BOOLEAN
+}
+
+SupportedWLANApsChannel11bg ::= SEQUENCE {
+ ch1  BOOLEAN,
+ ch2  BOOLEAN,
+ ch3  BOOLEAN,
+ ch4  BOOLEAN,
+ ch5  BOOLEAN,
+ ch6  BOOLEAN,
+ ch7  BOOLEAN,
+ ch8  BOOLEAN,
+ ch9  BOOLEAN,
+ ch10 BOOLEAN,
+ ch11 BOOLEAN,
+ ch12 BOOLEAN,
+ ch13 BOOLEAN,
+ ch14 BOOLEAN
+}
+
+SupportedWLANApData ::= SEQUENCE {
+ apMACAddress  BIT STRING (SIZE (48)),
+ apDevType  ENUMERATED {wlan802-11a(0), wlan802-11b(1), wlan802-11g(2), ...},
+ ...}
+
+SupportedWCDMAInfo ::= SEQUENCE {
+  mRL    BOOLEAN, -- Measured Results List
+  ...}
+
+Ver2-CellInfo-extension ::= CHOICE {
+  hrpdCell   HrpdCellInformation,
+  umbCell    UmbCellInformation,
+  lteCell    LteCellInformation,
+  wlanAP     WlanAPInformation,
+  wimaxBS    WimaxBSInformation,
+  ...}
+
+HrpdCellInformation ::= SEQUENCE {
+  refSECTORID    BIT STRING(SIZE (128)) OPTIONAL, -- HRPD Sector Id
+  refBASELAT     INTEGER(0..4194303), -- Base Station Latitude
+  reBASELONG     INTEGER(0..8388607), -- Base Station Longitude
+  refWeekNumber  INTEGER(0..65535), -- GPS Week Number
+  refSeconds     INTEGER(0..4194303), -- GPS Seconds --
+  ...}
+
+UmbCellInformation ::= SEQUENCE {
+  refSECTORID    	BIT STRING(SIZE (128)), -- UMB Sector Id
+  refMCC  	INTEGER(0..999), -- Mobile Country Code
+  refMNC  	INTEGER(0..999), -- Mobile Network Code
+  refBASELAT     	INTEGER(0..4194303), -- Base Station Latitude
+  reBASELONG     	INTEGER(0..8388607), -- Base Station Longitude
+  refWeekNumber  	INTEGER(0..65535), -- GPS Week Number
+  refSeconds     	INTEGER(0..4194303), -- GPS Seconds --
+  ...}
+
+-- LTE Cell info per 3GPP TS 36.331. --
+-- If not otherwise stated info is related to serving cell --
+
+LteCellInformation ::= SEQUENCE {
+  cellGlobalIdEUTRA	 	CellGlobalIdEUTRA,
+  physCellId		PhysCellId,
+  trackingAreaCode		TrackingAreaCode,
+  rsrpResult		RSRP-Range	OPTIONAL,
+  rsrqResult		RSRQ-Range	OPTIONAL,
+  tA      INTEGER(0..1282) OPTIONAL, -- Timing Advance as per 3GPP TS 36.321
+  measResultListEUTRA   MeasResultListEUTRA OPTIONAL, --Neighbour measurements
+  ...}
+
+-- Measured results of neighbours cells per 3GPP TS 36.331 --
+
+MeasResultListEUTRA ::= SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultEUTRA
+
+MeasResultEUTRA ::=	SEQUENCE {
+ physCellId PhysCellId,
+ cgi-Info SEQUENCE {
+	cellGlobalId	CellGlobalIdEUTRA,
+	trackingAreaCode TrackingAreaCode
+} OPTIONAL,
+ measResult SEQUENCE {
+	rsrpResult	RSRP-Range	OPTIONAL,  -- Mapping to measured values
+	rsrqResult	RSRQ-Range	OPTIONAL,  -- in 3GPP TS 36.133
+	...
+ }
+}
+
+PhysCellId ::=	 INTEGER (0..503)
+
+TrackingAreaCode ::=	BIT STRING (SIZE (16))
+
+CellGlobalIdEUTRA ::= SEQUENCE {
+ plmn-Identity	PLMN-Identity,
+ cellIdentity	CellIdentity,
+ ...
+}
+
+PLMN-Identity ::= SEQUENCE {
+ mcc MCC OPTIONAL,
+ mnc MNC
+}
+
+CellIdentity ::= BIT STRING (SIZE (28))
+
+MCC ::= SEQUENCE (SIZE (3)) OF MCC-MNC-Digit
+
+MNC ::=	SEQUENCE (SIZE (2..3)) OF MCC-MNC-Digit
+
+MCC-MNC-Digit ::= INTEGER (0..9)
+
+RSRP-Range ::= INTEGER(0..97)
+RSRQ-Range ::= INTEGER(0..34)
+maxCellReport INTEGER ::= 8
+
+WlanAPInformation ::= SEQUENCE { -- as per [IEEE 802.11v]
+  apMACAddress       BIT STRING(SIZE (48)), -- AP MAC Address
+  apTransmitPower    INTEGER(-127..128) OPTIONAL, -- AP transmit power in dbm
+  apAntennaGain      INTEGER(-127..128) OPTIONAL, -- AP antenna gain in dBi
+  apSignaltoNoise    INTEGER(-127..128) OPTIONAL, -- AP S/N received at SET
+  apDeviceType       ENUMERATED {wlan802-11a(0), wlan802-11b(1), wlan802-11g(2), ...} OPTIONAL,
+  apSignalStrength   INTEGER(-127..128) OPTIONAL, -- AP signal strength at SET
+  apChannelFrequency INTEGER(0..256) OPTIONAL, -- AP channel/frequency of Tx/Rx
+  apRoundTripDelay   RTD OPTIONAL, -- Round Trip Delay between SET and AP
+  setTransmitPower   INTEGER(-127..128) OPTIONAL, -- SET transmit power in dBm
+  setAntennaGain     INTEGER (-127..128) OPTIONAL, -- SET antenna gain in dBi
+  setSignaltoNoise   INTEGER (-127..128) OPTIONAL, -- SET S/N received at AP
+  setSignalStrength  INTEGER(-127..128) OPTIONAL, -- SET signal strength at AP
+  apReportedLocation ReportedLocation OPTIONAL, -- AP Location reported by AP
+  ...}
+
+RTD ::= SEQUENCE { -- as per [IEEE 802.11v]
+  rTDValue     INTEGER(0..16777216), -- measured RTD value corresponding to
+-- about 500km in units of 1/10 of nanoseconds
+  rTDUnits     RTDUnits, -- units of RTD
+  rTDAccuracy  INTEGER(0..255) OPTIONAL, -- RTD accuracy
+  ...}
+
+RTDUnits ::= ENUMERATED {
+  microseconds(0), hundredsofnanoseconds(1), tensofnanoseconds(2), nanoseconds(3), tenthsofnanoseconds(4), ...}
+
+ReportedLocation ::= SEQUENCE { -- as per [IEEE 802.11v]
+  locationEncodingDescriptor  LocationEncodingDescriptor,
+  locationData        LocationData, -- location data field
+  ...}
+
+LocationEncodingDescriptor ::= ENUMERATED {
+  lCI(0), aSN1(1), ...}
+
+LocationData ::= SEQUENCE {
+  locationAccuracy   INTEGER(0..4294967295) OPTIONAL,
+  locationValue      OCTET STRING (SIZE(1..128)),
+  ...}
+
+WimaxBSInformation ::= SEQUENCE {
+  wimaxBsID 	WimaxBsID, 	-- WiMax serving base station ID
+  wimaxRTD	WimaxRTD 	OPTIONAL, -- Round Trip Delay measurements
+  wimaxNMRList	WimaxNMRList 	OPTIONAL, -- Network measurements
+  ...}
+
+WimaxBsID ::= SEQUENCE {
+  bsID-MSB	BIT STRING (SIZE(24)) OPTIONAL,
+  bsID-LSB	BIT STRING (SIZE(24)),
+...}
+-- if only LSB is present, MSB is assumed to be identical to the current serving BS or clamped on network value
+
+WimaxRTD ::= SEQUENCE {
+  rTD	INTEGER (0..65535), -- Round trip delay of serving BS in units of 10 ns
+  rTDstd	INTEGER (0..1023) OPTIONAL, -- Standard deviation of round trip delay in units of 10 ns
+...}
+
+WimaxNMRList ::= SEQUENCE  (SIZE (1..maxWimaxBSMeas)) OF WimaxNMR
+
+WimaxNMR ::= SEQUENCE {
+  wimaxBsID   WimaxBsID, 	-- WiMax BS ID for the measurement
+  relDelay    INTEGER (-32768..32767) OPTIONAL, -- Relative delay for this neighbouring BSs to the serving cell in units of 10 ns
+  relDelaystd  INTEGER (0..1023) OPTIONAL, -- Standard deviation of Relative delay in units of 10 ns
+  rSSI        INTEGER (0..255) OPTIONAL, -- RSSI in 0.25 dBm steps, starting from -103.75 dBm
+  rSSIstd     INTEGER (0..63) OPTIONAL, -- Standard deviation of RSSI in dB
+  bSTxPower   INTEGER (0..255) OPTIONAL, -- BS transmit power in 0.25 dBm steps, starting from -103.75 dBm
+  cINR        INTEGER (0..255) OPTIONAL, -- in dB
+  cINRstd     INTEGER (0..63) OPTIONAL, -- Standard deviation of CINR in dB
+  bSLocation  ReportedLocation OPTIONAL, -- Reported location of the BS
+...}
+
+maxWimaxBSMeas INTEGER ::= 32
+
+UTRAN-GPSReferenceTimeAssistance ::= SEQUENCE {
+utran-GPSReferenceTime	UTRAN-GPSReferenceTime,
+gpsReferenceTimeUncertainty	INTEGER (0..127) OPTIONAL,
+utranGPSDriftRate		UTRANGPSDriftRate OPTIONAL}
+
+UTRAN-GPSReferenceTime ::= SEQUENCE {
+-- For utran-GPSTimingOfCell values above 2322431999999 are not used in this version of the specification. Actual value utran-GPSTimingOfCell = (ms-part * 4294967296) + ls-part used on the downlink i.e. sent from the SLP to the SET
+     utran-GPSTimingOfCell	SEQUENCE {
+        ms-part 	INTEGER (0..1023),
+        ls-part	INTEGER (0..4294967295)},
+	    modeSpecificInfo	CHOICE {
+		 fdd	SEQUENCE {
+		   referenceIdentity	PrimaryCPICH-Info},
+		 tdd	SEQUENCE {
+		   referenceIdentity	CellParametersID}} OPTIONAL,
+	    sfn	INTEGER (0..4095)}
+
+UTRANGPSDriftRate ::= ENUMERATED {
+      utran-GPSDrift0, utran-GPSDrift1, utran-GPSDrift2,
+      utran-GPSDrift5, utran-GPSDrift10, utran-GPSDrift15,
+      utran-GPSDrift25, utran-GPSDrift50, utran-GPSDrift-1,
+      utran-GPSDrift-2, utran-GPSDrift-5, utran-GPSDrift-10,
+      utran-GPSDrift-15, utran-GPSDrift-25, utran-GPSDrift-50}
+
+UTRAN-GPSReferenceTimeResult ::= SEQUENCE {
+-- For ue-GPSTimingOfCell values above 37158911999999 are not used in this version of the specification. Actual value utran-GPSTimingOfCell = (ms-part * 4294967296) + ls-part used on the uplink i.e. reported by the SET to the SLP
+     set-GPSTimingOfCell	SEQUENCE {
+        ms-part 	INTEGER (0.. 16383),
+        ls-part	INTEGER (0..4294967295)},
+	    modeSpecificInfo	CHOICE {
+		 fdd	SEQUENCE {
+		   referenceIdentity	PrimaryCPICH-Info},
+		 tdd	SEQUENCE {
+		   referenceIdentity	CellParametersID}} OPTIONAL,
+	    sfn	INTEGER (0..4095),
+     gpsReferenceTimeUncertainty	INTEGER (0..127) OPTIONAL,
+     ...}
+
+UTRAN-GANSSReferenceTimeAssistance ::= SEQUENCE {
+ganssDay INTEGER (0..8191) OPTIONAL,
+ganssTimeID	INTEGER (0..15),
+utran-GANSSReferenceTime	UTRAN-GANSSReferenceTime,
+utranGANSSDriftRate	UTRANGANSSDriftRate	OPTIONAL}
+
+UTRAN-GANSSReferenceTime ::= SEQUENCE {
+
+     ganssTOD INTEGER (0..86399),
+     utran-GANSSTimingOfCell	INTEGER (0..3999999)OPTIONAL,
+	    modeSpecificInfo	CHOICE {
+		 fdd	SEQUENCE {
+		   referenceIdentity	PrimaryCPICH-Info},
+		 tdd	SEQUENCE {
+		   referenceIdentity	CellParametersID}} OPTIONAL,
+	    sfn	INTEGER (0..4095),
+	    ganss-TODUncertainty INTEGER (0..127) OPTIONAL,
+...}
+
+UTRANGANSSDriftRate ::= ENUMERATED {
+      utran-GANSSDrift0, utran-GANSSDrift1, utran-GANSSDrift2,
+      utran-GANSSDrift5, utran-GANSSDrift10, utran-GANSSDrift15,
+      utran-GANSSDrift25, utran-GANSSDrift50, utran-GANSSDrift-1,
+      utran-GANSSDrift-2, utran-GANSSDrift-5, utran-GANSSDrift-10,
+      utran-GANSSDrift-15, utran-GANSSDrift-25, utran-GANSSDrift-50}
+
+UTRAN-GANSSReferenceTimeResult ::= SEQUENCE {
+     ganssTimeID	INTEGER (0..15),
+     set-GANSSReferenceTime	SET-GANSSReferenceTime,
+	    ...}
+
+SET-GANSSReferenceTime ::= SEQUENCE {
+-- Actual value [ns] = (ms-Part * 4294967296 + ls-Part) * 250
+-- Actual values [ns] > 86399999999750 are reserved and are considered a
+-- protocol error
+            set-GANSSTimingOfCell	SEQUENCE {
+                 ms-part	INTEGER (0..80),
+                 ls-part	INTEGER (0..4294967295)} OPTIONAL,
+	    modeSpecificInfo	CHOICE {
+		 fdd	SEQUENCE {
+		   referenceIdentity	PrimaryCPICH-Info},
+		 tdd	SEQUENCE {
+		   referenceIdentity	CellParametersID}} OPTIONAL,
+	    sfn	INTEGER (0..4095),
+	    ganss-TODUncertainty INTEGER (0..127) OPTIONAL,
+...}
+
+GNSSPosTechnology ::= SEQUENCE {
+  gps 		BOOLEAN,
+  galileo 	BOOLEAN,
+  sbas		BOOLEAN,
+  modernized-gps	BOOLEAN,
+  qzss		BOOLEAN,
+  glonass	BOOLEAN,
+...}
+
+-- indicates MS support for particular GANSS signals and frequencies coding according to parameter definition in section 10.9
+
+GANSSSignals ::= BIT STRING {
+  signal1 (0),
+  signal2 (1),
+  signal3 (2),
+  signal4 (3),
+  signal5 (4),
+  signal6 (5),
+  signal7 (6),
+  signal8 (7)} (SIZE (1..8))
+
+SPCSETKey ::= BIT STRING(SIZE (128))
+
+SPCTID ::= SEQUENCE {
+  rAND		BIT STRING(SIZE (128)),
+  slpFQDN	FQDN,
+	...}
+
+SPCSETKeylifetime ::= INTEGER (1..24) -- units in hours
+
+CauseCode ::= ENUMERATED {
+servingNetWorkNotInAreaIdList(0), sETCapabilitiesChanged(1), noSUPLCoverage(2), ...}
+
+ThirdParty ::= SEQUENCE (SIZE (1..64)) OF ThirdPartyID
+
+ThirdPartyID ::= CHOICE {
+	logicalName	IA5String(SIZE (1..1000)),
+	msisdn	OCTET STRING(SIZE (8)),
+	emailaddr	IA5String(SIZE (1..1000)),
+--	sip-uri VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | ":./-_~%#@?")) (SIZE (1..255)),
+--	ims-public-identity VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | ":./-_~%#@?")) (SIZE (1..255)),
+-- # asn2wrs does not handle '%' in the resticted string
+	sip-uri VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | ":./-_~#@?")) (SIZE (1..255)),
+	ims-public-identity VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | ":./-_~#@?")) (SIZE (1..255)),
+	min	BIT STRING(SIZE (34)), -- coded according to TIA-553
+	mdn	OCTET STRING(SIZE (8)),
+--	uri VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | "./-_~%#")) (SIZE (1..255)),
+	uri VisibleString(FROM ("a".."z" | "A".."Z" | "0".."9" | "./-_~#")) (SIZE (1..255)),
+...}
+
+ApplicationID ::= SEQUENCE {
+	appProvider IA5String(SIZE (1..24)), -- The application provider
+	appName IA5String(SIZE (1..32)), -- The application name
+	appVersion IA5String(SIZE (1..8)) OPTIONAL,  -- The application version
+...}
+
+ReportingCap ::= SEQUENCE {
+  minInt	INTEGER (1..3600), -- units in seconds
+  maxInt	INTEGER (1..1440) OPTIONAL, -- units in minutes
+repMode	RepMode-cap,
+batchRepCap	BatchRepCap OPTIONAL, -- only used for batch and quasi real time reporting
+...}
+
+RepMode-cap ::= SEQUENCE {
+realtime 	BOOLEAN,
+quasirealtime 	BOOLEAN,
+batch 		BOOLEAN,
+...}
+
+BatchRepCap ::= SEQUENCE {
+report-position	BOOLEAN, -- set to "true"if reporting of position is supported
+report-measurements	BOOLEAN, -- set to "true"if reporting of measurements is supported
+max-num-positions	INTEGER (1..1024) OPTIONAL,
+max-num-measurements INTEGER (1..1024) OPTIONAL,
+...}
+
+Coordinate::= SEQUENCE {
+ latitudeSign	ENUMERATED {north(0), south(1)},
+ latitude	INTEGER(0..8388607),
+ longitude	INTEGER(-8388608..8388607)} -- Coding as in [3GPP GAD]
+
+CircularArea ::= SEQUENCE {
+ coordinate	Coordinate,
+ radius		INTEGER(1..1000000), -- radius in meters
+ radius-min	INTEGER(1..1000000) OPTIONAL, -- hysteresis minimum radius
+ radius-max	INTEGER(1..1500000) OPTIONAL} -- hysteresis maximum radius
+
+EllipticalArea ::= SEQUENCE {
+ coordinate	Coordinate,
+ semiMajor	INTEGER(1..1000000), -- units in meters
+ semiMajor-min	INTEGER(1..1000000) OPTIONAL, -- hysteresis minimum semiMajor
+ semiMajor-max	INTEGER(1..1500000) OPTIONAL, -- hysteresis maximum semiMajor
+ semiMinor	INTEGER(1..1000000), -- units in meters
+ semiMinor-min	INTEGER(1..1000000) OPTIONAL, -- hysteresis minimum semiMinor
+ semiMinor-max	INTEGER(1..1500000) OPTIONAL, -- hysteresis maximum semiMinor
+ angle		INTEGER(0.. 179)} -- units in degrees "the angle is defined as the angle between the semi-major axis and North, increasing in a clockwise direction. An angle of 0 represents an ellipse with the semi-major axis pointing North/South while an angle of 90 represents an ellipse with the semi-major axis pointing East/West.
+
+PolygonArea ::= SEQUENCE {
+ polygonDescription	PolygonDescription,
+ polygonHysteresis	INTEGER(1..100000) OPTIONAL} -- units in meters
+
+PolygonDescription ::= SEQUENCE (SIZE (3..15)) OF Coordinate
+
+END
+

--- a/examples/specs/supl/SUPL.asn
+++ b/examples/specs/supl/SUPL.asn
@@ -1,0 +1,1010 @@
+-- SUPL.asn
+-- $Id$
+-- From OMA UserPlane Location Protocol Candidate Version 2.0 06 Aug 2010
+-- OMA-TS-ULP-V2_0-20100806-D
+--
+-- 11.2 Message Specific Part
+--
+
+--
+-- 11.2.1 SUPL INIT
+--
+
+SUPL-INIT DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLINIT, Notification;
+
+IMPORTS
+	SLPAddress, QoP, PosMethod
+FROM ULP-Components
+	Ver2-SUPL-INIT-extension
+FROM ULP-Version-2-message-extensions
+	Ver2-Notification-extension
+FROM ULP-Version-2-parameter-extensions;
+
+SUPLINIT ::= SEQUENCE {
+  posMethod     PosMethod,
+  notification  Notification OPTIONAL,
+  sLPAddress    SLPAddress OPTIONAL,
+  qoP           QoP OPTIONAL,
+  sLPMode       SLPMode,
+  mAC           MAC OPTIONAL, -- included for backwards compatibility
+  keyIdentity   KeyIdentity OPTIONAL, -- included for backwards compatibility
+  ...,
+-- version 2 extension element
+  ver2-SUPL-INIT-extension	Ver2-SUPL-INIT-extension OPTIONAL}
+
+Notification ::= SEQUENCE {
+  notificationType  NotificationType,
+  encodingType      EncodingType OPTIONAL,
+  requestorId       OCTET STRING(SIZE (1..maxReqLength)) OPTIONAL,
+  requestorIdType   FormatIndicator OPTIONAL,
+  clientName        OCTET STRING(SIZE (1..maxClientLength)) OPTIONAL,
+  clientNameType    FormatIndicator OPTIONAL,
+  ...,
+  ver2-Notification-extension	Ver2-Notification-extension OPTIONAL}
+
+NotificationType ::= ENUMERATED {
+  noNotificationNoVerification(0), notificationOnly(1),
+  notificationAndVerficationAllowedNA(2),
+  notificationAndVerficationDeniedNA(3), privacyOverride(4), ...}
+
+EncodingType ::= ENUMERATED {ucs2(0), gsmDefault(1), utf8(2), ...}
+
+maxReqLength INTEGER ::= 50
+
+maxClientLength INTEGER ::= 50
+
+FormatIndicator ::= ENUMERATED {
+  logicalName(0), e-mailAddress(1), msisdn(2), url(3), sipUrl(4), min(5),
+  mdn(6), iMSPublicidentity(7), ...}
+
+SLPMode ::= ENUMERATED {proxy(0), nonProxy(1)}
+
+MAC ::= BIT STRING(SIZE (64)) -- empty placeholder required for SUPL 1.0 backwards compatibility
+
+KeyIdentity ::= BIT STRING(SIZE (128)) -- empty placeholder required for SUPL 1.0 backwards compatibility
+
+END
+
+--
+-- 11.2.2 SUPL START
+--
+SUPL-START DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLSTART, SETCapabilities;
+
+IMPORTS
+	LocationId, QoP
+FROM ULP-Components
+	Ver2-SUPL-START-extension
+FROM ULP-Version-2-message-extensions
+	Ver2-SETCapabilities-extension, Ver2-PosProtocol-extension, Ver2-PosTechnology-extension
+FROM ULP-Version-2-parameter-extensions;
+
+SUPLSTART ::= SEQUENCE {
+  sETCapabilities  SETCapabilities,
+  locationId       LocationId,
+  qoP              QoP OPTIONAL,
+  ...,
+-- version 2 extension element
+  ver2-SUPL-START-extension	Ver2-SUPL-START-extension OPTIONAL}
+
+SETCapabilities ::= SEQUENCE {
+  posTechnology  PosTechnology,
+  prefMethod     PrefMethod,
+  posProtocol    PosProtocol,
+  ...,
+  ver2-SETCapabilities-extension	Ver2-SETCapabilities-extension OPTIONAL}
+
+PosTechnology ::= SEQUENCE {
+  agpsSETassisted  BOOLEAN,
+  agpsSETBased     BOOLEAN,
+  autonomousGPS    BOOLEAN,
+  aFLT             BOOLEAN,
+  eCID             BOOLEAN,
+  eOTD             BOOLEAN,
+  oTDOA            BOOLEAN,
+  ...,
+  ver2-PosTechnology-extension	Ver2-PosTechnology-extension OPTIONAL}
+
+PrefMethod ::= ENUMERATED {
+  agpsSETassistedPreferred, agpsSETBasedPreferred, noPreference}
+-- To achieve compatibility  with ULP V1.0 the names of the enumerations are
+-- kept the same as in ULP V1.0. agps shall be interpreted as agnss.
+
+PosProtocol ::= SEQUENCE {
+  tia801  BOOLEAN,
+  rrlp    BOOLEAN,
+  rrc     BOOLEAN,
+  ...,
+  ver2-PosProtocol-extension	Ver2-PosProtocol-extension OPTIONAL}
+
+END
+
+--
+-- 11.2.3 SUPL RESPONSE
+--
+SUPL-RESPONSE DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLRESPONSE;
+
+IMPORTS
+	PosMethod, SLPAddress
+FROM ULP-Components
+	Ver2-SUPL-RESPONSE-extension
+FROM ULP-Version-2-message-extensions;
+
+SUPLRESPONSE ::= SEQUENCE {
+  posMethod     PosMethod,
+  sLPAddress    SLPAddress OPTIONAL,
+sETAuthKey    SETAuthKey OPTIONAL, -- included for backwards compatibility
+  keyIdentity4  KeyIdentity4 OPTIONAL, -- included for backwards compatibility
+  ...,
+-- version 2 extension element
+  ver2-SUPL-RESPONSE-extension	Ver2-SUPL-RESPONSE-extension OPTIONAL}
+
+SETAuthKey ::= CHOICE {
+  shortKey  BIT STRING(SIZE (128)),
+  longKey   BIT STRING(SIZE (256)),
+  ...}
+
+KeyIdentity4 ::= BIT STRING(SIZE (128))
+
+END
+
+--
+-- 11.2.4 SUPL POS INIT
+--
+SUPL-POS-INIT DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLPOSINIT;
+
+IMPORTS
+	SUPLPOS
+FROM SUPL-POS
+	SETCapabilities
+FROM SUPL-START
+	LocationId, Position, Ver
+FROM ULP-Components
+	Ver2-SUPL-POS-INIT-extension
+FROM ULP-Version-2-message-extensions
+	Ver2-RequestedAssistData-extension
+FROM ULP-Version-2-parameter-extensions;
+
+SUPLPOSINIT ::= SEQUENCE {
+  sETCapabilities      SETCapabilities,
+  requestedAssistData  RequestedAssistData OPTIONAL,
+  locationId           LocationId,
+  position             Position OPTIONAL,
+  sUPLPOS              SUPLPOS OPTIONAL,
+  ver                  Ver OPTIONAL,
+  ...,
+-- version 2 extension element
+  ver2-SUPL-POS-INIT-extension	Ver2-SUPL-POS-INIT-extension OPTIONAL}
+
+RequestedAssistData ::= SEQUENCE {
+  almanacRequested                BOOLEAN,
+  utcModelRequested               BOOLEAN,
+  ionosphericModelRequested       BOOLEAN,
+  dgpsCorrectionsRequested        BOOLEAN,
+  referenceLocationRequested      BOOLEAN, -- Note: Used also for GANSS
+  referenceTimeRequested          BOOLEAN,
+  acquisitionAssistanceRequested  BOOLEAN,
+  realTimeIntegrityRequested      BOOLEAN,
+  navigationModelRequested        BOOLEAN,
+  navigationModelData             NavigationModel OPTIONAL,
+  ...,
+  ver2-RequestedAssistData-extension Ver2-RequestedAssistData-extension OPTIONAL}
+
+NavigationModel ::= SEQUENCE {
+  gpsWeek   INTEGER(0..1023),
+  gpsToe    INTEGER(0..167),
+  nSAT      INTEGER(0..31),
+  toeLimit  INTEGER(0..10),
+  satInfo   SatelliteInfo OPTIONAL,
+...}
+
+-- Further information on this fields can be found
+-- in [3GPP RRLP]and [3GPP 49.031]
+
+SatelliteInfo ::= SEQUENCE (SIZE (1..31)) OF SatelliteInfoElement
+
+SatelliteInfoElement ::= SEQUENCE {
+  satId  INTEGER(0..63),
+  iODE   INTEGER(0..255),
+  ...}
+
+END
+
+--
+-- 11.2.5 SUPL POS
+--
+SUPL-POS DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLPOS;
+
+IMPORTS
+	Velocity
+FROM ULP-Components
+	Ver2-SUPL-POS-extension
+FROM ULP-Version-2-message-extensions
+Ver2-PosPayLoad-extension
+FROM ULP-Version-2-parameter-extensions;
+
+SUPLPOS ::= SEQUENCE {
+  posPayLoad  PosPayLoad,
+  velocity    Velocity OPTIONAL,
+  ...,
+-- version 2 extension element
+  ver2-SUPL-POS-extension	Ver2-SUPL-POS-extension OPTIONAL}
+
+PosPayLoad ::= CHOICE {
+  tia801payload  OCTET STRING(SIZE (1..8192)),
+  rrcPayload     OCTET STRING(SIZE (1..8192)),
+  rrlpPayload    OCTET STRING(SIZE (1..8192)),
+  ...,
+  ver2-PosPayLoad-extension  Ver2-PosPayLoad-extension}
+
+END
+
+--
+-- 11.2.6 SUPL END
+--
+SUPL-END DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLEND;
+
+IMPORTS
+	StatusCode, Position, Ver
+FROM ULP-Components
+	Ver2-SUPL-END-extension
+FROM ULP-Version-2-message-extensions;
+
+SUPLEND ::= SEQUENCE {
+  position	Position OPTIONAL,
+  statusCode	StatusCode OPTIONAL,
+  ver		Ver OPTIONAL,
+  ...,
+-- version 2 extension element
+  ver2-SUPL-END-extension	Ver2-SUPL-END-extension OPTIONAL}
+
+END
+
+--
+-- 11.2.7 SUPL AUTH REQ
+--
+SUPL-AUTH-REQ DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLAUTHREQ;
+
+IMPORTS
+	Ver
+FROM ULP-Components
+	SETCapabilities
+FROM SUPL-START;
+
+SUPLAUTHREQ ::= SEQUENCE {
+  ver      	Ver OPTIONAL,
+  sETCapabilities	SETCapabilities OPTIONAL,
+  ...}
+
+END
+
+--
+-- 11.2.8 SUPL AUTH RESP
+--
+SUPL-AUTH-RESP DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS SUPLAUTHRESP;
+
+IMPORTS
+	SPCSETKey, SPCTID, SPCSETKeylifetime
+FROM Ver2-ULP-Components;
+
+SUPLAUTHRESP ::= SEQUENCE {
+  sPCSETKey	SPCSETKey,
+  sPCTID  	SPCTID,
+  sPCSETKeylifetime	SPCSETKeylifetime OPTIONAL,
+  ...}
+
+END
+
+--
+-- 11.2.9 SUPL NOTIFY
+--
+SUPL-NOTIFY DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-SUPLNOTIFY;
+
+IMPORTS
+	Notification
+FROM SUPL-INIT;
+
+Ver2-SUPLNOTIFY ::= SEQUENCE {
+  notification  Notification,
+  ...}
+END
+
+--
+-- 11.2.10 SUPL NOTIFY RESPONSE
+--
+SUPL-NOTIFY-RESPONSE DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-SUPLNOTIFYRESPONSE;
+
+Ver2-SUPLNOTIFYRESPONSE ::= SEQUENCE {
+  notificationResponse  NotificationResponse OPTIONAL,
+  ...}
+
+NotificationResponse ::= ENUMERATED {allowed(0), notAllowed(1), ...}
+
+END
+
+--
+-- 11.2.11 SUPL SET INIT
+--
+SUPL-SET-INIT DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-SUPLSETINIT;
+
+IMPORTS
+	SETId, QoP
+FROM ULP-Components
+ApplicationID
+FROM Ver2-ULP-Components;
+
+
+Ver2-SUPLSETINIT ::= SEQUENCE {
+  targetSETID    SETId, --Target SETid identifies the target SET to be located
+  qoP            QoP OPTIONAL,
+  applicationID  ApplicationID OPTIONAL,
+  ...}
+
+END
+
+--
+-- 11.2.12 SUPL TRIGGERED START
+--
+SUPL-TRIGGERED-START DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-SUPLTRIGGEREDSTART, TriggerType, TriggerParams, maxNumGeoArea, maxAreaId, maxAreaIdList;
+
+IMPORTS
+	LocationId, QoP, Ver, Position
+FROM ULP-Components
+	MultipleLocationIds, CauseCode, ThirdParty, ApplicationID, ReportingCap, Coordinate, CircularArea, EllipticalArea, PolygonArea
+FROM Ver2-ULP-Components
+	SETCapabilities
+FROM SUPL-START;
+
+Ver2-SUPLTRIGGEREDSTART ::= SEQUENCE {
+  sETCapabilities  	SETCapabilities,
+  locationId       	LocationId,
+  ver              	Ver OPTIONAL,
+  qoP              	QoP OPTIONAL,
+  multipleLocationIds	MultipleLocationIds OPTIONAL,
+thirdParty    	ThirdParty OPTIONAL,
+applicationID	ApplicationID OPTIONAL,
+  triggerType   	TriggerType OPTIONAL,
+  triggerParams 	TriggerParams OPTIONAL,
+  position         	Position OPTIONAL,
+  reportingCap	ReportingCap OPTIONAL,
+  causeCode	CauseCode OPTIONAL,
+...}
+
+TriggerType ::= ENUMERATED {
+  periodic(0), areaEvent(1),
+  ...}
+
+TriggerParams ::= CHOICE {
+   periodicParams	PeriodicParams,
+   areaEventParams	AreaEventParams,
+   ...}
+
+PeriodicParams ::= SEQUENCE{
+   numberOfFixes   		INTEGER(1.. 8639999),
+   intervalBetweenFixes    	INTEGER(1.. 8639999),
+   startTime		INTEGER(0..2678400) OPTIONAL,
+...}
+-- intervalBetweenFixes and startTime are in seconds.
+-- numberOfFixes  * intervalBetweenFixes shall not exceed 8639999
+-- (100 days in seconds) for compatibility with OMA MLP and RLP
+-- startTime is in relative time in units of seconds measured from "now"
+-- a value of 0 signifies "now", a value of "startTime" signifies startTime
+-- seconds from "now"
+
+AreaEventParams ::= SEQUENCE {
+areaEventType		AreaEventType,
+locationEstimate		BOOLEAN,
+repeatedReportingParams	RepeatedReportingParams OPTIONAL,
+startTime		INTEGER(0..2678400) OPTIONAL,
+stopTime		INTEGER(0..11318399) OPTIONAL,
+geographicTargetAreaList	GeographicTargetAreaList	OPTIONAL,
+areaIdLists		SEQUENCE (SIZE (1..maxAreaIdList)) OF AreaIdList OPTIONAL,
+...}
+
+-- startTime and stopTime are in seconds.
+-- startTime and stop Time are in relative time in units of seconds measured
+-- from "now"
+-- a value of 0 signifies "now"
+-- stopTime must be > startTime
+-- stopTime - startTime shall not exceed 8639999
+-- (100 days in seconds) for compatibility with OMA MLP and RLP
+
+AreaEventType ::= ENUMERATED {enteringArea(0), insideArea(1), outsideArea(2), leavingArea(3), ...}
+
+RepeatedReportingParams ::= SEQUENCE {
+minimumIntervalTime	     INTEGER (1..604800), -- time in seconds
+maximumNumberOfReports   INTEGER (1..1024),
+...}
+
+GeographicTargetAreaList ::= SEQUENCE (SIZE (1..maxNumGeoArea)) OF GeographicTargetArea
+
+GeographicTargetArea ::= CHOICE {
+ circularArea	CircularArea,
+ ellipticalArea	EllipticalArea,
+ polygonArea	PolygonArea,
+ ...}
+
+AreaIdList ::= SEQUENCE {
+ areaIdSet	AreaIdSet,
+ areaIdSetType    	AreaIdSetType OPTIONAL,
+ geoAreaMappingList		GeoAreaMappingList OPTIONAL}
+
+AreaIdSet ::= SEQUENCE SIZE (1..maxAreaId) OF AreaId
+
+AreaId ::= CHOICE {
+ gSMAreaId	GSMAreaId,
+ wCDMAAreaId  	WCDMAAreaId, -- For TD-SCDMA networks, this parameter indicates a TD-SCDMA Area ID
+ cDMAAreaId 	CDMAAreaId,
+ hRPDAreaId	HRPDAreaId,
+ uMBAreaId	UMBAreaId,
+ lTEAreaId	LTEAreaId,
+ wLANAreaId 	WLANAreaId,
+ wiMAXAreaId	WimaxAreaId,
+ ...}
+
+GSMAreaId ::= SEQUENCE {
+ refMCC		INTEGER(0..999) OPTIONAL, -- Mobile Country Code
+ refMNC		INTEGER(0..999) OPTIONAL, -- Mobile Network Code
+ refLAC		INTEGER(0..65535) OPTIONAL, -- Location Area Code
+ refCI		INTEGER(0..65535) OPTIONAL, -- Cell Id
+ ...}
+
+-- if only CI is present, MCC, MNC and LAC are assumed to be identical to the current serving or camped on network values
+-- if only CI + LAC are present, MCC and MNC are assumed to be identical to the current serving or camped on network values
+-- if only CI + LAC + MNC are present, MCC is assumed to be identical to the current serving or camped on network values
+-- if only LAC is present, MCC and MNC are assumed to be identical to the current serving or camped on network values
+-- if only MNC is present, MCC is assumed to be identical to the current serving or camped on network value
+
+WCDMAAreaId ::= SEQUENCE {
+  refMCC	INTEGER(0..999) OPTIONAL, -- Mobile Country Code
+refMNC	INTEGER(0..999) OPTIONAL, -- Mobile Network Code
+  refLAC	INTEGER(0..65535) OPTIONAL, -- Location Area Code
+refUC	INTEGER(0..268435455) OPTIONAL, -- Cell identity
+...}
+
+-- if only UC is present, MCC and MNC are assumed to be identical to the current serving or camped on network values
+-- if only LAC is present, MCC and MNC are assumed to be identical to the current serving or camped on network values
+-- if only MNC is present, MCC is assumed to be identical to the current serving or camped on network value
+
+CDMAAreaId::= SEQUENCE {
+  refSID         INTEGER(0..65535) OPTIONAL, -- System Id
+  refNID         INTEGER(0..32767) OPTIONAL, -- Network Id
+  refBASEID      INTEGER(0..65535) OPTIONAL, -- Base Station Id
+...}
+
+-- if only BASEID is present, SID and NID are assumed to be identical to the current serving or camped on network values
+-- if only NID is present, SID is assumed to be identical to the current serving or camped on network value
+
+HRPDAreaId::= SEQUENCE {
+refSECTORID    BIT STRING(SIZE (128)), -- HRPD Sector Id
+...}
+
+UMBAreaId::= SEQUENCE {
+  refMCC		INTEGER(0..999) OPTIONAL, -- Mobile Country Code
+  refMNC		INTEGER(0..999) OPTIONAL, -- Mobile Network Code
+refSECTORID    	BIT STRING(SIZE (128)) OPTIONAL, -- UMB Sector Id
+...}
+
+-- if only SECTORID is present, MCC and MNC are assumed to be identical to the current serving or camped on network values
+-- if only SECTORID + MNC are present, MCC is assumed to be identical to the current serving or camped on network values
+-- if only MNC is present, MCC is assumed to be identical to the current serving or camped on network value
+
+LTEAreaId::= SEQUENCE {
+  refMCC	INTEGER(0..999) OPTIONAL, -- Mobile Country Code
+  refMNC	INTEGER(0..999) OPTIONAL, -- Mobile Network Code
+refCI	BIT STRING(SIZE (29)) OPTIONAL, -- LTE Cell-Id including CSG bit
+...}
+
+-- if only CI is present, MCC and MNC are assumed to be identical to the current serving or camped on network values
+-- if only CI + MNC are present, MCC is assumed to be identical to the current serving or camped on network values
+-- if only MNC is present, MCC is assumed to be identical to the current serving or camped on network value
+
+
+WLANAreaId::= SEQUENCE {
+  apMACAddress       BIT STRING(SIZE (48)), -- AP MAC Address
+...}
+
+WimaxAreaId ::= SEQUENCE {
+  bsID-MSB      BIT STRING (SIZE(24)) OPTIONAL,
+  bsID-LSB      BIT STRING (SIZE(24)) }
+-- if only LSB is present, MSB is assumed to be identical to the current serving BS or clamped on network value
+
+AreaIdSetType ::=  ENUMERATED {border(0), within(1), ...}
+
+GeoAreaMappingList ::= SEQUENCE (SIZE (1..maxNumGeoArea)) OF GeoAreaIndex
+
+GeoAreaIndex ::= INTEGER (1..maxNumGeoArea)
+
+maxNumGeoArea INTEGER ::= 32
+
+maxAreaId INTEGER ::= 256
+
+maxAreaIdList INTEGER ::= 32
+
+END
+
+--
+-- 11.2.13 SUPL TRIGGERED RESPONSE
+--
+SUPL-TRIGGERED-RESPONSE DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-SUPLTRIGGEREDRESPONSE;
+
+IMPORTS
+	PosMethod, SLPAddress
+FROM ULP-Components
+	SupportedNetworkInformation, SPCSETKey, SPCTID, SPCSETKeylifetime, GNSSPosTechnology
+FROM Ver2-ULP-Components
+	TriggerParams
+FROM SUPL-TRIGGERED-START;
+
+Ver2-SUPLTRIGGEREDRESPONSE::= SEQUENCE{
+  posMethod     		PosMethod,
+  triggerParams 		TriggerParams  OPTIONAL,
+  sLPAddress    		SLPAddress OPTIONAL,
+  supportedNetworkInformation   	SupportedNetworkInformation OPTIONAL,
+  reportingMode		ReportingMode OPTIONAL,
+  sPCSETKey		SPCSETKey	OPTIONAL,
+  sPCTID			SPCTID	OPTIONAL,
+  sPCSETKeylifetime		SPCSETKeylifetime OPTIONAL,
+  gnssPosTechnology		GNSSPosTechnology OPTIONAL,
+  ...}
+ReportingMode ::= SEQUENCE {
+repMode	RepMode,
+batchRepConditions	BatchRepConditions OPTIONAL, -- only used for batch reporting
+batchRepType	BatchRepType OPTIONAL, -- only used for batch reporting
+...}
+
+RepMode ::= ENUMERATED {realtime(1), quasirealtime(2), batch(3), ...}
+
+BatchRepConditions ::= CHOICE {
+ num-interval INTEGER (1..1024), -- number of periodic fixes/measurements after which the batch report is sent to the SLP
+ num-minutes INTEGER (1..2048), -- number of minutes after which the batch report is sent to the SLP
+ endofsession NULL, -- if selected batch report is to be sent at the end of the session
+ ...}
+
+BatchRepType ::= SEQUENCE {
+reportPosition	BOOLEAN, -- set to "true" if reporting of position is allowed
+reportMeasurements	BOOLEAN, -- set to "true" if reporting of measurements is allowed
+intermediateReports   BOOLEAN, -- set to "true" if the SET is allowed to send intermediate reports if it runs out of memory
+discardOldest 	BOOLEAN OPTIONAL, -- set to "true" if the SET should discard the oldest positions or measurements of the batch report in order to save memory, set to "false" the SET should discard the latest positions or measurements
+...}
+
+END
+
+--
+-- 11.2.14 SUPL REPORT
+--
+SUPL-REPORT DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-SUPLREPORT;
+
+IMPORTS
+	SETCapabilities
+FROM SUPL-START
+	Position, PosMethod, SessionID, Ver
+FROM ULP-Components
+	MultipleLocationIds, GNSSPosTechnology, GANSSSignals
+FROM Ver2-ULP-Components
+	maxGANSS
+FROM ULP-Version-2-parameter-extensions;
+
+Ver2-SUPLREPORT ::= SEQUENCE {
+ sessionList	SessionList OPTIONAL,
+ sETCapabilities      SETCapabilities OPTIONAL,
+ reportDataList 	ReportDataList OPTIONAL,
+ ver  		Ver OPTIONAL,
+ moreComponents	NULL OPTIONAL,
+...}
+
+SessionList ::= SEQUENCE SIZE (1..maxnumSessions) OF SessionInformation
+
+SessionInformation ::= SEQUENCE {
+ sessionID	SessionID,
+ ...}
+
+maxnumSessions    INTEGER ::= 64
+
+ReportDataList ::= SEQUENCE SIZE (1.. 1024) OF ReportData
+
+ReportData ::= SEQUENCE {
+  positionData	PositionData OPTIONAL,
+  multipleLocationIds	MultipleLocationIds OPTIONAL,
+  resultCode	ResultCode OPTIONAL,
+  timestamp	TimeStamp OPTIONAL,
+  ...}
+
+PositionData ::= SEQUENCE {
+ position		Position,
+ posMethod		PosMethod OPTIONAL,
+ gnssPosTechnology		GNSSPosTechnology OPTIONAL,
+ ganssSignalsInfo		GANSSsignalsInfo OPTIONAL,
+ ...}
+
+GANSSsignalsInfo ::= SEQUENCE SIZE (1..maxGANSS) OF GANSSSignalsDescription
+
+GANSSSignalsDescription ::= SEQUENCE {
+ganssId		INTEGER(0..15), -- coding according to parameter definition in section 10.10
+gANSSSignals	GANSSSignals,
+...}
+
+ResultCode ::= ENUMERATED {outofradiocoverage(1), noposition(2), nomeasurement(3), nopositionnomeasurement(4), outofmemory(5), outofmemoryintermediatereporting(6), other(7), ...}
+
+TimeStamp ::= CHOICE {
+  absoluteTime  UTCTime,
+  relativeTime  INTEGER (0..31536000)} -- relative time to when the SUPL REPORT message is sent in units of 1 sec, where 0 signifies "now" and n signifies n seconds in the past
+
+END
+
+--
+--11.2.15 SUPL TRIGGERED STOP
+--
+SUPL-TRIGGERED-STOP DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS Ver2-SUPLTRIGGEREDSTOP;
+
+IMPORTS
+	StatusCode
+FROM ULP-Components;
+
+Ver2-SUPLTRIGGEREDSTOP::= SEQUENCE{
+  statusCode     StatusCode OPTIONAL,
+  ...}
+
+END
+
+--
+--11.3 Messsage Extensions (SUPL Version 2)
+--
+ULP-Version-2-message-extensions DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS
+Ver2-SUPL-INIT-extension, Ver2-SUPL-START-extension, Ver2-SUPL-RESPONSE-extension, Ver2-SUPL-POS-INIT-extension, Ver2-SUPL-POS-extension, Ver2-SUPL-END-extension;
+
+IMPORTS
+	SLPAddress, Position, Ver
+FROM ULP-Components
+	SETCapabilities
+FROM SUPL-START
+	SupportedNetworkInformation, GNSSPosTechnology, MultipleLocationIds, UTRAN-GPSReferenceTimeResult, UTRAN-GANSSReferenceTimeResult, UTRAN-GPSReferenceTimeAssistance, UTRAN-GANSSReferenceTimeAssistance, SPCSETKey, SPCTID, SPCSETKeylifetime, ThirdParty, ApplicationID
+FROM Ver2-ULP-Components
+	TriggerType
+FROM SUPL-TRIGGERED-START;
+
+Ver2-SUPL-INIT-extension ::= SEQUENCE {
+  notificationMode  		NotificationMode OPTIONAL,
+  supportedNetworkInformation   	SupportedNetworkInformation OPTIONAL,
+  triggerType   		TriggerType OPTIONAL,
+  e-SLPAddress  		SLPAddress OPTIONAL,
+  historicReporting		HistoricReporting OPTIONAL,
+  protectionLevel		ProtectionLevel OPTIONAL,
+  gnssPosTechnology		GNSSPosTechnology OPTIONAL,
+  minimumMajorVersion		INTEGER (0..255) OPTIONAL,
+...}
+
+NotificationMode ::= ENUMERATED {normal(0), basedOnLocation(1), ...}
+
+HistoricReporting ::= SEQUENCE {
+  allowedReportingType 	AllowedReportingType,
+  reportingCriteria	   	ReportingCriteria OPTIONAL,...}
+
+AllowedReportingType ::= ENUMERATED {
+  positionsOnly(0), measurementsOnly(1), positionsAndMeasurements(2),...}
+
+ReportingCriteria ::= SEQUENCE {
+  timeWindow	TimeWindow	OPTIONAL,
+  maxNumberofReports	INTEGER(1..65536) OPTIONAL,
+  minTimeInterval	INTEGER(1..86400) OPTIONAL,
+...}
+
+TimeWindow ::= SEQUENCE {
+  startTime	INTEGER(-525600..-1), -- Time in minutes
+  stopTime	INTEGER(-525599..0)} -- Time in minutes
+
+ProtectionLevel ::= SEQUENCE {
+ protlevel		ProtLevel,
+ basicProtectionParams	BasicProtectionParams	OPTIONAL,
+...}
+
+ProtLevel ::= ENUMERATED {
+ nullProtection(0), basicProtection(1), ...}
+
+BasicProtectionParams ::= SEQUENCE {
+ keyIdentifier 		OCTET STRING(SIZE (8)),
+ basicReplayCounter		INTEGER(0..65535),
+ basicMAC		BIT STRING(SIZE (32)),
+...}
+
+Ver2-SUPL-START-extension ::= SEQUENCE {
+  multipleLocationIds	MultipleLocationIds OPTIONAL,
+  thirdParty     	ThirdParty OPTIONAL,
+  applicationID	ApplicationID OPTIONAL,
+  position         	Position OPTIONAL,
+...}
+
+Ver2-SUPL-RESPONSE-extension ::= SEQUENCE {
+  supportedNetworkInformation   	SupportedNetworkInformation OPTIONAL,
+  sPCSETKey     		SPCSETKey	OPTIONAL,
+  sPCTID	       		SPCTID	OPTIONAL,
+  sPCSETKeylifetime		SPCSETKeylifetime OPTIONAL,
+  initialApproximateposition    	Position 	OPTIONAL,
+  gnssPosTechnology		GNSSPosTechnology OPTIONAL,
+...}
+
+Ver2-SUPL-POS-INIT-extension ::= SEQUENCE {
+  multipleLocationIds	 	MultipleLocationIds OPTIONAL,
+  utran-GPSReferenceTimeResult	UTRAN-GPSReferenceTimeResult OPTIONAL,
+  utran-GANSSReferenceTimeResult	UTRAN-GANSSReferenceTimeResult OPTIONAL,
+...}
+
+Ver2-SUPL-POS-extension ::= SEQUENCE {
+utran-GPSReferenceTimeAssistance	UTRAN-GPSReferenceTimeAssistance OPTIONAL,
+utran-GPSReferenceTimeResult	UTRAN-GPSReferenceTimeResult OPTIONAL,
+utran-GANSSReferenceTimeAssistance	UTRAN-GANSSReferenceTimeAssistance OPTIONAL,
+utran-GANSSReferenceTimeResult	UTRAN-GANSSReferenceTimeResult OPTIONAL,
+...}
+
+Ver2-SUPL-END-extension ::= SEQUENCE {
+  sETCapabilities	SETCapabilities OPTIONAL,
+...}
+
+END
+
+--
+--	11.4 Parameter Extensions (SUPL Version 2)
+--
+
+ULP-Version-2-parameter-extensions DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+EXPORTS
+maxGANSS, Ver2-Notification-extension, Ver2-SETCapabilities-extension, Ver2-PosProtocol-extension, Ver2-PosTechnology-extension, Ver2-RequestedAssistData-extension, Ver2-PosPayLoad-extension;
+
+IMPORTS
+	GANSSSignals, ReportingCap
+FROM Ver2-ULP-Components
+	maxNumGeoArea, maxAreaId, maxAreaIdList
+FROM SUPL-TRIGGERED-START;
+
+Ver2-Notification-extension ::= SEQUENCE {
+  emergencyCallLocation  NULL OPTIONAL,
+  ...}
+
+Ver2-SETCapabilities-extension ::= SEQUENCE {
+serviceCapabilities	ServiceCapabilities OPTIONAL,
+...,
+  supportedBearers SupportedBearers OPTIONAL}
+
+
+ServiceCapabilities ::= SEQUENCE {
+  servicesSupported		ServicesSupported,
+  reportingCapabilities	ReportingCap OPTIONAL,
+  eventTriggerCapabilities	EventTriggerCapabilities OPTIONAL,
+  sessionCapabilities		SessionCapabilities,
+...}
+
+ServicesSupported ::= SEQUENCE {
+  periodicTrigger	BOOLEAN,
+  areaEventTrigger	BOOLEAN,
+...}
+
+EventTriggerCapabilities ::= SEQUENCE {
+  geoAreaShapesSupported        	GeoAreaShapesSupported,
+  maxNumGeoAreaSupported	INTEGER (0..maxNumGeoArea) OPTIONAL,
+  maxAreaIdListSupported	INTEGER (0..maxAreaIdList) OPTIONAL,
+  maxAreaIdSupportedPerList	INTEGER (0..maxAreaId) OPTIONAL,
+...}
+
+GeoAreaShapesSupported ::= SEQUENCE {
+  ellipticalArea   BOOLEAN,
+  polygonArea      BOOLEAN,
+...}
+
+SessionCapabilities ::= SEQUENCE {
+  maxNumberTotalSessions	INTEGER (1..128),
+  maxNumberPeriodicSessions	INTEGER (1..32),
+  maxNumberTriggeredSessions	INTEGER (1..32),
+...}
+
+SupportedBearers ::= SEQUENCE {
+  gsm		BOOLEAN,
+  wcdma		BOOLEAN,
+  lte		BOOLEAN,
+  cdma		BOOLEAN,
+  hprd		BOOLEAN,
+  umb		BOOLEAN,
+  wlan		BOOLEAN,
+  wiMAX		BOOLEAN,
+...}
+
+Ver2-PosProtocol-extension ::= SEQUENCE {
+  lpp     BOOLEAN,
+posProtocolVersionRRLP	PosProtocolVersion3GPP OPTIONAL,
+posProtocolVersionRRC	PosProtocolVersion3GPP OPTIONAL,
+posProtocolVersionTIA801	PosProtocolVersion3GPP2 OPTIONAL,
+posProtocolVersionLPP  PosProtocolVersion3GPP OPTIONAL,
+...}
+
+PosProtocolVersion3GPP ::= SEQUENCE {
+  majorVersionField      INTEGER(0..255),
+  technicalVersionField  INTEGER(0..255),
+  editorialVersionField  INTEGER(0..255),
+...}
+
+PosProtocolVersion3GPP2 ::= SEQUENCE (SIZE(1..8)) OF Supported3GPP2PosProtocolVersion
+
+Supported3GPP2PosProtocolVersion ::= SEQUENCE {
+  revisionNumber   		BIT STRING(SIZE (6)), -- the location standard revision number the SET supports coded according to 3GPP2 C.S0022
+  pointReleaseNumber  	INTEGER(0..255),
+  internalEditLevel  		INTEGER(0..255),
+...}
+
+Ver2-PosTechnology-extension ::= SEQUENCE {
+  gANSSPositionMethods  GANSSPositionMethods OPTIONAL,
+...}
+
+GANSSPositionMethods ::= SEQUENCE (SIZE(1..16)) OF GANSSPositionMethod
+
+GANSSPositionMethod ::= SEQUENCE {
+ganssId			INTEGER(0..15), -- coding according to parameter definition in section 10.10
+ganssSBASid 		BIT STRING(SIZE(3)) OPTIONAL, --coding according to parameter definition in section 10.10
+gANSSPositioningMethodTypes	GANSSPositioningMethodTypes,
+gANSSSignals		GANSSSignals,
+...}
+
+GANSSPositioningMethodTypes ::= SEQUENCE {
+  setAssisted	BOOLEAN,
+  setBased	BOOLEAN,
+  autonomous	BOOLEAN,
+...}
+
+Ver2-RequestedAssistData-extension ::= SEQUENCE {
+  ganssRequestedCommonAssistanceDataList          GanssRequestedCommonAssistanceDataList OPTIONAL,
+  ganssRequestedGenericAssistanceDataList GanssRequestedGenericAssistanceDataList OPTIONAL,
+  extendedEphemeris		ExtendedEphemeris OPTIONAL,
+  extendedEphemerisCheck	ExtendedEphCheck OPTIONAL,
+...}
+
+GanssRequestedCommonAssistanceDataList ::= SEQUENCE {
+  ganssReferenceTime			BOOLEAN,
+  ganssIonosphericModel		BOOLEAN,
+  ganssAdditionalIonosphericModelForDataID00	BOOLEAN,
+  ganssAdditionalIonosphericModelForDataID11	BOOLEAN,
+  ganssEarthOrientationParameters		BOOLEAN,
+...}
+
+GanssRequestedGenericAssistanceDataList ::= SEQUENCE(SIZE(1..maxGANSS)) OF GanssReqGenericData
+
+GanssReqGenericData ::= SEQUENCE {
+  ganssId   INTEGER(0..15), -- coding according to parameter definition in section 10.10
+  ganssSBASid BIT STRING(SIZE(3)) OPTIONAL, --coding according to parameter definition in section 10.10
+  ganssRealTimeIntegrity	BOOLEAN,
+  ganssDifferentialCorrection	DGANSS-Sig-Id-Req OPTIONAL,
+  ganssAlmanac		BOOLEAN,
+  ganssNavigationModelData	GanssNavigationModelData OPTIONAL,
+  ganssTimeModels		BIT STRING(SIZE(16)) OPTIONAL,
+  ganssReferenceMeasurementInfo	BOOLEAN,
+  ganssDataBits		GanssDataBits OPTIONAL,
+  ganssUTCModel		BOOLEAN,
+  ganssAdditionalDataChoices GanssAdditionalDataChoices OPTIONAL,
+  ganssAuxiliaryInformation	BOOLEAN,
+  ganssExtendedEphemeris         	ExtendedEphemeris OPTIONAL,
+  ganssExtendedEphemerisCheck    	GanssExtendedEphCheck OPTIONAL,
+...}
+
+DGANSS-Sig-Id-Req ::= BIT STRING (SIZE(8)) -- coding according to parameter definition in section 10.9
+
+GanssNavigationModelData ::= SEQUENCE {
+ganssWeek		INTEGER(0..4095),
+ganssToe			INTEGER(0..167),
+t-toeLimit		INTEGER(0..15),
+satellitesListRelatedDataList	SatellitesListRelatedDataList OPTIONAL,
+...}
+
+SatellitesListRelatedDataList ::= SEQUENCE(SIZE(0..maxGANSSSat)) OF SatellitesListRelatedData
+
+SatellitesListRelatedData ::= SEQUENCE {
+  satId	INTEGER(0..63),
+  iod	INTEGER(0..1023),
+...}
+
+maxGANSS    INTEGER ::= 16
+maxGANSSSat INTEGER ::= 32
+
+GanssDataBits ::= SEQUENCE {
+  ganssTODmin     		INTEGER (0..59),
+  reqDataBitAssistanceList 	ReqDataBitAssistanceList,
+...}
+
+ReqDataBitAssistanceList ::= SEQUENCE {
+  gnssSignals  	     	GANSSSignals,
+  ganssDataBitInterval  	INTEGER (0..15),
+  ganssDataBitSatList		SEQUENCE (SIZE(1..maxGANSSSat)) OF INTEGER (0..63) OPTIONAL,
+...}
+
+GanssAdditionalDataChoices ::= SEQUENCE {
+  orbitModelID	INTEGER(0..7) OPTIONAL,
+  clockModelID	INTEGER(0..7) OPTIONAL,
+  utcModelID	INTEGER(0..7) OPTIONAL,
+  almanacModelID	INTEGER(0..7) OPTIONAL,
+...}
+
+ExtendedEphemeris ::= SEQUENCE {
+  validity        INTEGER (1..256), -- Requested validity in 4 hour steps
+  ...}
+
+ExtendedEphCheck ::= SEQUENCE {
+  beginTime       GPSTime, -- Begin time of ephemeris extension held by SET
+  endTime         GPSTime, -- End time of ephemeris extension held by SET
+  ...}
+
+GanssExtendedEphCheck ::= SEQUENCE {
+  beginTime  GANSSextEphTime, -- Begin time of ephemeris extension held by SET
+  endTime    GANSSextEphTime, -- End time of ephemeris extension held by SET
+  ...}
+
+GPSTime ::= SEQUENCE {
+  gPSWeek    INTEGER (0..1023),
+  gPSTOWhour INTEGER (0..167),
+...}
+
+GANSSextEphTime ::= SEQUENCE {
+  gANSSday       INTEGER (0..8191),
+  gANSSTODhour   INTEGER (0..23),
+...}
+
+Ver2-PosPayLoad-extension ::= SEQUENCE {
+   lPPPayload SEQUENCE (SIZE (1..3)) OF OCTET STRING(SIZE (1..60000)) OPTIONAL,
+   tIA801Payload SEQUENCE (SIZE(1..3)) OF OCTET STRING(SIZE (1..60000)) OPTIONAL,
+...}
+
+
+END
+
+--
+--11.5 Common elements (SUPL Version 1)
+--
+
+
+--
+-- 11.6 Common elements (SUPL Version 2)
+--

--- a/examples/tests/15-supl.rs
+++ b/examples/tests/15-supl.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code, unreachable_patterns, non_camel_case_types)]
+
+mod s1ap {
+    include!(concat!(env!("OUT_DIR"), "/supl.rs"));
+}
+
+fn main() {
+    eprintln!("SUPL");
+}

--- a/examples/tests/compile.rs
+++ b/examples/tests/compile.rs
@@ -6,4 +6,5 @@ fn tests() {
     t.pass("tests/12-s1ap.rs");
     t.pass("tests/13-ngap.rs");
     t.pass("tests/14-e2ap.rs");
+    t.pass("tests/15-supl.rs");
 }


### PR DESCRIPTION
Also added examples for `supl` definitions.

Also upgraded crate versions for all the crates.