### PR TITLE
Generating Better Type Names for enum Variants

### DIFF
--- a/asn-compiler/src/generator/asn/types/base/bitstring.rs
+++ b/asn-compiler/src/generator/asn/types/base/bitstring.rs
@@ -38,8 +38,13 @@ impl Asn1ResolvedBitString {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("BIT STRING");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("BIT STRING")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/base/boolean.rs
+++ b/asn-compiler/src/generator/asn/types/base/boolean.rs
@@ -28,8 +28,13 @@ impl Asn1ResolvedBoolean {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("BOOLEAN");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("BOOLEAN")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/base/charstring.rs
+++ b/asn-compiler/src/generator/asn/types/base/charstring.rs
@@ -40,8 +40,13 @@ impl Asn1ResolvedCharacterString {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("CharacterString");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("CharacterString")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/base/enumerated.rs
+++ b/asn-compiler/src/generator/asn/types/base/enumerated.rs
@@ -64,8 +64,13 @@ impl Asn1ResolvedEnumerated {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("ENUMERATED");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("ENUMERATED")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/base/integer.rs
+++ b/asn-compiler/src/generator/asn/types/base/integer.rs
@@ -67,8 +67,13 @@ impl Asn1ResolvedInteger {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("INTEGER");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("INTEGER")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/base/mod.rs
+++ b/asn-compiler/src/generator/asn/types/base/mod.rs
@@ -43,16 +43,21 @@ impl ResolvedBaseType {
     pub(crate) fn generate_ident_and_aux_type_for_base(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
         match self {
-            ResolvedBaseType::Integer(ref i) => i.generate_ident_and_aux_type(generator),
-            ResolvedBaseType::Enum(ref e) => e.generate_ident_and_aux_type(generator),
-            ResolvedBaseType::BitString(ref b) => b.generate_ident_and_aux_type(generator),
-            ResolvedBaseType::Boolean(ref b) => b.generate_ident_and_aux_type(generator),
-            ResolvedBaseType::OctetString(ref o) => o.generate_ident_and_aux_type(generator),
-            ResolvedBaseType::CharacterString(ref c) => c.generate_ident_and_aux_type(generator),
-            ResolvedBaseType::Null(ref n) => n.generate_ident_and_aux_type(generator),
-            ResolvedBaseType::ObjectIdentifier(ref o) => o.generate_ident_and_aux_type(generator),
+            ResolvedBaseType::Integer(ref i) => i.generate_ident_and_aux_type(generator, input),
+            ResolvedBaseType::Enum(ref e) => e.generate_ident_and_aux_type(generator, input),
+            ResolvedBaseType::BitString(ref b) => b.generate_ident_and_aux_type(generator, input),
+            ResolvedBaseType::Boolean(ref b) => b.generate_ident_and_aux_type(generator, input),
+            ResolvedBaseType::OctetString(ref o) => o.generate_ident_and_aux_type(generator, input),
+            ResolvedBaseType::CharacterString(ref c) => {
+                c.generate_ident_and_aux_type(generator, input)
+            }
+            ResolvedBaseType::Null(ref n) => n.generate_ident_and_aux_type(generator, input),
+            ResolvedBaseType::ObjectIdentifier(ref o) => {
+                o.generate_ident_and_aux_type(generator, input)
+            }
         }
     }
 }

--- a/asn-compiler/src/generator/asn/types/base/null.rs
+++ b/asn-compiler/src/generator/asn/types/base/null.rs
@@ -28,8 +28,13 @@ impl Asn1ResolvedNull {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("NULL");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("NULL")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/base/octetstring.rs
+++ b/asn-compiler/src/generator/asn/types/base/octetstring.rs
@@ -38,8 +38,13 @@ impl Asn1ResolvedOctetString {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("OCTET STRING");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("OCTET STRING")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/base/oid.rs
+++ b/asn-compiler/src/generator/asn/types/base/oid.rs
@@ -28,8 +28,13 @@ impl Asn1ResolvedObjectIdentifier {
     pub(crate) fn generate_ident_and_aux_type(
         &self,
         generator: &mut Generator,
+        input: Option<&String>,
     ) -> Result<Ident, Error> {
-        let unique_name = generator.get_unique_name("OBJECT IDENTIFIER");
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("OBJECT IDENTIFIER")
+        } else {
+            input.unwrap().to_string()
+        };
 
         let item = self.generate(&unique_name, generator)?;
         generator.aux_items.push(item);

--- a/asn-compiler/src/generator/asn/types/constructed/choice.rs
+++ b/asn-compiler/src/generator/asn/types/constructed/choice.rs
@@ -141,7 +141,7 @@ impl ResolvedConstructedType {
         let mut out_components = vec![];
         for (i, c) in components.iter().enumerate() {
             let comp_variant_ident = generator.to_type_ident(&c.id);
-            let input_comp_type_ident = format!("{}{}", name, c.id);
+            let input_comp_type_ident = format!("{}_{}", name, c.id);
             let comp_variant_ty_ident = Asn1ResolvedType::generate_name_maybe_aux_type(
                 &c.ty,
                 generator,

--- a/asn-compiler/src/generator/asn/types/int.rs
+++ b/asn-compiler/src/generator/asn/types/int.rs
@@ -30,7 +30,9 @@ impl Asn1ResolvedType {
         input: Option<&String>,
     ) -> Result<Ident, Error> {
         match ty {
-            Asn1ResolvedType::Base(ref b) => b.generate_ident_and_aux_type_for_base(generator),
+            Asn1ResolvedType::Base(ref b) => {
+                b.generate_ident_and_aux_type_for_base(generator, input)
+            }
             Asn1ResolvedType::Reference(ref r) => {
                 Asn1ResolvedType::generate_ident_for_reference(r, generator)
             }
@@ -118,7 +120,8 @@ impl ResolvedSetType {
         let mut variant_tokens = TokenStream::new();
         for (name, ty) in &self.types {
             let variant_ident = generator.to_type_ident(&name.0);
-            let ty_ident = Asn1ResolvedType::generate_name_maybe_aux_type(&ty.1, generator, None)?;
+            let ty_ident =
+                Asn1ResolvedType::generate_name_maybe_aux_type(&ty.1, generator, Some(&name.0))?;
             let key: proc_macro2::TokenStream = ty.0.to_string().parse().unwrap();
             let key_tokens = quote! {
                 #[asn(key = #key)]


### PR DESCRIPTION
When the types of the Enum Variants were base types like `INTEGER` etc. we were generating unique type names like `INTEGER_42`. Instead, now we are using the Enum Ident and Variant Ident to generate the type names.