### PR TITLE
Fixes issue with encode `constrained_whole_number`

### DIFF
--- a/codecs/src/per/common/decode/decode_internal.rs
+++ b/codecs/src/per/common/decode/decode_internal.rs
@@ -215,10 +215,14 @@ pub(super) fn decode_constrained_whole_number_common(
 
             Ok(value + lb)
         } else {
-            let leading_zeros = range.leading_zeros();
-            let bits = 128 - leading_zeros as usize;
-            let value = data.decode_bits_as_integer(bits, false)?;
-            Ok(value + lb)
+            if range > 1 {
+                let leading_zeros = (range - 1).leading_zeros();
+                let bits = 128 - leading_zeros as usize;
+                let value = data.decode_bits_as_integer(bits, false)?;
+                Ok(value + lb)
+            } else {
+                Ok(lb)
+            }
         }
     }
 }

--- a/codecs_derive/tests/11-issue-59.rs
+++ b/codecs_derive/tests/11-issue-59.rs
@@ -13,8 +13,8 @@ fn main() {
     assert!(result.is_ok());
 
     let decoded = INTEGER_20::uper_decode(&mut data);
-    assert!(decoded.is_ok());
+    assert!(decoded.is_ok(), "{:?}", decoded.err().unwrap());
 
     let INTEGER_20(v) = decoded.unwrap();
-    assert!(v == 3u8);
+    assert!(v == 3u8, "decoded: {}", v);
 }


### PR DESCRIPTION
In the `encode_whole_number_common` for `uper` (`aligned = false`) codec, when the range was 1 (ie. only one value possible, we were still encoding the '0' value.

This issue is exposed due to #70 . Now encoding only if the range is greater than one.