### PR TITLE
Fixed integer underflow panic when self.bytes.len() == 0

### DIFF
--- a/codecs/src/per/mod.rs
+++ b/codecs/src/per/mod.rs
@@ -366,7 +366,7 @@ impl PerCodecData {
     /// Get the length of the data in bytes
     /// This is useful when encoding an open type.
     pub fn length_in_bytes(&self) -> usize {
-        ((self.bits.len() - 1) / 8) + 1
+        (self.bits.len() + 7) / 8
     }
 
     /// Append one encoding to another preserving byte alignment.


### PR DESCRIPTION
This is functionally the same as before:

((len - 1) / 8) + 1 = ((len - 1) / 8) + 8/8 = ((len - 1) + 8) / 8 = (len + 7) / 8

It just ensures that the function will not panic if the length of the data happens to be 0.