### PR TITLE
advance() method on PerCodecData

### DIFF
--- a/codecs/src/per/mod.rs
+++ b/codecs/src/per/mod.rs
@@ -214,7 +214,11 @@ impl PerCodecData {
         }
     }
 
-    fn advance_maybe_err(&mut self, bits: usize, ignore: bool) -> Result<(), PerCodecError> {
+    /// Advance the decode offset by a given number of bits.
+    /// If there are not enough bits remaining, the behaviour depends on the `ignore` argument.
+    /// -  If `true`, the offset is advanced to the end of the buffer, and Ok is returned.
+    /// -  If `false`, the offset is left unchanged, and Err is returned.
+    pub fn advance_maybe_err(&mut self, bits: usize, ignore: bool) -> Result<(), PerCodecError> {
         let offset = self.decode_offset + bits;
         if offset > self.bits.len() {
             if ignore {
@@ -330,11 +334,6 @@ impl PerCodecData {
     #[inline]
     pub fn seek(&mut self, offset: usize) {
         self.decode_offset = offset;
-    }
-
-    /// Advance the decode offset by a given number of bits (for example, to skip over an unknown extension)
-    pub fn advance(&mut self, bits: usize) -> Result<(), PerCodecError> {
-        self.advance_maybe_err(bits, false)
     }
 
     pub fn swap_bits(&mut self, other: &mut BitSlice<u8, Msb0>, offset: usize) {

--- a/codecs/src/per/mod.rs
+++ b/codecs/src/per/mod.rs
@@ -332,6 +332,11 @@ impl PerCodecData {
         self.decode_offset = offset;
     }
 
+    /// Advance the decode offset by a given number of bits (for example, to skip over an unknown extension)
+    pub fn advance(&mut self, bits: usize) -> Result<(), PerCodecError> {
+        self.advance_maybe_err(bits, false)
+    }
+
     pub fn swap_bits(&mut self, other: &mut BitSlice<u8, Msb0>, offset: usize) {
         self.bits[offset..other.len() + offset].swap_with_bitslice(other);
     }


### PR DESCRIPTION
Hello @gabhijit, it's been a while...

Here is a small enhancement that I think is helpful to deal with unrecognised extensions.  For example, consider an NGAP ProtocolExtensionContainer.

```
ProtocolExtensionContainer {NGAP-PROTOCOL-EXTENSION : ExtensionSetParam} ::= 
	SEQUENCE (SIZE (1..maxProtocolExtensions)) OF
	ProtocolExtensionField {{ExtensionSetParam}}

ProtocolExtensionField {NGAP-PROTOCOL-EXTENSION : ExtensionSetParam} ::= SEQUENCE {
	id					NGAP-PROTOCOL-EXTENSION.&id				({ExtensionSetParam}),
	criticality			NGAP-PROTOCOL-EXTENSION.&criticality	({ExtensionSetParam}{@id}),
	extensionValue		NGAP-PROTOCOL-EXTENSION.&Extension		({ExtensionSetParam}{@id})
}
```

For each `ProtocolExtensionField`, you decode ID and criticality and length.  If you recognize the ID you decode the extension value.  If you don't recognize the ID (and it is non critical), you `data.advance(length)?` using this new API.

I couldn't think of a good way to do this using the existing API.