### PR TITLE
Fixes #59 - Panic during encode

### DIFF
--- a/codecs/src/per/common/encode/encode_internal.rs
+++ b/codecs/src/per/common/encode/encode_internal.rs
@@ -125,7 +125,7 @@ pub(super) fn encode_constrained_whole_number_common(
         // Let's say range is 1000 -> 0b_0000_0011_1110_1000 (Minimum number of bits needed is 10)
         let leading_zeros = range.leading_zeros() as usize;
         let bytes = value.to_be_bytes();
-        data.append_bits(bytes[leading_zeros..].view_bits())
+        data.append_bits(&bytes.view_bits()[leading_zeros..])
     }
     Ok(())
 }

--- a/codecs_derive/tests/11-issue-59.rs
+++ b/codecs_derive/tests/11-issue-59.rs
@@ -1,0 +1,13 @@
+#![allow(non_camel_case_types, dead_code)]
+
+use asn1_codecs::{uper::UperCodec, PerCodecData};
+
+#[derive(asn1_codecs_derive :: UperCodec, Debug)]
+#[asn(type = "INTEGER", lb = "0", ub = "63")]
+pub struct INTEGER_20(pub u8);
+
+fn main() {
+    let mut data: PerCodecData = PerCodecData::new_uper();
+    let my_int: INTEGER_20 = INTEGER_20(3);
+    let _result = my_int.uper_encode(&mut data);
+}

--- a/codecs_derive/tests/compile.rs
+++ b/codecs_derive/tests/compile.rs
@@ -12,4 +12,5 @@ fn tests() {
     t.pass("tests/08-seq.rs");
     t.pass("tests/09-open.rs");
     t.pass("tests/10-seqof.rs");
+    t.pass("tests/11-issue-59.rs");
 }


### PR DESCRIPTION
We need to first take the `bit_view` and then take the slice (not the other way round).