### PR TITLE
Support for `Eq` and `PartialEq` derive macros and `--all` CLI switch

### DIFF
--- a/asn-compiler/Cargo.toml
+++ b/asn-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-compiler"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "ASN.1 Compiler in Rust."

--- a/asn-compiler/src/bin/hampi-rs-asn1c.rs
+++ b/asn-compiler/src/bin/hampi-rs-asn1c.rs
@@ -46,9 +46,17 @@ fn main() -> io::Result<()> {
         ));
     }
 
-    if !cli.derive.contains(&Derive::Debug) {
-        cli.derive.push(Derive::Debug);
-    }
+    let derives = if cli.derive.contains(&Derive::All) {
+        cli.derive
+            .into_iter()
+            .filter(|t| t == &Derive::All)
+            .collect::<Vec<Derive>>()
+    } else {
+        if !cli.derive.contains(&Derive::Debug) {
+            cli.derive.push(Derive::Debug);
+        }
+        cli.derive
+    };
 
     let level = if cli.debug > 0 {
         if cli.debug == 1 {
@@ -67,7 +75,7 @@ fn main() -> io::Result<()> {
         &cli.module,
         &cli.visibility,
         cli.codec.clone(),
-        cli.derive.clone(),
+        derives.clone(),
     );
     compiler.compile_files(&cli.files)?;
 

--- a/asn-compiler/src/generator/int.rs
+++ b/asn-compiler/src/generator/int.rs
@@ -27,7 +27,8 @@ pub enum Codec {
 /// Supported Derive Macros
 #[derive(clap::ValueEnum, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Derive {
-    /// Generate `Debug` code for the generated strucutres.
+    /// Generate `Debug` code for the generated strucutres. Generated for all structures by
+    /// default.
     Debug,
 
     /// Generate 'Clone' code for the generated structures.
@@ -38,6 +39,12 @@ pub enum Derive {
 
     /// Generate 'serde::Deserialize' code for the generated structures.
     Deserialize,
+
+    /// Generate `Eq` and `PartialEq` code for the generated structures.
+    EqPartialEq,
+
+    /// Generate code for all supported derives for the generated structures.
+    All,
 }
 
 /// Visibility to be used for the generated Structs, Enums etc.
@@ -64,6 +71,7 @@ lazy_static! {
         m.insert(Derive::Clone, "Clone".to_string());
         m.insert(Derive::Serialize, "serde::Serialize".to_string());
         m.insert(Derive::Deserialize, "serde::Deserialize".to_string());
+        m.insert(Derive::EqPartialEq, "Eq, PartialEq".to_string());
         m
     };
 }
@@ -209,8 +217,14 @@ impl Generator {
         }
 
         for derive in &self.derives {
-            let derive_token = DERIVE_TOKENS.get(derive).unwrap();
-            tokens.push(derive_token.to_string());
+            if derive == &Derive::All {
+                for derive_token in DERIVE_TOKENS.values() {
+                    tokens.push(derive_token.to_string());
+                }
+            } else {
+                let derive_token = DERIVE_TOKENS.get(derive).unwrap();
+                tokens.push(derive_token.to_string());
+            }
         }
 
         let token_string = tokens.join(",");

--- a/codecs/Cargo.toml
+++ b/codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-codecs"
-version = "0.5.3"
+version = "0.5.4"
 description = "ASN.1 Codecs for Rust Types representing ASN.1 Types."
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 keywords = ["asn1", "per", "decoder", "encoder"]

--- a/codecs_derive/Cargo.toml
+++ b/codecs_derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "asn1_codecs_derive"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 description = "ASN.1 Codecs derive Macros"
 keywords = ["asn1", "per"]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2018"
 license-file = "LICENSE"
 repository = "https://github.com/gabhijit/hampi.git"
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 log = { version = "0.4" }
-asn1-codecs = { path = "../codecs" , version = "=0.5.3"}
+asn1-codecs = { path = "../codecs" , version = "=0.5.4"}
 bitvec = { version = "1.0" }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "hampi-examples"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "Examples for usage of ASN.1 Compiler and Codecs."
 publish = false
 
 [build-dependencies]
-asn1-compiler = { path = "../asn-compiler", version = "=0.5.3" }
+asn1-compiler = { path = "../asn-compiler", version = "=0.5.4" }
 
 [dev-dependencies]
-asn1-codecs = { path = "../codecs", version = "=0.5.3" }
-asn1_codecs_derive = { path = "../codecs_derive", version = "=0.5.3" }
+asn1-codecs = { path = "../codecs", version = "=0.5.4" }
+asn1_codecs_derive = { path = "../codecs_derive", version = "=0.5.4" }
 trybuild = { version = "1.0" }
 hex = { version = "0.4" }
 bitvec = { version = "1.0" , features = ["serde"]}

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -65,7 +65,12 @@ fn main() -> std::io::Result<()> {
             rs_module,
             &Visibility::Public,
             codecs_map.get(module).unwrap().clone(),
-            vec![Derive::Debug, Derive::Serialize, Derive::Deserialize],
+            vec![
+                Derive::Debug,
+                Derive::EqPartialEq,
+                Derive::Serialize,
+                Derive::Deserialize,
+            ],
         );
         compiler.compile_files(&specs_files)?;
     }


### PR DESCRIPTION
We are not supporting code generation for `Eq` and `PartialEq` as well. In addition, defined another CLI switch for `--derive` called all. This will generated all derives supported.

Also, updated crate version to 0.5.4, so that this 'new' support can be utilized.