### PR TITLE
fix sequence-of decoding for empty sequence-of's

### DIFF
--- a/codecs/src/per/common/decode/mod.rs
+++ b/codecs/src/per/common/decode/mod.rs
@@ -57,9 +57,9 @@ pub fn decode_sequence_header_common(
 
     let mut bitmap = BitVec::new();
     if optional_count > 0 {
+        log::trace!("{:?} optionals found", optional_count);
         bitmap.extend(data.get_bitvec(optional_count)?);
     }
-
     data.dump();
     Ok((bitmap, extended))
 }

--- a/codecs/src/per/mod.rs
+++ b/codecs/src/per/mod.rs
@@ -12,8 +12,9 @@ mod common;
 pub use error::Error as PerCodecError;
 
 use bitvec::prelude::*;
+use std::convert::TryFrom;
 
-/// Structure representing an APER Codec.
+/// Structure representing a PER Codec.
 ///
 /// While En(De)coding ASN.1 Types using the APER encoding scheme, the encoded data is stored in a
 /// `BitVec`.
@@ -120,9 +121,22 @@ impl PerCodecData {
             let value = if !signed {
                 if bits == 0 {
                     0_i128
+                } else if bits > 128 {
+                    return Err(
+                        PerCodecError::new(
+                            format!(
+                                "For an unsigned number, requested bits {} not supported!",
+                                bits)));
                 } else {
-                    self.bits[self.decode_offset..self.decode_offset + bits].load_be::<u128>()
-                        as i128
+                    let unsigned_value = self.bits[self.decode_offset..self.decode_offset + bits].load_be::<u128>();
+                    match i128::try_from(unsigned_value) {
+                        Ok(v) => v,
+                        Err(_) => return Err(
+                            PerCodecError::new(
+                                format!(
+                                    "Unsigned value {} exceeded signed bounds for 128-bit integer!",
+                                    unsigned_value))),
+                    }
                 }
             } else {
                 match bits {

--- a/codecs/src/per/uper/decode/mod.rs
+++ b/codecs/src/per/uper/decode/mod.rs
@@ -1,4 +1,4 @@
-//! Decode APIs for APER Codec
+//! Decode APIs for UPER Codec
 
 use bitvec::prelude::*;
 

--- a/codecs_derive/src/per/seqof.rs
+++ b/codecs_derive/src/per/seqof.rs
@@ -66,12 +66,9 @@ pub(super) fn generate_aper_codec_for_asn_sequence_of(
 
                 let mut items = vec![];
                 let mut count = 0;
-                loop {
+
+                for _ in 0..length {
                     items.push(#ty::#codec_decode_fn(data)?);
-                    count += 1;
-                    if count == length {
-                        break;
-                    }
                 }
 
                 Ok(Self(items))

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -42,14 +42,15 @@ fn get_specs_files(
 }
 
 fn main() -> std::io::Result<()> {
-    let specs = vec!["ranap", "s1ap", "ngap", "e2ap", "supl"];
-    let modules = vec!["ranap.rs", "s1ap.rs", "ngap.rs", "e2ap.rs", "supl.rs"];
+    let specs = vec!["ranap", "s1ap", "ngap", "e2ap", "supl", "rrc"];
+    let modules = vec!["ranap.rs", "s1ap.rs", "ngap.rs", "e2ap.rs", "supl.rs", "rrc.rs"];
     let mut codecs_map = HashMap::new();
     codecs_map.insert("ranap.rs", vec![Codec::Aper]);
     codecs_map.insert("s1ap.rs", vec![Codec::Aper]);
     codecs_map.insert("ngap.rs", vec![Codec::Aper]);
     codecs_map.insert("e2ap.rs", vec![Codec::Aper]);
     codecs_map.insert("supl.rs", vec![Codec::Uper]);
+    codecs_map.insert("rrc.rs", vec![Codec::Uper]);
 
     for (spec, module) in std::iter::zip(specs, modules) {
         let specs_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())

--- a/examples/specs/rrc/RRC-36331.asn
+++ b/examples/specs/rrc/RRC-36331.asn
@@ -1,0 +1,21131 @@
+﻿-- $Id: 2f755a366f3af0a1481c05475239e93a82eaf419 $
+
+-- 3GPP TS 36.331 V16.4.0 (2021-03)
+
+
+--<OSS.ROOT EUTRA-RRC-Definitions, EUTRA-UE-Variables>--
+
+--<OSS.PDU EUTRA-RRC-Definitions.BCCH-BCH-Message>--
+--<OSS.PDU EUTRA-RRC-Definitions.BCCH-DL-SCH-Message>--
+--<OSS.PDU EUTRA-RRC-Definitions.PCCH-Message>--
+--<OSS.PDU EUTRA-RRC-Definitions.DL-CCCH-Message>--
+--<OSS.PDU EUTRA-RRC-Definitions.DL-DCCH-Message>--
+--<OSS.PDU EUTRA-RRC-Definitions.UL-CCCH-Message>--
+--<OSS.PDU EUTRA-RRC-Definitions.UL-DCCH-Message>--
+
+--<OSS.PDU EUTRA-RRC-Definitions.SC-MCCH-Message-r13>--
+
+EUTRA-RRC-Definitions DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+
+
+BCCH-BCH-Message ::= SEQUENCE {
+	message					BCCH-BCH-MessageType
+}
+
+BCCH-BCH-MessageType ::=						MasterInformationBlock
+
+
+
+BCCH-BCH-Message-MBMS::= SEQUENCE {
+	message					BCCH-BCH-MessageType-MBMS-r14
+}
+
+BCCH-BCH-MessageType-MBMS-r14 ::=					MasterInformationBlock-MBMS-r14
+
+
+
+BCCH-DL-SCH-Message ::= SEQUENCE {
+	message					BCCH-DL-SCH-MessageType
+}
+
+BCCH-DL-SCH-MessageType ::= CHOICE {
+	c1						CHOICE {
+		systemInformation						SystemInformation,
+		systemInformationBlockType1				SystemInformationBlockType1
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+BCCH-DL-SCH-Message-BR ::= SEQUENCE {
+	message					BCCH-DL-SCH-MessageType-BR-r13
+}
+
+BCCH-DL-SCH-MessageType-BR-r13 ::= CHOICE {
+	c1						CHOICE {
+		systemInformation-BR-r13				SystemInformation-BR-r13,
+		systemInformationBlockType1-BR-r13		SystemInformationBlockType1-BR-r13
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+BCCH-DL-SCH-Message-MBMS ::= SEQUENCE {
+	message						BCCH-DL-SCH-MessageType-MBMS-r14
+}
+
+BCCH-DL-SCH-MessageType-MBMS-r14 ::= CHOICE {
+	c1									CHOICE {
+		systemInformation-MBMS-r14					SystemInformation-MBMS-r14,
+		systemInformationBlockType1-MBMS-r14		SystemInformationBlockType1-MBMS-r14
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+MCCH-Message ::=		SEQUENCE {
+	message					MCCH-MessageType
+}
+
+MCCH-MessageType ::= CHOICE {
+	c1							CHOICE {
+		mbsfnAreaConfiguration-r9		MBSFNAreaConfiguration-r9
+	},
+	later						CHOICE {
+		c2								CHOICE{
+			mbmsCountingRequest-r10			MBMSCountingRequest-r10
+		},
+		messageClassExtension	SEQUENCE {}
+	}
+}
+
+
+
+PCCH-Message ::= SEQUENCE {
+	message					PCCH-MessageType
+}
+
+PCCH-MessageType ::= CHOICE {
+	c1						CHOICE {
+		paging									Paging
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+DL-CCCH-Message ::= SEQUENCE {
+	message					DL-CCCH-MessageType
+}
+
+DL-CCCH-MessageType ::= CHOICE {
+	c1						CHOICE {
+		rrcConnectionReestablishment			RRCConnectionReestablishment,
+		rrcConnectionReestablishmentReject		RRCConnectionReestablishmentReject,
+		rrcConnectionReject						RRCConnectionReject,
+		rrcConnectionSetup						RRCConnectionSetup
+	},
+	messageClassExtension	CHOICE {
+		c2						CHOICE {
+			rrcEarlyDataComplete-r15			RRCEarlyDataComplete-r15,
+			spare3	NULL, spare2 NULL, spare1 NULL
+		},
+		messageClassExtensionFuture-r15			SEQUENCE {}
+	}
+}
+
+
+
+DL-DCCH-Message ::= SEQUENCE {
+	message					DL-DCCH-MessageType
+}
+
+DL-DCCH-MessageType ::= CHOICE {
+	c1						CHOICE {
+		csfbParametersResponseCDMA2000			CSFBParametersResponseCDMA2000,
+		dlInformationTransfer					DLInformationTransfer,
+		handoverFromEUTRAPreparationRequest		HandoverFromEUTRAPreparationRequest,
+		mobilityFromEUTRACommand				MobilityFromEUTRACommand,
+		rrcConnectionReconfiguration			RRCConnectionReconfiguration,
+		rrcConnectionRelease					RRCConnectionRelease,
+		securityModeCommand						SecurityModeCommand,
+		ueCapabilityEnquiry						UECapabilityEnquiry,
+		counterCheck							CounterCheck,
+		ueInformationRequest-r9					UEInformationRequest-r9,
+		loggedMeasurementConfiguration-r10		LoggedMeasurementConfiguration-r10,
+		rnReconfiguration-r10					RNReconfiguration-r10,
+		rrcConnectionResume-r13					RRCConnectionResume-r13,
+		dlDedicatedMessageSegment-r16			DLDedicatedMessageSegment-r16,
+		spare2 NULL, spare1 NULL
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+UL-CCCH-Message ::= SEQUENCE {
+	message					UL-CCCH-MessageType
+}
+
+UL-CCCH-MessageType ::= CHOICE {
+	c1						CHOICE {
+		rrcConnectionReestablishmentRequest		RRCConnectionReestablishmentRequest,
+		rrcConnectionRequest					RRCConnectionRequest
+	},
+	messageClassExtension	CHOICE {
+		c2						CHOICE {
+			rrcConnectionResumeRequest-r13		RRCConnectionResumeRequest-r13
+		},
+		messageClassExtensionFuture-r13	CHOICE {
+			c3						CHOICE {
+				rrcEarlyDataRequest-r15			RRCEarlyDataRequest-r15,
+				spare3	NULL, spare2	NULL, spare1	NULL
+			},
+			messageClassExtensionFuture-r15		SEQUENCE {}
+		}
+	}
+}
+
+
+
+UL-DCCH-Message ::= SEQUENCE {
+	message			UL-DCCH-MessageType
+}
+
+UL-DCCH-MessageType ::= CHOICE {
+	c1						CHOICE {
+		csfbParametersRequestCDMA2000				CSFBParametersRequestCDMA2000,
+		measurementReport							MeasurementReport,
+		rrcConnectionReconfigurationComplete		RRCConnectionReconfigurationComplete,
+		rrcConnectionReestablishmentComplete		RRCConnectionReestablishmentComplete,
+		rrcConnectionSetupComplete					RRCConnectionSetupComplete,
+		securityModeComplete						SecurityModeComplete,
+		securityModeFailure							SecurityModeFailure,
+		ueCapabilityInformation						UECapabilityInformation,
+		ulHandoverPreparationTransfer				ULHandoverPreparationTransfer,
+		ulInformationTransfer						ULInformationTransfer,
+		counterCheckResponse						CounterCheckResponse,
+		ueInformationResponse-r9					UEInformationResponse-r9,
+		proximityIndication-r9						ProximityIndication-r9,
+		rnReconfigurationComplete-r10				RNReconfigurationComplete-r10,
+		mbmsCountingResponse-r10					MBMSCountingResponse-r10,
+		interFreqRSTDMeasurementIndication-r10		InterFreqRSTDMeasurementIndication-r10
+	},
+	messageClassExtension	CHOICE {
+		c2							CHOICE {
+			ueAssistanceInformation-r11			UEAssistanceInformation-r11,
+			inDeviceCoexIndication-r11			InDeviceCoexIndication-r11,
+			mbmsInterestIndication-r11			MBMSInterestIndication-r11,
+			scgFailureInformation-r12			SCGFailureInformation-r12,
+			sidelinkUEInformation-r12			SidelinkUEInformation-r12,
+			wlanConnectionStatusReport-r13		WLANConnectionStatusReport-r13,
+			rrcConnectionResumeComplete-r13		RRCConnectionResumeComplete-r13,
+			ulInformationTransferMRDC-r15		ULInformationTransferMRDC-r15,
+			scgFailureInformationNR-r15			SCGFailureInformationNR-r15,
+			measReportAppLayer-r15				MeasReportAppLayer-r15,
+			failureInformation-r15				FailureInformation-r15,
+			ulDedicatedMessageSegment-r16		ULDedicatedMessageSegment-r16,
+			purConfigurationRequest-r16			PURConfigurationRequest-r16,
+			failureInformation-r16				FailureInformation-r16,
+			mcgFailureInformation-r16			MCGFailureInformation-r16,
+			ulInformationTransferIRAT-r16		ULInformationTransferIRAT-r16
+		},
+		messageClassExtensionFuture-r11
+	SEQUENCE {}
+	}
+}
+
+
+
+SC-MCCH-Message-r13 ::= SEQUENCE {
+	message					SC-MCCH-MessageType-r13
+}
+
+
+SC-MCCH-MessageType-r13 ::= CHOICE {
+	c1						CHOICE {
+		scptmConfiguration-r13						SCPTMConfiguration-r13
+	},
+	messageClassExtension	CHOICE {
+		c2							CHOICE {
+			scptmConfiguration-BR-r14				SCPTMConfiguration-BR-r14,
+			spare									NULL
+		},
+		messageClassExtensionFuture-r14	SEQUENCE {}
+	}
+}
+
+
+
+CounterCheck ::=			SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			counterCheck-r8						CounterCheck-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+CounterCheck-r8-IEs ::=	SEQUENCE {
+	drb-CountMSB-InfoList				DRB-CountMSB-InfoList,
+	nonCriticalExtension				CounterCheck-v8a0-IEs				OPTIONAL
+}
+
+CounterCheck-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				CounterCheck-v1530-IEs				OPTIONAL
+}
+
+CounterCheck-v1530-IEs ::= SEQUENCE {
+	drb-CountMSB-InfoListExt-r15		DRB-CountMSB-InfoListExt-r15		OPTIONAL,	-- Need ON
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+DRB-CountMSB-InfoList ::=		SEQUENCE (SIZE (1..maxDRB)) OF DRB-CountMSB-Info
+
+DRB-CountMSB-InfoListExt-r15 ::=	SEQUENCE (SIZE (1..maxDRBExt-r15)) OF DRB-CountMSB-Info
+
+DRB-CountMSB-Info ::=	SEQUENCE {
+	drb-Identity					DRB-Identity,
+	countMSB-Uplink					INTEGER(0..33554431),
+	countMSB-Downlink				INTEGER(0..33554431)
+}
+
+
+
+CounterCheckResponse ::=			SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		counterCheckResponse-r8				CounterCheckResponse-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+CounterCheckResponse-r8-IEs ::=	SEQUENCE {
+	drb-CountInfoList					DRB-CountInfoList,
+	nonCriticalExtension				CounterCheckResponse-v8a0-IEs		OPTIONAL
+}
+
+CounterCheckResponse-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				CounterCheckResponse-v1530-IEs		OPTIONAL
+}
+
+CounterCheckResponse-v1530-IEs ::= SEQUENCE {
+	drb-CountInfoListExt-r15			DRB-CountInfoListExt-r15			OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+DRB-CountInfoList ::=			SEQUENCE (SIZE (0..maxDRB)) OF DRB-CountInfo
+
+DRB-CountInfoListExt-r15 ::=	SEQUENCE (SIZE (1..maxDRBExt-r15)) OF DRB-CountInfo
+
+DRB-CountInfo ::=	SEQUENCE {
+	drb-Identity					DRB-Identity,
+	count-Uplink					INTEGER(0..4294967295),
+	count-Downlink					INTEGER(0..4294967295)
+}
+
+
+
+CSFBParametersRequestCDMA2000 ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		csfbParametersRequestCDMA2000-r8	CSFBParametersRequestCDMA2000-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+CSFBParametersRequestCDMA2000-r8-IEs ::= SEQUENCE {
+	nonCriticalExtension				CSFBParametersRequestCDMA2000-v8a0-IEs	OPTIONAL
+}
+
+CSFBParametersRequestCDMA2000-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+CSFBParametersResponseCDMA2000 ::= SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions						CHOICE {
+		csfbParametersResponseCDMA2000-r8		CSFBParametersResponseCDMA2000-r8-IEs,
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+CSFBParametersResponseCDMA2000-r8-IEs ::= SEQUENCE {
+	rand								RAND-CDMA2000,
+	mobilityParameters					MobilityParametersCDMA2000,
+	nonCriticalExtension				CSFBParametersResponseCDMA2000-v8a0-IEs	OPTIONAL
+}
+
+CSFBParametersResponseCDMA2000-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+DLDedicatedMessageSegment-r16 ::=		SEQUENCE {
+	criticalExtensions						CHOICE {
+		dlDedicatedMessageSegment-r16			DLDedicatedMessageSegment-r16-IEs,
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+DLDedicatedMessageSegment-r16-IEs ::=	SEQUENCE {
+	segmentNumber-r16						INTEGER (0..4),
+	rrc-MessageSegmentContainer-r16			OCTET STRING,
+	rrc-MessageSegmentType-r16				ENUMERATED {notLastSegment, lastSegment},
+	lateNonCriticalExtensions				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}						OPTIONAL
+}
+
+
+
+DLInformationTransfer ::=			SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			dlInformationTransfer-r8			DLInformationTransfer-r8-IEs,
+			dlInformationTransfer-r15			DLInformationTransfer-r15-IEs,
+			spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+DLInformationTransfer-r8-IEs ::=	SEQUENCE {
+	dedicatedInfoType					CHOICE {
+		dedicatedInfoNAS					DedicatedInfoNAS,
+		dedicatedInfoCDMA2000-1XRTT			DedicatedInfoCDMA2000,
+		dedicatedInfoCDMA2000-HRPD			DedicatedInfoCDMA2000
+	},
+	nonCriticalExtension				DLInformationTransfer-v8a0-IEs		OPTIONAL
+}
+
+DLInformationTransfer-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				DLInformationTransfer-v1610-IEs		OPTIONAL
+}
+
+DLInformationTransfer-r15-IEs ::=	SEQUENCE {
+	dedicatedInfoType-r15				CHOICE {
+		dedicatedInfoNAS-r15				DedicatedInfoNAS,
+		dedicatedInfoCDMA2000-1XRTT-r15		DedicatedInfoCDMA2000,
+		dedicatedInfoCDMA2000-HRPD-r15		DedicatedInfoCDMA2000
+	}																		OPTIONAL,	-- Need ON
+	timeReferenceInfo-r15				TimeReferenceInfo-r15				OPTIONAL,	-- Need ON
+	nonCriticalExtension				DLInformationTransfer-v8a0-IEs		OPTIONAL
+}
+
+DLInformationTransfer-v1610-IEs ::= SEQUENCE {
+	dedicatedInfoF1c-r16				DedicatedInfoF1c-r16				OPTIONAL,	-- Need ON
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+FailureInformation-r15 ::=		SEQUENCE {
+	failedLogicalChannelInfo-r15	FailedLogicalChannelInfo-r15		OPTIONAL
+	-- nonCriticalExtension is removed in this version as OPTIONAL was missing
+}
+
+FailureInformation-r16 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		failureInformation-r16				FailureInformation-r16-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+FailedLogicalChannelInfo-r15 ::=	SEQUENCE {
+	failedLogicalChannelIdentity-r15		SEQUENCE {
+		cellGroupIndication-r15				ENUMERATED {mn, sn},
+		logicalChannelIdentity-r15			INTEGER (1..10)				OPTIONAL,
+		logicalChannelIdentityExt-r15		INTEGER (32..38)			OPTIONAL
+	},
+	failureType	ENUMERATED {duplication, spare3, spare2, spare1}
+}
+
+FailureInformation-r16-IEs ::=	SEQUENCE {
+	failedLogicalChannelIdentity-r16	FailedLogicalChannelIdentity-r16	OPTIONAL,
+	failureType-r16						ENUMERATED {duplication, dapsHO-failure,
+											spare2, spare1}					OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+FailedLogicalChannelIdentity-r16 ::=	SEQUENCE {
+	cellGroupIndication-r16				ENUMERATED {mn, sn},
+	logicalChannelIdentity-r16			INTEGER (1..10)				OPTIONAL,
+	logicalChannelIdentityExt-r16		INTEGER (32..38)			OPTIONAL
+}
+
+
+
+HandoverFromEUTRAPreparationRequest ::= SEQUENCE {
+	rrc-TransactionIdentifier		RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			handoverFromEUTRAPreparationRequest-r8		HandoverFromEUTRAPreparationRequest-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+HandoverFromEUTRAPreparationRequest-r8-IEs ::= SEQUENCE {
+	cdma2000-Type					CDMA2000-Type,
+	rand							RAND-CDMA2000				OPTIONAL,	-- Cond cdma2000-Type
+	mobilityParameters				MobilityParametersCDMA2000	OPTIONAL,	-- Cond cdma2000-Type
+	nonCriticalExtension			HandoverFromEUTRAPreparationRequest-v890-IEs	OPTIONAL
+}
+
+HandoverFromEUTRAPreparationRequest-v890-IEs ::= SEQUENCE {
+	lateNonCriticalExtension		OCTET STRING				OPTIONAL,
+	nonCriticalExtension			HandoverFromEUTRAPreparationRequest-v920-IEs	OPTIONAL
+}
+
+HandoverFromEUTRAPreparationRequest-v920-IEs ::= SEQUENCE {
+	concurrPrepCDMA2000-HRPD-r9		BOOLEAN					OPTIONAL,	-- Cond cdma2000-Type
+	nonCriticalExtension			HandoverFromEUTRAPreparationRequest-v1020-IEs	OPTIONAL
+}
+
+HandoverFromEUTRAPreparationRequest-v1020-IEs ::= SEQUENCE {
+	dualRxTxRedirectIndicator-r10		ENUMERATED {true}		OPTIONAL,	-- Cond cdma2000-1XRTT
+	redirectCarrierCDMA2000-1XRTT-r10	CarrierFreqCDMA2000		OPTIONAL,	-- Cond dualRxTxRedirect
+	nonCriticalExtension				SEQUENCE {}				OPTIONAL
+}
+
+
+
+InDeviceCoexIndication-r11 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			inDeviceCoexIndication-r11				InDeviceCoexIndication-r11-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+InDeviceCoexIndication-r11-IEs ::=	SEQUENCE {
+	affectedCarrierFreqList-r11			AffectedCarrierFreqList-r11					OPTIONAL,
+	tdm-AssistanceInfo-r11				TDM-AssistanceInfo-r11						OPTIONAL,
+	lateNonCriticalExtension			OCTET STRING								OPTIONAL,
+	nonCriticalExtension				InDeviceCoexIndication-v11d0-IEs			OPTIONAL
+}
+
+InDeviceCoexIndication-v11d0-IEs ::=	SEQUENCE {
+	ul-CA-AssistanceInfo-r11			SEQUENCE {
+		affectedCarrierFreqCombList-r11		AffectedCarrierFreqCombList-r11		OPTIONAL,
+		victimSystemType-r11				VictimSystemType-r11
+	}																			OPTIONAL,
+	nonCriticalExtension				InDeviceCoexIndication-v1310-IEs		OPTIONAL
+}
+
+InDeviceCoexIndication-v1310-IEs ::=	SEQUENCE {
+	affectedCarrierFreqList-v1310			AffectedCarrierFreqList-v1310		OPTIONAL,
+	affectedCarrierFreqCombList-r13			AffectedCarrierFreqCombList-r13		OPTIONAL,
+	nonCriticalExtension					InDeviceCoexIndication-v1360-IEs	OPTIONAL
+}
+
+InDeviceCoexIndication-v1360-IEs ::=	SEQUENCE {
+	hardwareSharingProblem-r13				ENUMERATED {true}					OPTIONAL,
+	nonCriticalExtension					InDeviceCoexIndication-v1530-IEs	OPTIONAL
+}
+
+InDeviceCoexIndication-v1530-IEs ::=	SEQUENCE {
+	mrdc-AssistanceInfo-r15					MRDC-AssistanceInfo-r15				OPTIONAL,
+	nonCriticalExtension					InDeviceCoexIndication-v1610-IEs	OPTIONAL
+}
+
+InDeviceCoexIndication-v1610-IEs::=	SEQUENCE {
+	victimSystemType-v1610					VictimSystemType-v1610			OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}							OPTIONAL
+}
+
+AffectedCarrierFreqList-r11 ::=	SEQUENCE (SIZE (1..maxFreqIDC-r11)) OF AffectedCarrierFreq-r11
+
+AffectedCarrierFreqList-v1310 ::= SEQUENCE (SIZE (1..maxFreqIDC-r11)) OF AffectedCarrierFreq-v1310
+
+AffectedCarrierFreq-r11 ::=	SEQUENCE {
+	carrierFreq-r11				MeasObjectId,
+	interferenceDirection-r11	ENUMERATED {eutra, other, both, spare}
+}
+
+AffectedCarrierFreq-v1310 ::=	SEQUENCE {
+	carrierFreq-v1310				MeasObjectId-v1310								OPTIONAL
+}
+
+AffectedCarrierFreqCombList-r11 ::=	SEQUENCE (SIZE (1..maxCombIDC-r11)) OF AffectedCarrierFreqComb-r11
+
+AffectedCarrierFreqCombList-r13 ::= SEQUENCE (SIZE (1..maxCombIDC-r11)) OF AffectedCarrierFreqComb-r13
+
+AffectedCarrierFreqComb-r11 ::=	SEQUENCE (SIZE (2..maxServCell-r10)) OF MeasObjectId
+
+AffectedCarrierFreqComb-r13 ::= SEQUENCE (SIZE (2..maxServCell-r13)) OF MeasObjectId-r13
+
+TDM-AssistanceInfo-r11 ::=	CHOICE {
+	drx-AssistanceInfo-r11				SEQUENCE {
+		drx-CycleLength-r11					ENUMERATED {sf40, sf64, sf80, sf128, sf160,
+												sf256, spare2, spare1},
+		drx-Offset-r11						INTEGER (0..255)	OPTIONAL,
+		drx-ActiveTime-r11					ENUMERATED {sf20, sf30, sf40, sf60, sf80,
+												sf100, spare2, spare1}
+	},
+	idc-SubframePatternList-r11			IDC-SubframePatternList-r11,
+	...
+}
+
+IDC-SubframePatternList-r11 ::=	SEQUENCE (SIZE (1..maxSubframePatternIDC-r11)) OF IDC-SubframePattern-r11
+
+IDC-SubframePattern-r11 ::= CHOICE {
+	subframePatternFDD-r11				BIT STRING (SIZE (4)),
+	subframePatternTDD-r11				CHOICE {
+		subframeConfig0-r11					BIT STRING (SIZE (70)),
+		subframeConfig1-5-r11				BIT STRING (SIZE (10)),
+		subframeConfig6-r11					BIT STRING (SIZE (60))
+	},
+	...
+}
+
+VictimSystemType-r11 ::= SEQUENCE {
+	gps-r11							ENUMERATED {true}				OPTIONAL,
+	glonass-r11						ENUMERATED {true}				OPTIONAL,
+	bds-r11							ENUMERATED {true}				OPTIONAL,
+	galileo-r11						ENUMERATED {true}				OPTIONAL,
+	wlan-r11						ENUMERATED {true}				OPTIONAL,
+	bluetooth-r11					ENUMERATED {true}				OPTIONAL
+}
+
+VictimSystemType-v1610 ::= SEQUENCE {
+	navic-r16						ENUMERATED {true}				OPTIONAL
+}
+
+MRDC-AssistanceInfo-r15 ::= SEQUENCE {
+	affectedCarrierFreqCombInfoListMRDC-r15		SEQUENCE (SIZE (1..maxCombIDC-r11)) OF AffectedCarrierFreqCombInfoMRDC-r15,
+	...,
+	[[	affectedCarrierFreqCombInfoListMRDC-v1610		SEQUENCE (SIZE (1..maxCombIDC-r11)) OF VictimSystemType-v1610			OPTIONAL
+	]]
+}
+
+AffectedCarrierFreqCombInfoMRDC-r15 ::= SEQUENCE {
+	victimSystemType-r15					VictimSystemType-r11,
+	interferenceDirectionMRDC-r15			ENUMERATED {eutra-nr, nr, other, eutra-nr-other,
+											nr-other, spare3, spare2, spare1},
+	affectedCarrierFreqCombMRDC-r15		SEQUENCE {
+		affectedCarrierFreqCombEUTRA-r15		AffectedCarrierFreqComb-r15		OPTIONAL,
+		affectedCarrierFreqCombNR-r15			AffectedCarrierFreqCombNR-r15
+	}				OPTIONAL
+}
+
+AffectedCarrierFreqComb-r15 ::= SEQUENCE (SIZE (1..maxServCell-r13)) OF MeasObjectId-r13
+
+AffectedCarrierFreqCombNR-r15 ::= SEQUENCE (SIZE (1..maxServCellNR-r15)) OF ARFCN-ValueNR-r15
+
+
+
+InterFreqRSTDMeasurementIndication-r10 ::=			SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			interFreqRSTDMeasurementIndication-r10	InterFreqRSTDMeasurementIndication-r10-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+InterFreqRSTDMeasurementIndication-r10-IEs ::=		SEQUENCE {
+	rstd-InterFreqIndication-r10		CHOICE {
+		start								SEQUENCE {
+			rstd-InterFreqInfoList-r10				RSTD-InterFreqInfoList-r10
+		},
+		stop								NULL
+	},
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+RSTD-InterFreqInfoList-r10 ::=	SEQUENCE (SIZE(1..maxRSTD-Freq-r10)) OF RSTD-InterFreqInfo-r10
+
+RSTD-InterFreqInfo-r10 ::=		SEQUENCE {
+	carrierFreq-r10					ARFCN-ValueEUTRA,
+	measPRS-Offset-r10				INTEGER (0..39),
+	...,
+	[[	carrierFreq-v1090			ARFCN-ValueEUTRA-v9e0				OPTIONAL
+	]],
+	[[	measPRS-Offset-r15		CHOICE {
+			rstd0-r15				INTEGER (0..79),
+			rstd1-r15				INTEGER (0..159),
+			rstd2-r15				INTEGER (0..319),
+			rstd3-r15				INTEGER (0..639),
+			rstd4-r15				INTEGER (0..1279),
+			rstd5-r15				INTEGER (0..159),
+			rstd6-r15				INTEGER (0..319),
+			rstd7-r15				INTEGER (0..639),
+			rstd8-r15				INTEGER (0..1279),
+			rstd9-r15				INTEGER (0..319),
+			rstd10-r15				INTEGER (0..639),
+			rstd11-r15				INTEGER (0..1279),
+			rstd12-r15				INTEGER (0..319),
+			rstd13-r15				INTEGER (0..639),
+			rstd14-r15				INTEGER (0..1279),
+			rstd15-r15				INTEGER (0..639),
+			rstd16-r15				INTEGER (0..1279),
+			rstd17-r15				INTEGER (0..639),
+			rstd18-r15				INTEGER (0..1279),
+			rstd19-r15				INTEGER (0..639),
+			rstd20-r15				INTEGER (0..1279)
+		}														OPTIONAL
+	]]
+}
+
+
+
+LoggedMeasurementConfiguration-r10 ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			loggedMeasurementConfiguration-r10		LoggedMeasurementConfiguration-r10-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+
+LoggedMeasurementConfiguration-r10-IEs ::= SEQUENCE {		
+	traceReference-r10				TraceReference-r10,
+	traceRecordingSessionRef-r10	OCTET STRING (SIZE (2)),
+	tce-Id-r10						OCTET STRING (SIZE (1)),
+	absoluteTimeInfo-r10			AbsoluteTimeInfo-r10,
+	areaConfiguration-r10			AreaConfiguration-r10		OPTIONAL,	-- Need OR
+	loggingDuration-r10				LoggingDuration-r10,
+	loggingInterval-r10				LoggingInterval-r10,
+	nonCriticalExtension			LoggedMeasurementConfiguration-v1080-IEs	OPTIONAL
+}
+
+LoggedMeasurementConfiguration-v1080-IEs ::= SEQUENCE {
+	lateNonCriticalExtension-r10	OCTET STRING						OPTIONAL,
+	nonCriticalExtension			LoggedMeasurementConfiguration-v1130-IEs	OPTIONAL
+}
+
+LoggedMeasurementConfiguration-v1130-IEs ::= SEQUENCE {
+	plmn-IdentityList-r11			PLMN-IdentityList3-r11		OPTIONAL,	-- Need OR
+	areaConfiguration-v1130			AreaConfiguration-v1130		OPTIONAL,	-- Need OR
+	nonCriticalExtension			LoggedMeasurementConfiguration-v1250-IEs	OPTIONAL
+}
+
+LoggedMeasurementConfiguration-v1250-IEs ::= SEQUENCE {
+	targetMBSFN-AreaList-r12	TargetMBSFN-AreaList-r12		OPTIONAL,	-- Need OP
+	nonCriticalExtension			LoggedMeasurementConfiguration-v1530-IEs					OPTIONAL
+}
+
+LoggedMeasurementConfiguration-v1530-IEs ::= SEQUENCE {
+	bt-NameList-r15					BT-NameList-r15					OPTIONAL,	--Need OR
+	wlan-NameList-r15				WLAN-NameList-r15				OPTIONAL,	--Need OR
+	nonCriticalExtension			SEQUENCE {}						OPTIONAL
+}
+
+TargetMBSFN-AreaList-r12 ::=			SEQUENCE (SIZE (0..maxMBSFN-Area)) OF TargetMBSFN-Area-r12
+
+TargetMBSFN-Area-r12 ::=				SEQUENCE {
+	mbsfn-AreaId-r12					MBSFN-AreaId-r12		OPTIONAL,	-- Need OR
+	carrierFreq-r12						ARFCN-ValueEUTRA-r9,
+	...
+}
+
+
+
+MasterInformationBlock ::=			SEQUENCE {
+	dl-Bandwidth						ENUMERATED {
+											n6, n15, n25, n50, n75, n100},
+	phich-Config						PHICH-Config,
+	systemFrameNumber					BIT STRING (SIZE (8)),
+	schedulingInfoSIB1-BR-r13			INTEGER (0..31),
+	systemInfoUnchanged-BR-r15			BOOLEAN,
+	spare								BIT STRING (SIZE (4))
+}
+
+
+
+
+MasterInformationBlock-MBMS-r14 ::=			SEQUENCE {
+	dl-Bandwidth-MBMS-r14						ENUMERATED {
+												n6, n15, n25, n50, n75, n100},
+	systemFrameNumber-r14						BIT STRING (SIZE (6)),
+	additionalNonMBSFNSubframes-r14				INTEGER (0..3),
+	semiStaticCFI-MBMS-r16						INTEGER (0..3),
+	spare										BIT STRING (SIZE (11))
+}
+
+
+
+MBMSCountingRequest-r10 ::=		SEQUENCE {
+	countingRequestList-r10			CountingRequestList-r10,
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+CountingRequestList-r10 ::=	SEQUENCE (SIZE (1..maxServiceCount)) OF CountingRequestInfo-r10
+
+CountingRequestInfo-r10 ::=		SEQUENCE {
+	tmgi-r10							TMGI-r9,
+	...
+}
+
+
+
+MBMSCountingResponse-r10 ::=			SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			countingResponse-r10				MBMSCountingResponse-r10-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+MBMSCountingResponse-r10-IEs ::=	SEQUENCE {
+	mbsfn-AreaIndex-r10				INTEGER (0..maxMBSFN-Area-1)						OPTIONAL,
+	countingResponseList-r10		CountingResponseList-r10			OPTIONAL,
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+CountingResponseList-r10 ::=		SEQUENCE (SIZE (1..maxServiceCount)) OF CountingResponseInfo-r10
+
+CountingResponseInfo-r10 ::=		SEQUENCE {
+	countingResponseService-r10	INTEGER (0..maxServiceCount-1),
+	...
+}
+
+
+
+MBMSInterestIndication-r11 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			interestIndication-r11				MBMSInterestIndication-r11-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+MBMSInterestIndication-r11-IEs ::=	SEQUENCE {
+	mbms-FreqList-r11					CarrierFreqListMBMS-r11				OPTIONAL,
+	mbms-Priority-r11					ENUMERATED {true}					OPTIONAL,
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				MBMSInterestIndication-v1310-IEs	OPTIONAL
+}
+
+MBMSInterestIndication-v1310-IEs ::=	SEQUENCE {
+	mbms-Services-r13					MBMS-ServiceList-r13				OPTIONAL,
+	nonCriticalExtension				MBMSInterestIndication-v1540-IEs		OPTIONAL
+}
+
+MBMSInterestIndication-v1540-IEs ::=	 SEQUENCE {
+	mbms-ROM-InfoList-r15			SEQUENCE (SIZE(1..maxMBMS-ServiceListPerUE-r13)) OF MBMS-ROM-Info-r15																	OPTIONAL,
+	nonCriticalExtension				MBMSInterestIndication-v1610-IEs	OPTIONAL
+}
+
+MBMSInterestIndication-v1610-IEs ::=	SEQUENCE {
+	mbms-ROM-InfoList-r16				SEQUENCE (SIZE(1..maxMBMS-ServiceListPerUE-r13)) OF MBMS-ROM-Info-r16		OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+MBMS-ROM-Info-r15 ::= SEQUENCE {
+	mbms-ROM-Freq-r15						ARFCN-ValueEUTRA-r9,
+	mbms-ROM-SubcarrierSpacing-r15		ENUMERATED {kHz15, kHz7dot5, kHz1dot25},
+	mbms-Bandwidth-r15					ENUMERATED {n6, n15, n25, n50, n75, n100}
+}
+
+MBMS-ROM-Info-r16 ::= SEQUENCE {
+	mbms-ROM-Freq-r16					ARFCN-ValueEUTRA-r9,
+	mbms-ROM-SubcarrierSpacing-r16		ENUMERATED {kHz2dot5, kHz0dot37},
+	mbms-Bandwidth-r16					ENUMERATED {n6, n15, n25, n50, n75, n100}
+}
+
+
+
+MBSFNAreaConfiguration-r9 ::=		SEQUENCE {
+	commonSF-Alloc-r9					CommonSF-AllocPatternList-r9,
+	commonSF-AllocPeriod-r9				ENUMERATED {
+												rf4, rf8, rf16, rf32, rf64, rf128, rf256},
+	pmch-InfoList-r9					PMCH-InfoList-r9,
+	nonCriticalExtension				MBSFNAreaConfiguration-v930-IEs	OPTIONAL
+}
+
+MBSFNAreaConfiguration-v930-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				MBSFNAreaConfiguration-v1250-IEs	OPTIONAL
+}
+
+MBSFNAreaConfiguration-v1250-IEs ::= SEQUENCE {
+	pmch-InfoListExt-r12				PMCH-InfoListExt-r12				OPTIONAL,	-- Need OR
+	nonCriticalExtension				MBSFNAreaConfiguration-v1430-IEs	OPTIONAL
+}
+
+MBSFNAreaConfiguration-v1430-IEs ::= SEQUENCE {
+	commonSF-Alloc-v1430					CommonSF-AllocPatternList-v1430,
+	nonCriticalExtension				MBSFNAreaConfiguration-v1610-IEs							OPTIONAL
+}
+
+MBSFNAreaConfiguration-v1610-IEs ::= SEQUENCE {
+	commonSF-Alloc-v1610					CommonSF-AllocPatternList-v1610		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+CommonSF-AllocPatternList-r9 ::=	SEQUENCE (SIZE (1..maxMBSFN-Allocations)) OF MBSFN-SubframeConfig
+
+CommonSF-AllocPatternList-v1430 ::=	SEQUENCE (SIZE (1..maxMBSFN-Allocations)) OF MBSFN-SubframeConfig-v1430
+
+CommonSF-AllocPatternList-v1610 ::=	SEQUENCE (SIZE (1..maxMBSFN-Allocations)) OF MBSFN-SubframeConfig-v1610
+
+
+
+MCGFailureInformation-r16 ::=				SEQUENCE {
+	criticalExtensions						CHOICE {
+		mcgFailureInformation					MCGFailureInformation-r16-IEs,
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+MCGFailureInformation-r16-IEs ::=			SEQUENCE {
+	failureReportMCG-r16						FailureReportMCG-r16					OPTIONAL,
+	lateNonCriticalExtension				OCTET STRING						OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}							OPTIONAL
+}
+
+FailureReportMCG-r16 ::=					SEQUENCE {
+	failureType-r16								ENUMERATED {
+												t310-Expiry, randomAccessProblem,
+												rlc-MaxNumRetx, t312-Expiry, spare4,
+												spare3, spare2, spare1}			OPTIONAL,
+	measResultFreqListEUTRA-r16					MeasResultList3EUTRA-r15			OPTIONAL,
+	measResultFreqListNR-r16					MeasResultFreqListFailNR-r15		OPTIONAL,
+	measResultFreqListGERAN-r16					MeasResultList2GERAN-r10			OPTIONAL,
+	measResultFreqListUTRA-r16					MeasResultList2UTRA-r9 				OPTIONAL,
+	measResultSCG-r16							OCTET STRING						OPTIONAL,
+	...
+}
+
+
+MeasReportAppLayer-r15 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		measReportAppLayer-r15				MeasReportAppLayer-r15-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+MeasReportAppLayer-r15-IEs ::=		SEQUENCE {
+	measReportAppLayerContainer-r15		OCTET STRING (SIZE(1..8000))			OPTIONAL,
+	serviceType-r15						ENUMERATED {qoe, qoemtsi, spare6, spare5, spare4, spare3, spare2, spare1}		OPTIONAL,
+	nonCriticalExtension				MeasReportAppLayer-v1590-IEs				OPTIONAL
+}
+
+MeasReportAppLayer-v1590-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+
+
+MeasurementReport ::=				SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			measurementReport-r8				MeasurementReport-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+MeasurementReport-r8-IEs ::=		SEQUENCE {
+	measResults							MeasResults,
+	nonCriticalExtension				MeasurementReport-v8a0-IEs			OPTIONAL
+}
+
+MeasurementReport-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+MobilityFromEUTRACommand ::=		SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			mobilityFromEUTRACommand-r8			MobilityFromEUTRACommand-r8-IEs,
+			mobilityFromEUTRACommand-r9			MobilityFromEUTRACommand-r9-IEs,
+			spare2 NULL, spare1					NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+MobilityFromEUTRACommand-r8-IEs ::=	SEQUENCE {
+	cs-FallbackIndicator				BOOLEAN,
+	purpose								CHOICE{
+		handover							Handover,
+		cellChangeOrder						CellChangeOrder
+	},
+	nonCriticalExtension				MobilityFromEUTRACommand-v8a0-IEs	OPTIONAL
+}
+
+MobilityFromEUTRACommand-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				MobilityFromEUTRACommand-v8d0-IEs	OPTIONAL
+}
+
+MobilityFromEUTRACommand-v8d0-IEs ::= SEQUENCE {
+	bandIndicator						BandIndicatorGERAN			OPTIONAL,	-- Cond GERAN
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+MobilityFromEUTRACommand-r9-IEs ::=	SEQUENCE {
+	cs-FallbackIndicator				BOOLEAN,
+	purpose								CHOICE{
+		handover							Handover,
+		cellChangeOrder						CellChangeOrder,
+		e-CSFB-r9							E-CSFB-r9,
+		...
+	},
+	nonCriticalExtension				MobilityFromEUTRACommand-v930-IEs	OPTIONAL
+}
+
+MobilityFromEUTRACommand-v930-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				MobilityFromEUTRACommand-v960-IEs	OPTIONAL
+}
+
+MobilityFromEUTRACommand-v960-IEs ::= SEQUENCE {
+	bandIndicator					BandIndicatorGERAN					OPTIONAL,	-- Cond GERAN
+	nonCriticalExtension			MobilityFromEUTRACommand-v1530-IEs	OPTIONAL
+}
+
+MobilityFromEUTRACommand-v1530-IEs ::= SEQUENCE {
+	smtc-r15							MTC-SSB-NR-r15				OPTIONAL,		-- Need OP
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+Handover ::=						SEQUENCE {
+	targetRAT-Type						ENUMERATED {
+											utra, geran, cdma2000-1XRTT, cdma2000-HRPD,
+											nr, eutra, spare2, spare1, ...},
+	targetRAT-MessageContainer			OCTET STRING,
+	nas-SecurityParamFromEUTRA			OCTET STRING (SIZE (1))	OPTIONAL,	-- Cond UTRAGERANEPC
+	systemInformation					SI-OrPSI-GERAN				OPTIONAL	-- Cond PSHO
+}
+
+CellChangeOrder ::=				SEQUENCE {
+	t304								ENUMERATED {
+											ms100, ms200, ms500, ms1000,
+											ms2000, ms4000, ms8000, ms10000-v1310},
+	targetRAT-Type						CHOICE {
+			geran							SEQUENCE {
+				physCellId						PhysCellIdGERAN,
+				carrierFreq						CarrierFreqGERAN,
+				networkControlOrder				BIT STRING (SIZE (2))		OPTIONAL,	-- Need OP
+				systemInformation				SI-OrPSI-GERAN				OPTIONAL	-- Need OP
+			},
+			...
+	}
+}
+
+SI-OrPSI-GERAN ::=					CHOICE {
+	si									SystemInfoListGERAN,
+	psi									SystemInfoListGERAN
+}
+
+E-CSFB-r9 ::=						SEQUENCE {
+	messageContCDMA2000-1XRTT-r9		OCTET STRING		OPTIONAL,	-- Need ON
+	mobilityCDMA2000-HRPD-r9			ENUMERATED {
+											handover, redirection
+										}					OPTIONAL,	-- Need OP
+	messageContCDMA2000-HRPD-r9		OCTET STRING			OPTIONAL,	-- Cond concHO
+	redirectCarrierCDMA2000-HRPD-r9	CarrierFreqCDMA2000		OPTIONAL	-- Cond concRedir
+}
+
+
+
+Paging ::=					SEQUENCE {
+	pagingRecordList				PagingRecordList					OPTIONAL,	-- Need ON
+	systemInfoModification			ENUMERATED {true}					OPTIONAL,	-- Need ON
+	etws-Indication					ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension			Paging-v890-IEs						OPTIONAL
+}
+
+Paging-v890-IEs ::=			SEQUENCE {
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			Paging-v920-IEs						OPTIONAL
+}
+
+Paging-v920-IEs ::=			SEQUENCE {
+	cmas-Indication-r9				ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension			Paging-v1130-IEs					OPTIONAL
+}
+
+Paging-v1130-IEs ::=			SEQUENCE {
+	eab-ParamModification-r11		ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension			Paging-v1310-IEs					OPTIONAL
+}
+
+Paging-v1310-IEs ::=			SEQUENCE {
+	redistributionIndication-r13	ENUMERATED {true}					OPTIONAL,	-- Need ON
+	systemInfoModification-eDRX-r13	ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension			Paging-v1530-IEs					OPTIONAL
+}
+
+Paging-v1530-IEs ::=			SEQUENCE {
+	accessType						ENUMERATED {non3GPP}				OPTIONAL,	-- Need ON
+	nonCriticalExtension			Paging-v1610-IEs					OPTIONAL
+}
+
+Paging-v1610-IEs ::=			SEQUENCE {
+	pagingRecordList-v1610			PagingRecordList-v1610				OPTIONAL,	-- Need ON
+	uac-ParamModification-r16		ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+PagingRecordList ::=				SEQUENCE (SIZE (1..maxPageRec)) OF PagingRecord
+
+PagingRecordList-v1610 ::=			SEQUENCE (SIZE (1..maxPageRec)) OF PagingRecord-v1610
+
+PagingRecord ::=					SEQUENCE {
+	ue-Identity							PagingUE-Identity,
+	cn-Domain							ENUMERATED	{ps, cs},
+	...
+}
+
+PagingRecord-v1610 ::=				SEQUENCE {
+	accessType-r16						ENUMERATED {non3GPP}			OPTIONAL,		-- Need ON
+	mt-EDT-r16							ENUMERATED {true}				OPTIONAL		-- Need ON
+}
+
+PagingUE-Identity ::=				CHOICE {
+	s-TMSI								S-TMSI,
+	imsi								IMSI,
+	...,
+	ng-5G-S-TMSI-r15					NG-5G-S-TMSI-r15,
+	fullI-RNTI-r15						I-RNTI-r15
+}
+
+IMSI ::=							SEQUENCE (SIZE (6..21)) OF IMSI-Digit
+
+IMSI-Digit ::=						INTEGER (0..9)
+
+
+
+ProximityIndication-r9 ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			proximityIndication-r9				ProximityIndication-r9-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+			},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+ProximityIndication-r9-IEs ::= SEQUENCE {
+	type-r9								ENUMERATED {entering, leaving},
+	carrierFreq-r9						CHOICE {
+		eutra-r9							ARFCN-ValueEUTRA,
+		utra-r9								ARFCN-ValueUTRA,
+		...,
+		eutra2-v9e0							ARFCN-ValueEUTRA-v9e0
+	},
+	nonCriticalExtension				ProximityIndication-v930-IEs							OPTIONAL
+}
+
+ProximityIndication-v930-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+PURConfigurationRequest-r16 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		purConfigurationRequest				PURConfigurationRequest-r16-IEs,
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+PURConfigurationRequest-r16-IEs ::=	SEQUENCE {
+	pur-ConfigRequest-r16				CHOICE {
+		pur-ReleaseRequest					NULL,
+		pur-SetupRequest					SEQUENCE {
+			requestedNumOccasions-r16			ENUMERATED {one, infinite},
+			requestedPeriodicityAndOffset-r16	PUR-PeriodicityAndOffset-r16 	OPTIONAL,
+			requestedTBS-r16					ENUMERATED {b328, b344, b376, b392, b408,
+													b424, b440, b456, b472, b488, b504, b536,
+													b568, b584, b616, b648, b680, b712, b744,
+													b776, b808, b840, b872, b904, b936, b968,
+													b1000, b1032, b1064, b1096, b1128, b1160,
+													b1192, b1224, b1256, b1288, b1320, b1352,
+													b1384, b1416, b1480, b1544, b1608, b1672,
+													b1736, b1800, b1864, b1928, b1992, b2024,
+													b2088, b2152, b2216, b2280, b2344, b2408,
+													b2472, b2536, b2600, b2664, b2728, b2792,
+													b2856, b2984},
+			rrc-ACK-r16							ENUMERATED {true}			OPTIONAL
+		}
+	}																		OPTIONAL,
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+RNReconfiguration-r10 ::=		SEQUENCE {
+	rrc-TransactionIdentifier		RRC-TransactionIdentifier,
+	criticalExtensions				CHOICE {
+		c1								CHOICE {
+			rnReconfiguration-r10		RNReconfiguration-r10-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture		SEQUENCE {}
+	}
+}
+
+RNReconfiguration-r10-IEs ::=		SEQUENCE {
+	rn-SystemInfo-r10					RN-SystemInfo-r10				OPTIONAL,	-- Need ON
+	rn-SubframeConfig-r10				RN-SubframeConfig-r10			OPTIONAL,	-- Need ON
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+RN-SystemInfo-r10 ::=			SEQUENCE {
+	systemInformationBlockType1-r10		OCTET STRING (CONTAINING SystemInformationBlockType1)	OPTIONAL,	-- Need ON
+	systemInformationBlockType2-r10		SystemInformationBlockType2		OPTIONAL,	-- Need ON
+	...
+}
+
+
+
+RNReconfigurationComplete-r10 ::=		SEQUENCE {
+	rrc-TransactionIdentifier				RRC-TransactionIdentifier,
+	criticalExtensions						CHOICE {
+		c1										CHOICE{
+			rnReconfigurationComplete-r10			RNReconfigurationComplete-r10-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+RNReconfigurationComplete-r10-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}					OPTIONAL
+}
+
+
+
+RRCConnectionReconfiguration ::=	SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			rrcConnectionReconfiguration-r8		RRCConnectionReconfiguration-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReconfiguration-r8-IEs ::= SEQUENCE {
+	measConfig							MeasConfig						OPTIONAL,	-- Need ON
+	mobilityControlInfo					MobilityControlInfo				OPTIONAL,	-- Cond HO
+	dedicatedInfoNASList				SEQUENCE (SIZE(1..maxDRB)) OF
+											DedicatedInfoNAS			OPTIONAL,	-- Cond nonHO
+	radioResourceConfigDedicated		RadioResourceConfigDedicated	OPTIONAL, -- Cond HO-toEUTRA
+	securityConfigHO					SecurityConfigHO				OPTIONAL,	-- Cond HO-toEPC
+	nonCriticalExtension				RRCConnectionReconfiguration-v890-IEs	OPTIONAL
+}
+
+RRCConnectionReconfiguration-v890-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING RRCConnectionReconfiguration-v8m0-IEs)	OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfiguration-v920-IEs	OPTIONAL
+}
+
+-- Late non-critical extensions:
+RRCConnectionReconfiguration-v8m0-IEs ::= SEQUENCE {
+	-- Following field is only for pre REL-10 late non-critical extensions
+	lateNonCriticalExtension			OCTET STRING								OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfiguration-v10i0-IEs	OPTIONAL
+}
+
+RRCConnectionReconfiguration-v10i0-IEs ::= SEQUENCE {
+	antennaInfoDedicatedPCell-v10i0	AntennaInfoDedicated-v10i0		OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionReconfiguration-v10l0-IEs		OPTIONAL
+}
+
+RRCConnectionReconfiguration-v10l0-IEs ::= SEQUENCE {
+	mobilityControlInfo-v10l0			MobilityControlInfo-v10l0			OPTIONAL,
+	sCellToAddModList-v10l0			SCellToAddModList-v10l0			OPTIONAL,	-- Need ON
+	-- Following field is only for late non-critical extensions from REL-10 to REL-11
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfiguration-v12f0-IEs		OPTIONAL
+}
+
+RRCConnectionReconfiguration-v12f0-IEs ::= SEQUENCE {
+	scg-Configuration-v12f0			SCG-Configuration-v12f0		OPTIONAL,	-- Cond nonFullConfig
+	-- Following field is only for late non-critical extensions from REL-12
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfiguration-v1370-IEs		OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1370-IEs ::= SEQUENCE {
+	radioResourceConfigDedicated-v1370	RadioResourceConfigDedicated-v1370	OPTIONAL, -- Need ON
+	sCellToAddModListExt-v1370			SCellToAddModListExt-v1370	OPTIONAL,	-- Need ON
+	nonCriticalExtension					RRCConnectionReconfiguration-v13c0-IEs	OPTIONAL
+}
+
+RRCConnectionReconfiguration-v13c0-IEs ::= SEQUENCE {
+	radioResourceConfigDedicated-v13c0	RadioResourceConfigDedicated-v13c0	OPTIONAL, -- Need ON
+	sCellToAddModList-v13c0				SCellToAddModList-v13c0		OPTIONAL,	-- Need ON
+	sCellToAddModListExt-v13c0			SCellToAddModListExt-v13c0	OPTIONAL,	-- Need ON
+	scg-Configuration-v13c0				SCG-Configuration-v13c0		OPTIONAL,	-- Need ON
+	-- Following field is only for late non-critical extensions from REL-13 onwards
+	nonCriticalExtension					SEQUENCE {}					OPTIONAL
+}
+
+-- Regular non-critical extensions:
+RRCConnectionReconfiguration-v920-IEs ::= SEQUENCE {
+	otherConfig-r9						OtherConfig-r9				OPTIONAL,	-- Need ON
+	fullConfig-r9						ENUMERATED {true}			OPTIONAL,	-- Cond HO-Reestab
+	nonCriticalExtension				RRCConnectionReconfiguration-v1020-IEs	OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1020-IEs ::= SEQUENCE {
+	sCellToReleaseList-r10			SCellToReleaseList-r10			OPTIONAL,	-- Need ON
+	sCellToAddModList-r10				SCellToAddModList-r10				OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionReconfiguration-v1130-IEs	OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1130-IEs ::= SEQUENCE {
+	systemInformationBlockType1Dedicated-r11	OCTET STRING (CONTAINING SystemInformationBlockType1)																			OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionReconfiguration-v1250-IEs	OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1250-IEs ::= SEQUENCE {
+	wlan-OffloadInfo-r12				CHOICE {
+		release								NULL,
+		setup									SEQUENCE {
+			wlan-OffloadConfigDedicated-r12		WLAN-OffloadConfig-r12,
+			t350-r12								ENUMERATED {min5, min10, min20, min30, min60,
+												min120, min180, spare1}	OPTIONAL	-- Need OR
+		}
+	}																	OPTIONAL,		-- Need ON
+	scg-Configuration-r12				SCG-Configuration-r12		OPTIONAL,	-- Cond nonFullConfig
+	sl-SyncTxControl-r12				SL-SyncTxControl-r12			OPTIONAL,	-- Need ON
+	sl-DiscConfig-r12					SL-DiscConfig-r12				OPTIONAL,	-- Need ON
+	sl-CommConfig-r12					SL-CommConfig-r12				OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionReconfiguration-v1310-IEs	OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1310-IEs ::= SEQUENCE {
+	sCellToReleaseListExt-r13			SCellToReleaseListExt-r13		OPTIONAL,	-- Need ON
+	sCellToAddModListExt-r13			SCellToAddModListExt-r13		OPTIONAL,	-- Need ON
+	lwa-Configuration-r13				LWA-Configuration-r13			OPTIONAL,	-- Need ON
+	lwip-Configuration-r13				LWIP-Configuration-r13			OPTIONAL,	-- Need ON
+	rclwi-Configuration-r13				RCLWI-Configuration-r13			OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionReconfiguration-v1430-IEs						OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1430-IEs ::= SEQUENCE {
+	sl-V2X-ConfigDedicated-r14		SL-V2X-ConfigDedicated-r14		OPTIONAL,	-- Need ON
+	sCellToAddModListExt-v1430		SCellToAddModListExt-v1430		OPTIONAL,	-- Need ON
+	perCC-GapIndicationRequest-r14	ENUMERATED{true}					OPTIONAL,	-- Need ON
+	systemInformationBlockType2Dedicated-r14	OCTET STRING (CONTAINING SystemInformationBlockType2)											OPTIONAL,	-- Cond nonHO
+	nonCriticalExtension			RRCConnectionReconfiguration-v1510-IEs		OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1510-IEs ::= SEQUENCE {
+	nr-Config-r15					CHOICE {
+		release							NULL,
+		setup							SEQUENCE {
+			endc-ReleaseAndAdd-r15	BOOLEAN,
+			nr-SecondaryCellGroupConfig-r15	OCTET STRING				OPTIONAL,	-- Need ON
+			p-MaxEUTRA-r15					P-Max						OPTIONAL	-- Need ON
+		}
+	}																	OPTIONAL,	-- Need ON
+	sk-Counter-r15					INTEGER (0.. 65535)					OPTIONAL,	-- Need ON
+	nr-RadioBearerConfig1-r15		OCTET STRING						OPTIONAL,	-- Need ON
+	nr-RadioBearerConfig2-r15		OCTET STRING						OPTIONAL,	-- Need ON
+	tdm-PatternConfig-r15			TDM-PatternConfig-r15			OPTIONAL,	-- Cond FDD-PCell
+	nonCriticalExtension			RRCConnectionReconfiguration-v1530-IEs		OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1530-IEs ::= SEQUENCE {
+	securityConfigHO-v1530				SecurityConfigHO-v1530			OPTIONAL,	-- Cond HO-5GC
+	sCellGroupToReleaseList-r15		SCellGroupToReleaseList-r15			OPTIONAL,	-- Need ON
+	sCellGroupToAddModList-r15		SCellGroupToAddModList-r15			OPTIONAL,	-- Need ON
+	dedicatedInfoNASList-r15		SEQUENCE (SIZE(1..maxDRB-r15)) OF
+											DedicatedInfoNAS			OPTIONAL,	-- Cond nonHO
+	p-MaxUE-FR1-r15					P-Max								OPTIONAL,	-- Need OR
+	smtc-r15						MTC-SSB-NR-r15						OPTIONAL,	-- Need OP
+	nonCriticalExtension			RRCConnectionReconfiguration-v1610-IEs		OPTIONAL
+}
+
+RRCConnectionReconfiguration-v1610-IEs ::= SEQUENCE {
+	conditionalReconfiguration-r16			ConditionalReconfiguration-r16	OPTIONAL, -- Need ON
+	daps-SourceRelease-r16					ENUMERATED{true}				OPTIONAL, -- Need ON
+	tdm-PatternConfig2-r16						TDM-PatternConfig-r15			OPTIONAL, -- Need ON
+	sl-ConfigDedicatedForNR-r16					OCTET STRING					OPTIONAL, -- Need OR
+	sl-SSB-PriorityEUTRA-r16					INTEGER (1..8)					OPTIONAL, -- Need OR
+	nonCriticalExtension						SEQUENCE {}						OPTIONAL
+}
+
+SL-SyncTxControl-r12 ::=			SEQUENCE {
+	networkControlledSyncTx-r12				ENUMERATED {on, off}		OPTIONAL	-- Need OP
+}
+
+PSCellToAddMod-r12 ::=				SEQUENCE {
+	sCellIndex-r12						SCellIndex-r10,
+	cellIdentification-r12				SEQUENCE {
+		physCellId-r12						PhysCellId,
+		dl-CarrierFreq-r12					ARFCN-ValueEUTRA-r9
+	}																	OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigCommonPSCell-r12		RadioResourceConfigCommonPSCell-r12	OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigDedicatedPSCell-r12	RadioResourceConfigDedicatedPSCell-r12	OPTIONAL,	-- Cond SCellAdd2
+	...,
+	[[	antennaInfoDedicatedPSCell-v1280		AntennaInfoDedicated-v10i0	OPTIONAL	-- Need ON
+	]],
+	[[	sCellIndex-r13					SCellIndex-r13	OPTIONAL		-- Need ON
+	]],
+	[[	radioResourceConfigDedicatedPSCell-v1370	RadioResourceConfigDedicatedPSCell-v1370	OPTIONAL	-- Need ON
+	]],
+	[[	radioResourceConfigDedicatedPSCell-v13c0	RadioResourceConfigDedicatedPSCell-v13c0	OPTIONAL	-- Need ON
+	]]
+}
+
+PSCellToAddMod-v12f0 ::=				SEQUENCE {
+	radioResourceConfigCommonPSCell-r12		RadioResourceConfigCommonPSCell-v12f0	OPTIONAL
+}
+
+PSCellToAddMod-v1440 ::=				SEQUENCE {
+	radioResourceConfigCommonPSCell-r14		RadioResourceConfigCommonPSCell-v1440	OPTIONAL
+}
+
+PowerCoordinationInfo-r12 ::= SEQUENCE {
+	p-MeNB-r12							INTEGER (1..16),
+	p-SeNB-r12							INTEGER (1..16),
+	powerControlMode-r12				INTEGER (1..2)
+}
+
+SCellToAddModList-r10 ::=		SEQUENCE (SIZE (1..maxSCell-r10)) OF SCellToAddMod-r10
+
+SCellToAddModList-v10l0 ::=		SEQUENCE (SIZE (1..maxSCell-r10)) OF SCellToAddMod-v10l0
+
+SCellToAddModList-v13c0 ::=		SEQUENCE (SIZE (1..maxSCell-r10)) OF SCellToAddMod-v13c0
+
+SCellToAddModList-r16 ::=		SEQUENCE (SIZE (1..maxSCell-r13)) OF SCellToAddMod-r16
+
+SCellToAddModListExt-r13 ::=	SEQUENCE (SIZE (1..maxSCell-r13)) OF SCellToAddModExt-r13
+
+SCellToAddModListExt-v1370 ::=	SEQUENCE (SIZE (1..maxSCell-r13)) OF SCellToAddModExt-v1370
+
+SCellToAddModListExt-v13c0 ::=	SEQUENCE (SIZE (1..maxSCell-r13)) OF SCellToAddMod-v13c0
+
+SCellToAddModListExt-v1430 ::=	SEQUENCE (SIZE (1..maxSCell-r13)) OF SCellToAddModExt-v1430
+
+SCellGroupToAddModList-r15 ::=	SEQUENCE (SIZE (1..maxSCellGroups-r15)) OF SCellGroupToAddMod-r15
+
+SCellToAddMod-r10 ::=			SEQUENCE {
+	sCellIndex-r10						SCellIndex-r10,
+	cellIdentification-r10				SEQUENCE {
+		physCellId-r10						PhysCellId,
+		dl-CarrierFreq-r10					ARFCN-ValueEUTRA
+	}																OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigCommonSCell-r10		RadioResourceConfigCommonSCell-r10	OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigDedicatedSCell-r10	RadioResourceConfigDedicatedSCell-r10	OPTIONAL,	-- Cond SCellAdd2
+	...,
+	[[	dl-CarrierFreq-v1090				ARFCN-ValueEUTRA-v9e0	OPTIONAL	-- Cond EARFCN-max
+	]],
+	[[	antennaInfoDedicatedSCell-v10i0		AntennaInfoDedicated-v10i0	OPTIONAL	-- Need ON
+	]],
+	[[	srs-SwitchFromServCellIndex-r14		INTEGER (0.. 31) OPTIONAL	-- Need ON
+	]],
+	[[	sCellState-r15						ENUMERATED {activated, dormant}	OPTIONAL	-- Need ON
+	]]
+}
+
+SCellToAddMod-v10l0 ::=			SEQUENCE {
+	radioResourceConfigCommonSCell-v10l0		RadioResourceConfigCommonSCell-v10l0	OPTIONAL
+}
+
+SCellToAddMod-v13c0 ::=			SEQUENCE {
+	radioResourceConfigDedicatedSCell-v13c0	RadioResourceConfigDedicatedSCell-v13c0	OPTIONAL
+}
+
+SCellToAddMod-r16 ::=			SEQUENCE {
+	sCellIndex-r16						SCellIndex-r13,
+	cellIdentification-r16				SEQUENCE {
+		physCellId-r16						PhysCellId,
+		dl-CarrierFreq-r16					ARFCN-ValueEUTRA-r9
+	}																OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigCommonSCell-r16		RadioResourceConfigCommonSCell-r10	OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigDedicatedSCell-r16	RadioResourceConfigDedicatedSCell-r10	OPTIONAL,	-- Cond SCellAdd2
+	antennaInfoDedicatedSCell-r16		AntennaInfoDedicated-v10i0	OPTIONAL,	-- Need ON
+	srs-SwitchFromServCellIndex-r16			INTEGER (0.. 31) OPTIONAL,	-- Need ON
+	sCellState-r16							ENUMERATED {activated, dormant}	OPTIONAL, 	-- Need ON
+	...
+}
+
+SCellToAddModExt-r13 ::=			SEQUENCE {
+	sCellIndex-r13						SCellIndex-r13,
+	cellIdentification-r13				SEQUENCE {
+		physCellId-r13						PhysCellId,
+		dl-CarrierFreq-r13					ARFCN-ValueEUTRA-r9
+	}																OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigCommonSCell-r13		RadioResourceConfigCommonSCell-r10	OPTIONAL,	-- Cond SCellAdd
+	radioResourceConfigDedicatedSCell-r13	RadioResourceConfigDedicatedSCell-r10	OPTIONAL,	-- Cond SCellAdd2
+	antennaInfoDedicatedSCell-r13			AntennaInfoDedicated-v10i0		OPTIONAL	-- Need ON
+}
+
+SCellToAddModExt-v1370 ::=			SEQUENCE {
+	radioResourceConfigCommonSCell-v1370		RadioResourceConfigCommonSCell-v10l0	OPTIONAL
+}
+
+SCellToAddModExt-v1430 ::=			SEQUENCE {
+	srs-SwitchFromServCellIndex-r14			INTEGER (0.. 31)			OPTIONAL,	-- Need ON
+	...,
+	[[	sCellState-r15					ENUMERATED {activated, dormant}		OPTIONAL	-- Need ON
+	]]
+}
+
+SCellGroupToAddMod-r15 ::=			SEQUENCE {
+	sCellGroupIndex-r15					SCellGroupIndex-r15,
+	sCellConfigCommon-r15				SCellConfigCommon-r15			OPTIONAL,	-- Need ON
+	sCellToReleaseList-r15				SCellToReleaseListExt-r13		OPTIONAL,	-- Need ON
+	sCellToAddModList-r15				SCellToAddModListExt-r13		OPTIONAL	-- Need ON
+}
+
+SCellToReleaseList-r10 ::=			SEQUENCE (SIZE (1..maxSCell-r10)) OF SCellIndex-r10
+
+SCellToReleaseListExt-r13 ::=			SEQUENCE (SIZE (1..maxSCell-r13)) OF SCellIndex-r13
+
+SCellGroupToReleaseList-r15 ::=			SEQUENCE (SIZE (1..maxSCellGroups-r15)) OF SCellGroupIndex-r15
+
+SCellGroupIndex-r15 ::=			INTEGER (1..maxSCellGroups-r15)
+
+SCellConfigCommon-r15 ::= SEQUENCE {
+	radioResourceConfigCommonSCell-r15		RadioResourceConfigCommonSCell-r10	OPTIONAL,	-- Need ON
+	radioResourceConfigDedicatedSCell-r15	RadioResourceConfigDedicatedSCell-r10	OPTIONAL,-- Need ON
+	antennaInfoDedicatedSCell-r15			AntennaInfoDedicated-v10i0		OPTIONAL	-- Need ON
+}
+
+SCG-Configuration-r12 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		scg-ConfigPartMCG-r12				SEQUENCE {
+			scg-Counter-r12						INTEGER (0.. 65535)			OPTIONAL,	-- Need ON
+			powerCoordinationInfo-r12			PowerCoordinationInfo-r12	OPTIONAL,	-- Need ON
+			...
+		}																OPTIONAL,	-- Need ON
+		scg-ConfigPartSCG-r12				SCG-ConfigPartSCG-r12		OPTIONAL	-- Need ON
+	}
+}
+
+SCG-Configuration-v12f0 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		scg-ConfigPartSCG-v12f0				SCG-ConfigPartSCG-v12f0		OPTIONAL	-- Need ON
+	}
+}
+
+SCG-Configuration-v13c0 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		scg-ConfigPartSCG-v13c0				SCG-ConfigPartSCG-v13c0		OPTIONAL	-- Need ON
+	}
+}
+
+SCG-ConfigPartSCG-r12 ::=			SEQUENCE {
+	radioResourceConfigDedicatedSCG-r12	RadioResourceConfigDedicatedSCG-r12	OPTIONAL,	-- Need ON
+	sCellToReleaseListSCG-r12			SCellToReleaseList-r10		OPTIONAL,	-- Need ON
+	pSCellToAddMod-r12					PSCellToAddMod-r12			OPTIONAL,	-- Need ON
+	sCellToAddModListSCG-r12			SCellToAddModList-r10		OPTIONAL,	-- Need ON
+	mobilityControlInfoSCG-r12			MobilityControlInfoSCG-r12	OPTIONAL,	-- Need ON
+	...,
+	[[
+	sCellToReleaseListSCG-Ext-r13			SCellToReleaseListExt-r13		OPTIONAL,	-- Need ON
+	sCellToAddModListSCG-Ext-r13			SCellToAddModListExt-r13		OPTIONAL	-- Need ON
+	]],
+	[[
+	sCellToAddModListSCG-Ext-v1370		SCellToAddModListExt-v1370	OPTIONAL	-- Need ON
+	]],
+	[[
+	pSCellToAddMod-v1440				PSCellToAddMod-v1440		OPTIONAL	-- Need ON
+	]],
+	[[	sCellGroupToReleaseListSCG-r15	SCellGroupToReleaseList-r15	OPTIONAL,	-- Need ON
+		sCellGroupToAddModListSCG-r15	SCellGroupToAddModList-r15	OPTIONAL	-- Need ON
+	]],
+	[[	-- NE-DC addition for setup/ modification and release SN configured measurements
+		measConfigSN-r15				MeasConfig						OPTIONAL,	-- Need ON
+		-- NE-DC additions concerning DRBs/ SRBs are within RadioResourceConfigDedicatedSCG
+		tdm-PatternConfigNE-DC-r15		TDM-PatternConfig-r15			OPTIONAL	-- Cond FDD-PSCell
+	]],
+	[[	p-MaxEUTRA-r15					P-Max							OPTIONAL	-- Need ON
+	]]
+}
+
+SCG-ConfigPartSCG-v12f0 ::=			SEQUENCE {
+	pSCellToAddMod-v12f0				PSCellToAddMod-v12f0		OPTIONAL,	-- Need ON
+	sCellToAddModListSCG-v12f0			SCellToAddModList-v10l0		OPTIONAL	-- Need ON
+}
+
+SCG-ConfigPartSCG-v13c0 ::=			SEQUENCE {
+	sCellToAddModListSCG-v13c0			SCellToAddModList-v13c0		OPTIONAL,	-- Need ON
+	sCellToAddModListSCG-Ext-v13c0		SCellToAddModListExt-v13c0	OPTIONAL	-- Need ON
+}
+
+SecurityConfigHO ::=				SEQUENCE {
+	handoverType						CHOICE {
+		intraLTE							SEQUENCE {
+			securityAlgorithmConfig				SecurityAlgorithmConfig		OPTIONAL,	-- Cond fullConfig
+			keyChangeIndicator					BOOLEAN,
+			nextHopChainingCount				NextHopChainingCount
+		},
+		interRAT							SEQUENCE {
+			securityAlgorithmConfig				SecurityAlgorithmConfig,
+			nas-SecurityParamToEUTRA			OCTET STRING (SIZE(6))
+		}
+	},
+	...
+}
+
+SecurityConfigHO-v1530 ::=		SEQUENCE {
+	handoverType-v1530				CHOICE {
+		intra5GC-r15						SEQUENCE {
+			securityAlgorithmConfig-r15			SecurityAlgorithmConfig		OPTIONAL,	-- Cond HO-toEUTRA
+			keyChangeIndicator-r15				BOOLEAN,
+			nextHopChainingCount-r15			NextHopChainingCount,
+			nas-Container-r15					OCTET STRING	OPTIONAL	-- Need ON
+		},
+		fivegc-ToEPC-r15					SEQUENCE {
+			securityAlgorithmConfig-r15			SecurityAlgorithmConfig,
+			nextHopChainingCount-r15			NextHopChainingCount
+		},
+		epc-To5GC-r15					SEQUENCE {
+			securityAlgorithmConfig-r15		SecurityAlgorithmConfig,
+			nas-Container-r15				OCTET STRING
+		}
+	},
+	...
+}
+
+
+
+RRCConnectionReconfigurationComplete ::= SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		rrcConnectionReconfigurationComplete-r8
+											RRCConnectionReconfigurationComplete-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReconfigurationComplete-r8-IEs ::= SEQUENCE {
+	nonCriticalExtension				RRCConnectionReconfigurationComplete-v8a0-IEs	OPTIONAL
+}
+
+RRCConnectionReconfigurationComplete-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfigurationComplete-v1020-IEs	OPTIONAL
+}
+
+RRCConnectionReconfigurationComplete-v1020-IEs ::= SEQUENCE {
+	rlf-InfoAvailable-r10				ENUMERATED {true}				OPTIONAL,
+	logMeasAvailable-r10				ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfigurationComplete-v1130-IEs	OPTIONAL
+}
+
+RRCConnectionReconfigurationComplete-v1130-IEs ::= SEQUENCE {
+	connEstFailInfoAvailable-r11		ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfigurationComplete-v1250-IEs	OPTIONAL
+}
+
+RRCConnectionReconfigurationComplete-v1250-IEs ::= SEQUENCE {
+	logMeasAvailableMBSFN-r12			ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfigurationComplete-v1430-IEs						OPTIONAL
+}
+
+RRCConnectionReconfigurationComplete-v1430-IEs ::= SEQUENCE {
+	perCC-GapIndicationList-r14			PerCC-GapIndicationList-r14		OPTIONAL,
+	numFreqEffective-r14				INTEGER (1..12)					OPTIONAL,
+	numFreqEffectiveReduced-r14			INTEGER (1..12)					OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfigurationComplete-v1510-IEs						OPTIONAL
+}
+
+RRCConnectionReconfigurationComplete-v1510-IEs ::= SEQUENCE {
+	scg-ConfigResponseNR-r15			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				RRCConnectionReconfigurationComplete-v1530-IEs						OPTIONAL
+}
+
+RRCConnectionReconfigurationComplete-v1530-IEs ::= SEQUENCE {
+	logMeasAvailableBT-r15				ENUMERATED {true}				OPTIONAL,
+	logMeasAvailableWLAN-r15			ENUMERATED {true}				OPTIONAL,
+	flightPathInfoAvailable-r15			ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+
+
+RRCConnectionReestablishment ::=	SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			rrcConnectionReestablishment-r8		RRCConnectionReestablishment-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4	NULL,
+			spare3 NULL, spare2 NULL, spare1	NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReestablishment-r8-IEs ::= SEQUENCE {
+	radioResourceConfigDedicated		RadioResourceConfigDedicated,
+	nextHopChainingCount				NextHopChainingCount,
+	nonCriticalExtension				RRCConnectionReestablishment-v8a0-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishment-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+RRCConnectionReestablishmentComplete ::= SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		rrcConnectionReestablishmentComplete-r8
+											RRCConnectionReestablishmentComplete-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReestablishmentComplete-r8-IEs ::= SEQUENCE {
+	nonCriticalExtension				RRCConnectionReestablishmentComplete-v920-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-v920-IEs ::= SEQUENCE {
+	rlf-InfoAvailable-r9				ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionReestablishmentComplete-v8a0-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				RRCConnectionReestablishmentComplete-v1020-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-v1020-IEs ::= SEQUENCE {
+	logMeasAvailable-r10				ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionReestablishmentComplete-v1130-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-v1130-IEs ::= SEQUENCE {
+	connEstFailInfoAvailable-r11		ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionReestablishmentComplete-v1250-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-v1250-IEs ::= SEQUENCE {
+	logMeasAvailableMBSFN-r12			ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionReestablishmentComplete-v1530-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-v1530-IEs ::= SEQUENCE {
+	logMeasAvailableBT-r15				ENUMERATED {true}				OPTIONAL,
+	logMeasAvailableWLAN-r15			ENUMERATED {true}				OPTIONAL,
+	flightPathInfoAvailable-r15			ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+
+
+RRCConnectionReestablishmentReject ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcConnectionReestablishmentReject-r8
+											RRCConnectionReestablishmentReject-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReestablishmentReject-r8-IEs ::= SEQUENCE {
+	nonCriticalExtension				RRCConnectionReestablishmentReject-v8a0-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentReject-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+RRCConnectionReestablishmentRequest ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcConnectionReestablishmentRequest-r8
+											RRCConnectionReestablishmentRequest-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReestablishmentRequest-r8-IEs ::= SEQUENCE {
+	ue-Identity							ReestabUE-Identity,
+	reestablishmentCause				ReestablishmentCause,
+	spare								BIT STRING (SIZE (2))
+}
+
+ReestabUE-Identity ::=				SEQUENCE {
+	c-RNTI								C-RNTI,
+	physCellId							PhysCellId,
+	shortMAC-I							ShortMAC-I
+}
+
+ReestablishmentCause ::=			ENUMERATED {
+										reconfigurationFailure, handoverFailure,
+										otherFailure, spare1
+}
+
+
+
+RRCConnectionReject ::=				SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			rrcConnectionReject-r8				RRCConnectionReject-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReject-r8-IEs ::=		SEQUENCE {
+	waitTime							INTEGER (1..16),
+	nonCriticalExtension				RRCConnectionReject-v8a0-IEs		OPTIONAL
+}
+
+RRCConnectionReject-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				RRCConnectionReject-v1020-IEs		OPTIONAL
+}
+
+RRCConnectionReject-v1020-IEs ::=	SEQUENCE {
+	extendedWaitTime-r10				INTEGER (1..1800)					OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionReject-v1130-IEs		OPTIONAL
+}
+
+RRCConnectionReject-v1130-IEs ::=	SEQUENCE {
+	deprioritisationReq-r11				SEQUENCE {
+		deprioritisationType-r11			ENUMERATED {frequency, e-utra},
+		deprioritisationTimer-r11			ENUMERATED {min5, min10, min15, min30}
+	}																		OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionReject-v1320-IEs							OPTIONAL
+}
+
+RRCConnectionReject-v1320-IEs ::=	SEQUENCE {
+	rrc-SuspendIndication-r13				ENUMERATED {true}				OPTIONAL,	--	Need ON
+	nonCriticalExtension					SEQUENCE {}						OPTIONAL
+}
+
+
+
+RRCConnectionRelease ::=			SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			rrcConnectionRelease-r8				RRCConnectionRelease-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionRelease-r8-IEs ::=		SEQUENCE {
+	releaseCause						ReleaseCause,
+	redirectedCarrierInfo				RedirectedCarrierInfo				OPTIONAL,	-- Need ON
+	idleModeMobilityControlInfo			IdleModeMobilityControlInfo			OPTIONAL,	-- Need OP
+	nonCriticalExtension				RRCConnectionRelease-v890-IEs		OPTIONAL
+}
+
+RRCConnectionRelease-v890-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING RRCConnectionRelease-v9e0-IEs)	OPTIONAL,
+	nonCriticalExtension				RRCConnectionRelease-v920-IEs		OPTIONAL
+}
+
+-- Late non critical extensions
+RRCConnectionRelease-v9e0-IEs ::= SEQUENCE {
+	redirectedCarrierInfo-v9e0			RedirectedCarrierInfo-v9e0			OPTIONAL,	-- Cond NoRedirect-r8
+	idleModeMobilityControlInfo-v9e0	IdleModeMobilityControlInfo-v9e0	OPTIONAL,	-- Cond IdleInfoEUTRA
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+-- Regular non critical extensions
+RRCConnectionRelease-v920-IEs ::=	SEQUENCE {
+	cellInfoList-r9					CHOICE {
+		geran-r9						CellInfoListGERAN-r9,
+		utra-FDD-r9						CellInfoListUTRA-FDD-r9,
+		utra-TDD-r9						CellInfoListUTRA-TDD-r9,
+		...,
+		utra-TDD-r10					CellInfoListUTRA-TDD-r10
+	}															OPTIONAL,	-- Cond Redirection
+	nonCriticalExtension			RRCConnectionRelease-v1020-IEs		OPTIONAL
+}
+
+RRCConnectionRelease-v1020-IEs ::=	SEQUENCE {
+	extendedWaitTime-r10				INTEGER (1..1800)		OPTIONAL,	-- Need ON
+	nonCriticalExtension			RRCConnectionRelease-v1320-IEs				OPTIONAL
+}
+
+RRCConnectionRelease-v1320-IEs::=	SEQUENCE {
+	resumeIdentity-r13					ResumeIdentity-r13				OPTIONAL,	-- Need OR	
+	nonCriticalExtension				RRCConnectionRelease-v1530-IEs	OPTIONAL
+}
+
+RRCConnectionRelease-v1530-IEs ::=	SEQUENCE {
+	drb-ContinueROHC-r15				ENUMERATED {true}			OPTIONAL,	-- Cond UP-EDTorPUR
+	nextHopChainingCount-r15			NextHopChainingCount		OPTIONAL,	-- Cond EarlySec
+	measIdleConfig-r15					MeasIdleConfigDedicated-r15	OPTIONAL,	-- Need ON
+	rrc-InactiveConfig-r15				RRC-InactiveConfig-r15		OPTIONAL,	-- Need OR
+	cn-Type-r15							ENUMERATED {epc,fivegc}		OPTIONAL,	-- Need OR
+	nonCriticalExtension				RRCConnectionRelease-v1540-IEs			OPTIONAL
+}
+
+RRCConnectionRelease-v1540-IEs ::=	SEQUENCE {
+	waitTime							INTEGER (1..16)		OPTIONAL, -- Cond 5GC
+	nonCriticalExtension				RRCConnectionRelease-v15b0-IEs	OPTIONAL
+}
+
+RRCConnectionRelease-v15b0-IEs ::=	SEQUENCE {
+	noLastCellUpdate-r15				ENUMERATED {true}		OPTIONAL,	-- Need OP
+	nonCriticalExtension				RRCConnectionRelease-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionRelease-v1610-IEs ::=	SEQUENCE {
+	fullI-RNTI-r16						I-RNTI-r15					OPTIONAL, -- Need OR
+	shortI-RNTI-r16					ShortI-RNTI-r15 				OPTIONAL, -- Need OR
+	pur-Config-r16						SetupRelease {PUR-Config-r16}	OPTIONAL, -- Need ON
+	rrc-InactiveConfig-v1610			RRC-InactiveConfig-v1610	OPTIONAL,  -- Cond BLCE-IDLEeDRX
+	releaseIdleMeasConfig-r16			ENUMERATED {true}			OPTIONAL, -- Need ON
+	altFreqPriorities-r16				ENUMERATED {true}			OPTIONAL, -- Need ON
+	t323-r16							ENUMERATED {
+										min5, min10, min20, min30, min60, min120, min180,
+										min720}						OPTIONAL, -- Need OR
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+ReleaseCause ::=				ENUMERATED {loadBalancingTAUrequired,
+											other, cs-FallbackHighPriority-v1020, rrc-Suspend-v1320}
+
+RedirectedCarrierInfo ::=			CHOICE {
+	eutra								ARFCN-ValueEUTRA,
+	geran								CarrierFreqsGERAN,
+	utra-FDD							ARFCN-ValueUTRA,
+	utra-TDD							ARFCN-ValueUTRA,
+	cdma2000-HRPD						CarrierFreqCDMA2000,
+	cdma2000-1xRTT						CarrierFreqCDMA2000,
+	...,
+	utra-TDD-r10						CarrierFreqListUTRA-TDD-r10,
+	nr-r15								CarrierInfoNR-r15
+}
+
+RedirectedCarrierInfo-v9e0 ::=			SEQUENCE {
+	eutra-v9e0								ARFCN-ValueEUTRA-v9e0
+}
+
+RRC-InactiveConfig-r15::=		SEQUENCE {
+	fullI-RNTI-r15					I-RNTI-r15,
+	shortI-RNTI-r15					ShortI-RNTI-r15,
+	ran-PagingCycle-r15				ENUMERATED {	rf32, rf64, rf128, rf256}	OPTIONAL,	--Need OR
+	ran-NotificationAreaInfo-r15	RAN-NotificationAreaInfo-r15		OPTIONAL,	--Need ON
+	periodic-RNAU-timer-r15			ENUMERATED {min5, min10, min20, min30, min60,
+											min120, min360, min720}		OPTIONAL,	--Need OR
+	nextHopChainingCount-r15		NextHopChainingCount		OPTIONAL,	--Cond INACTIVE
+	dummy							SEQUENCE{}		OPTIONAL
+}
+
+RRC-InactiveConfig-v1610::=		SEQUENCE {
+	ran-PagingCycle-v1610				ENUMERATED {rf512, rf1024}
+}
+
+RAN-NotificationAreaInfo-r15	::= CHOICE {
+	cellList-r15				PLMN-RAN-AreaCellList-r15,
+	ran-AreaConfigList-r15		PLMN-RAN-AreaConfigList-r15
+}
+
+PLMN-RAN-AreaCellList-r15	::=	SEQUENCE (SIZE (1..maxPLMN-r15)) OF PLMN-RAN-AreaCell-r15
+
+PLMN-RAN-AreaCell-r15	::=		SEQUENCE {
+	plmn-Identity-r15				PLMN-Identity	OPTIONAL,
+	ran-AreaCells-r15				SEQUENCE (SIZE (1..32)) OF CellIdentity
+}
+
+PLMN-RAN-AreaConfigList-r15	::=	SEQUENCE (SIZE (1..maxPLMN-r15)) OF PLMN-RAN-AreaConfig-r15
+
+PLMN-RAN-AreaConfig-r15	::=	SEQUENCE {
+	plmn-Identity-r15			PLMN-Identity	OPTIONAL,
+	ran-Area-r15				SEQUENCE (SIZE (1..16)) OF	RAN-AreaConfig-r15
+}
+
+RAN-AreaConfig-r15	::=	SEQUENCE {
+	trackingAreaCode-5GC-r15	TrackingAreaCode-5GC-r15,
+	ran-AreaCodeList-r15		SEQUENCE (SIZE (1..32)) OF RAN-AreaCode-r15	OPTIONAL	--Need OR
+}
+
+CarrierFreqListUTRA-TDD-r10 ::=			SEQUENCE (SIZE (1..maxFreqUTRA-TDD-r10)) OF ARFCN-ValueUTRA
+
+IdleModeMobilityControlInfo ::=		SEQUENCE {
+	freqPriorityListEUTRA				FreqPriorityListEUTRA			OPTIONAL,		-- Need ON
+	freqPriorityListGERAN				FreqsPriorityListGERAN			OPTIONAL,		-- Need ON
+	freqPriorityListUTRA-FDD			FreqPriorityListUTRA-FDD		OPTIONAL,		-- Need ON
+	freqPriorityListUTRA-TDD			FreqPriorityListUTRA-TDD		OPTIONAL,		-- Need ON
+	bandClassPriorityListHRPD			BandClassPriorityListHRPD		OPTIONAL,		-- Need ON
+	bandClassPriorityList1XRTT			BandClassPriorityList1XRTT		OPTIONAL,		-- Need ON
+	t320								ENUMERATED {
+											min5, min10, min20, min30, min60, min120, min180,
+											spare1}						OPTIONAL,		-- Need OR
+	...,
+	[[	freqPriorityListExtEUTRA-r12		FreqPriorityListExtEUTRA-r12		OPTIONAL		-- Need ON
+	]],
+	[[	freqPriorityListEUTRA-v1310			FreqPriorityListEUTRA-v1310			OPTIONAL,		-- Need ON
+		freqPriorityListExtEUTRA-v1310		FreqPriorityListExtEUTRA-v1310		OPTIONAL		-- Need ON
+	]],
+	[[	freqPriorityListNR-r15				FreqPriorityListNR-r15		OPTIONAL		-- Need ON
+	]]
+}
+
+IdleModeMobilityControlInfo-v9e0 ::=	SEQUENCE {
+	freqPriorityListEUTRA-v9e0			SEQUENCE (SIZE (1..maxFreq)) OF FreqPriorityEUTRA-v9e0
+}
+
+FreqPriorityListEUTRA ::=			SEQUENCE (SIZE (1..maxFreq)) OF FreqPriorityEUTRA
+
+FreqPriorityListExtEUTRA-r12 ::=		SEQUENCE (SIZE (1..maxFreq)) OF FreqPriorityEUTRA-r12
+
+FreqPriorityListEUTRA-v1310 ::=			SEQUENCE (SIZE (1..maxFreq)) OF FreqPriorityEUTRA-v1310
+
+FreqPriorityListExtEUTRA-v1310 ::=		SEQUENCE (SIZE (1..maxFreq)) OF FreqPriorityEUTRA-v1310
+
+FreqPriorityEUTRA ::=				SEQUENCE {
+	carrierFreq							ARFCN-ValueEUTRA,
+	cellReselectionPriority				CellReselectionPriority
+}
+
+FreqPriorityEUTRA-v9e0 ::=			SEQUENCE {
+	carrierFreq-v9e0					ARFCN-ValueEUTRA-v9e0		OPTIONAL	-- Cond EARFCN-max
+}
+
+FreqPriorityEUTRA-r12 ::=				SEQUENCE {
+	carrierFreq-r12							ARFCN-ValueEUTRA-r9,
+	cellReselectionPriority-r12				CellReselectionPriority
+}
+
+FreqPriorityEUTRA-v1310 ::=				SEQUENCE {
+	cellReselectionSubPriority-r13				CellReselectionSubPriority-r13		OPTIONAL		-- Need ON
+}
+
+FreqPriorityListNR-r15 ::=		SEQUENCE (SIZE (1..maxFreq)) OF FreqPriorityNR-r15
+
+FreqPriorityNR-r15 ::=			SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueNR-r15,
+	cellReselectionPriority-r15			CellReselectionPriority,
+	cellReselectionSubPriority-r15		CellReselectionSubPriority-r13		OPTIONAL		-- Need OR
+}
+
+FreqsPriorityListGERAN ::=			SEQUENCE (SIZE (1..maxGNFG)) OF FreqsPriorityGERAN
+
+FreqsPriorityGERAN ::=				SEQUENCE {
+	carrierFreqs						CarrierFreqsGERAN,
+	cellReselectionPriority				CellReselectionPriority
+}
+
+FreqPriorityListUTRA-FDD ::=		SEQUENCE (SIZE (1..maxUTRA-FDD-Carrier)) OF FreqPriorityUTRA-FDD
+
+FreqPriorityUTRA-FDD ::=			SEQUENCE {
+	carrierFreq							ARFCN-ValueUTRA,
+	cellReselectionPriority				CellReselectionPriority
+}
+
+FreqPriorityListUTRA-TDD ::=		SEQUENCE (SIZE (1..maxUTRA-TDD-Carrier)) OF FreqPriorityUTRA-TDD
+
+FreqPriorityUTRA-TDD ::=			SEQUENCE {
+	carrierFreq							ARFCN-ValueUTRA,
+	cellReselectionPriority				CellReselectionPriority
+}
+
+BandClassPriorityListHRPD ::=		SEQUENCE (SIZE (1..maxCDMA-BandClass)) OF BandClassPriorityHRPD
+
+BandClassPriorityHRPD ::=			SEQUENCE {
+	bandClass							BandclassCDMA2000,
+	cellReselectionPriority				CellReselectionPriority
+}
+
+BandClassPriorityList1XRTT ::=	SEQUENCE (SIZE (1..maxCDMA-BandClass)) OF BandClassPriority1XRTT
+
+BandClassPriority1XRTT ::=			SEQUENCE {
+	bandClass							BandclassCDMA2000,
+	cellReselectionPriority				CellReselectionPriority
+}
+
+CellInfoListGERAN-r9 ::=		SEQUENCE (SIZE (1..maxCellInfoGERAN-r9)) OF CellInfoGERAN-r9
+
+CellInfoGERAN-r9 ::=				SEQUENCE {
+	physCellId-r9						PhysCellIdGERAN,
+	carrierFreq-r9						CarrierFreqGERAN,
+	systemInformation-r9				SystemInfoListGERAN
+}
+
+CarrierInfoNR-r15	::= SEQUENCE {
+	carrierFreq-r15					ARFCN-ValueNR-r15,
+	subcarrierSpacingSSB-r15			ENUMERATED {kHz15, kHz30, kHz120, kHz240},
+	smtc-r15							MTC-SSB-NR-r15				OPTIONAL		-- Need OP
+}
+
+CellInfoListUTRA-FDD-r9 ::=			SEQUENCE (SIZE (1..maxCellInfoUTRA-r9)) OF CellInfoUTRA-FDD-r9
+
+CellInfoUTRA-FDD-r9 ::=				SEQUENCE {
+	physCellId-r9						PhysCellIdUTRA-FDD,
+	utra-BCCH-Container-r9				OCTET STRING
+}
+
+CellInfoListUTRA-TDD-r9 ::=			SEQUENCE (SIZE (1..maxCellInfoUTRA-r9)) OF CellInfoUTRA-TDD-r9
+
+CellInfoUTRA-TDD-r9 ::=				SEQUENCE {
+	physCellId-r9						PhysCellIdUTRA-TDD,
+	utra-BCCH-Container-r9				OCTET STRING
+}
+
+CellInfoListUTRA-TDD-r10 ::=		SEQUENCE (SIZE (1..maxCellInfoUTRA-r9)) OF CellInfoUTRA-TDD-r10
+
+CellInfoUTRA-TDD-r10 ::=			SEQUENCE {
+	physCellId-r10						PhysCellIdUTRA-TDD,
+	carrierFreq-r10						ARFCN-ValueUTRA,
+	utra-BCCH-Container-r10				OCTET STRING
+}
+
+
+
+RRCConnectionRequest ::=			SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcConnectionRequest-r8				RRCConnectionRequest-r8-IEs,
+		rrcConnectionRequest-r15			RRCConnectionRequest-5GC-r15-IEs
+	}
+}
+
+RRCConnectionRequest-r8-IEs ::=		SEQUENCE {
+	ue-Identity							InitialUE-Identity,
+	establishmentCause					EstablishmentCause,
+	spare								BIT STRING (SIZE (1))
+}
+
+RRCConnectionRequest-5GC-r15-IEs ::=	SEQUENCE {
+	ue-Identity								InitialUE-Identity-5GC,
+	establishmentCause						EstablishmentCause-5GC,
+	spare									BIT STRING (SIZE (1))
+}
+
+InitialUE-Identity ::=				CHOICE {
+	s-TMSI								S-TMSI,
+	randomValue							BIT STRING (SIZE (40))
+}
+
+InitialUE-Identity-5GC ::=			CHOICE {
+	ng-5G-S-TMSI-Part1					BIT STRING (SIZE (40)),
+	randomValue							BIT STRING (SIZE (40))
+}
+
+
+EstablishmentCause ::=				ENUMERATED {
+										emergency, highPriorityAccess, mt-Access, mo-Signalling,
+										mo-Data, delayTolerantAccess-v1020, mo-VoiceCall-v1280, spare1}
+
+EstablishmentCause-5GC ::=			ENUMERATED {
+										emergency, highPriorityAccess, mt-Access, mo-Signalling,
+										mo-Data, mo-VoiceCall, spare2, spare1}
+
+
+
+RRCConnectionResume-r13 ::=		SEQUENCE {
+	rrc-TransactionIdentifier		RRC-TransactionIdentifier,
+	criticalExtensions				CHOICE {
+		c1								CHOICE {
+			rrcConnectionResume-r13			RRCConnectionResume-r13-IEs,
+			spare3							NULL,
+			spare2							NULL,
+			spare1							NULL
+		},
+		criticalExtensionsFuture		SEQUENCE {}
+	}
+}
+
+RRCConnectionResume-r13-IEs ::=		SEQUENCE {
+	radioResourceConfigDedicated-r13		RadioResourceConfigDedicated	OPTIONAL,	-- Need ON
+	nextHopChainingCount-r13				NextHopChainingCount,
+	measConfig-r13							MeasConfig						OPTIONAL,	-- Need ON
+	antennaInfoDedicatedPCell-r13			AntennaInfoDedicated-v10i0		OPTIONAL,	-- Need ON
+	drb-ContinueROHC-r13					ENUMERATED {true}				OPTIONAL,	-- Need OP
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	rrcConnectionResume-v1430-IEs			RRCConnectionResume-v1430-IEs	OPTIONAL
+}
+
+RRCConnectionResume-v1430-IEs ::= SEQUENCE {
+	otherConfig-r14						OtherConfig-r9					OPTIONAL,		-- Need ON
+	rrcConnectionResume-v1510-IEs		RRCConnectionResume-v1510-IEs	OPTIONAL
+}
+
+RRCConnectionResume-v1510-IEs ::= SEQUENCE {
+	sk-Counter-r15						INTEGER (0.. 65535)				OPTIONAL,	-- Need ON
+	nr-RadioBearerConfig1-r15			OCTET STRING					OPTIONAL,	-- Need ON
+	nr-RadioBearerConfig2-r15			OCTET STRING					OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionResume-v1530-IEs	OPTIONAL
+}
+
+RRCConnectionResume-v1530-IEs ::= SEQUENCE {
+	fullConfig-r15						ENUMERATED {true}				OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCConnectionResume-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionResume-v1610-IEs ::=	SEQUENCE {
+	idleModeMeasurementReq-r16			ENUMERATED {true}				OPTIONAL,	-- Need ON
+	restoreMCG-SCells					ENUMERATED {true}				OPTIONAL,	-- Need ON
+	restoreSCG							ENUMERATED {true}				OPTIONAL,	-- Cond EarlySec
+	sCellToAddModList-r16				SCellToAddModList-r16			OPTIONAL,	-- Cond EarlySec
+	sCellToReleaseList-r16				SCellToReleaseListExt-r13		OPTIONAL,	-- Need ON
+	sCellGroupToReleaseList-r16			SCellGroupToReleaseList-r15		OPTIONAL,	-- Need ON
+	sCellGroupToAddModList-r16			SCellGroupToAddModList-r15		OPTIONAL,	-- Cond EarlySec
+	nr-SecondaryCellGroupConfig			OCTET STRING					OPTIONAL,	-- Cond RestoreSCG
+	p-MaxEUTRA-r16						P-Max							OPTIONAL,	-- Cond SCG
+	p-MaxUE-FR1-r16						P-Max							OPTIONAL,	-- Cond SCG
+	tdm-PatternConfig-r16				TDM-PatternConfig-r15			OPTIONAL,	-- Cond FDD-PCell
+	tdm-PatternConfig2-r16				TDM-PatternConfig-r15			OPTIONAL,	-- Need OR
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+
+	
+RRCConnectionResumeComplete-r13 ::= SEQUENCE {
+	rrc-TransactionIdentifier				RRC-TransactionIdentifier,
+	criticalExtensions							CHOICE {
+		rrcConnectionResumeComplete-r13				RRCConnectionResumeComplete-r13-IEs,
+		criticalExtensionsFuture					SEQUENCE {}
+	}
+}
+
+RRCConnectionResumeComplete-r13-IEs ::= SEQUENCE {
+	selectedPLMN-Identity-r13				INTEGER (1..maxPLMN-r11)					OPTIONAL,
+	dedicatedInfoNAS-r13					DedicatedInfoNAS							OPTIONAL,
+	rlf-InfoAvailable-r13					ENUMERATED {true}							OPTIONAL,
+	logMeasAvailable-r13					ENUMERATED {true}							OPTIONAL,
+	connEstFailInfoAvailable-r13			ENUMERATED {true}							OPTIONAL,
+	mobilityState-r13						ENUMERATED {normal, medium, high, spare}	OPTIONAL,
+	mobilityHistoryAvail-r13				ENUMERATED {true}							OPTIONAL,
+	logMeasAvailableMBSFN-r13				ENUMERATED {true}							OPTIONAL,
+	lateNonCriticalExtension				OCTET STRING								OPTIONAL,
+	nonCriticalExtension					RRCConnectionResumeComplete-v1530-IEs		OPTIONAL
+}
+
+RRCConnectionResumeComplete-v1530-IEs ::= SEQUENCE {
+	logMeasAvailableBT-r15			ENUMERATED {true}				OPTIONAL,
+	logMeasAvailableWLAN-r15		ENUMERATED {true}				OPTIONAL,
+	idleMeasAvailable-r15			ENUMERATED {true}				OPTIONAL,
+	flightPathInfoAvailable-r15		ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension			RRCConnectionResumeComplete-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionResumeComplete-v1610-IEs ::= SEQUENCE {
+	measResultListIdle-r16				MeasResultListIdle-r15			OPTIONAL,
+	measResultListExtIdle-r16				MeasResultListExtIdle-r16			OPTIONAL,
+	measResultListIdleNR-r16			MeasResultListIdleNR-r16		OPTIONAL,
+	scg-ConfigResponseNR-r16			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				SEQUENCE{}						OPTIONAL
+}
+
+
+
+RRCConnectionResumeRequest-r13 ::=	SEQUENCE {
+	criticalExtensions						CHOICE {
+		rrcConnectionResumeRequest-r13			RRCConnectionResumeRequest-r13-IEs,	
+		rrcConnectionResumeRequest-r15			RRCConnectionResumeRequest-5GC-r15-IEs
+	}
+}
+
+RRCConnectionResumeRequest-r13-IEs ::=		SEQUENCE {
+	resumeIdentity-r13								CHOICE {
+		resumeID-r13									ResumeIdentity-r13,
+		truncatedResumeID-r13							BIT STRING (SIZE (24))
+	},
+	shortResumeMAC-I-r13							BIT STRING (SIZE (16)),
+	resumeCause-r13									ResumeCause,
+	spare											BIT STRING (SIZE (1))
+}
+
+RRCConnectionResumeRequest-5GC-r15-IEs ::=		SEQUENCE {
+	resumeIdentity-r15								CHOICE {
+		fullI-RNTI-r15									I-RNTI-r15,
+		shortI-RNTI-r15									ShortI-RNTI-r15
+	},
+	shortResumeMAC-I-r15							BIT STRING (SIZE (16)),
+	resumeCause-r15									ResumeCause-r15,
+	spare											BIT STRING (SIZE (1))
+}
+
+ResumeCause ::=				ENUMERATED {
+								emergency, highPriorityAccess, mt-Access, mo-Signalling,
+								mo-Data, delayTolerantAccess-v1020, mo-VoiceCall-v1280,
+								mt-EDT-v1610
+}
+
+ResumeCause-r15 ::=			ENUMERATED {
+								emergency, highPriorityAccess, mt-Access, mo-Signalling,
+								mo-Data, rna-Update, mo-VoiceCall, spare1
+}
+
+
+
+RRCConnectionSetup ::=				SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			rrcConnectionSetup-r8				RRCConnectionSetup-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionSetup-r8-IEs ::=		SEQUENCE {
+	radioResourceConfigDedicated		RadioResourceConfigDedicated,
+	nonCriticalExtension				RRCConnectionSetup-v8a0-IEs			OPTIONAL
+}
+
+RRCConnectionSetup-v8a0-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetup-v1610-IEs		OPTIONAL
+}
+
+RRCConnectionSetup-v1610-IEs ::=	SEQUENCE {
+	dedicatedInfoNAS-r16				DedicatedInfoNAS					OPTIONAL,	-- Need ON
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+RRCConnectionSetupComplete ::=		SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			rrcConnectionSetupComplete-r8		RRCConnectionSetupComplete-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionSetupComplete-r8-IEs ::= SEQUENCE {
+	selectedPLMN-Identity				INTEGER (1..maxPLMN-r11),
+	registeredMME						RegisteredMME						OPTIONAL,
+	dedicatedInfoNAS					DedicatedInfoNAS,
+	nonCriticalExtension				RRCConnectionSetupComplete-v8a0-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING							OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1020-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1020-IEs ::= SEQUENCE {
+	gummei-Type-r10						ENUMERATED {native, mapped}				OPTIONAL,
+	rlf-InfoAvailable-r10				ENUMERATED {true}						OPTIONAL,
+	logMeasAvailable-r10				ENUMERATED {true}						OPTIONAL,
+	rn-SubframeConfigReq-r10			ENUMERATED {required, notRequired}		OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1130-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1130-IEs ::= SEQUENCE {
+	connEstFailInfoAvailable-r11		ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1250-IEs		OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1250-IEs ::= SEQUENCE {
+	mobilityState-r12					ENUMERATED {normal, medium, high, spare}	OPTIONAL,
+	mobilityHistoryAvail-r12			ENUMERATED {true}							OPTIONAL,
+	logMeasAvailableMBSFN-r12			ENUMERATED {true}							OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1320-IEs		OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1320-IEs ::= SEQUENCE {
+	ce-ModeB-r13						ENUMERATED {supported}						OPTIONAL,
+	s-TMSI-r13							S-TMSI										OPTIONAL,
+	attachWithoutPDN-Connectivity-r13	ENUMERATED {true}							OPTIONAL,
+	up-CIoT-EPS-Optimisation-r13		ENUMERATED {true}							OPTIONAL,
+	cp-CIoT-EPS-Optimisation-r13		ENUMERATED {true}							OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1330-IEs		OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1330-IEs ::= SEQUENCE {
+	ue-CE-NeedULGaps-r13				ENUMERATED {true}							OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1430-IEs		OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1430-IEs ::= SEQUENCE {
+	dcn-ID-r14							INTEGER (0..65535)							OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1530-IEs		OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1530-IEs ::= SEQUENCE {
+	logMeasAvailableBT-r15				ENUMERATED {true}						OPTIONAL,
+	logMeasAvailableWLAN-r15			ENUMERATED {true}						OPTIONAL,
+	idleMeasAvailable-r15				ENUMERATED {true}						OPTIONAL,
+	flightPathInfoAvailable-r15			ENUMERATED {true}						OPTIONAL,
+	connectTo5GC-r15					ENUMERATED {true}						OPTIONAL,
+	registeredAMF-r15					RegisteredAMF-r15						OPTIONAL,
+	s-NSSAI-list-r15					SEQUENCE(SIZE (1..maxNrofS-NSSAI-r15)) OF S-NSSAI-r15 OPTIONAL,
+	ng-5G-S-TMSI-Bits-r15				CHOICE {
+		ng-5G-S-TMSI-r15					NG-5G-S-TMSI-r15,
+		ng-5G-S-TMSI-Part2-r15				BIT STRING (SIZE (8))
+	}																			OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1540-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1540-IEs ::= SEQUENCE {
+	gummei-Type-v1540					ENUMERATED {mappedFrom5G-v1540}		OPTIONAL,
+	guami-Type-r15						ENUMERATED {native, mapped}			OPTIONAL,
+	nonCriticalExtension				RRCConnectionSetupComplete-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-v1610-IEs ::= SEQUENCE {
+	rlos-Request-r16					ENUMERATED {true}					OPTIONAL,
+	cp-CIoT-5GS-Optimisation-r16		ENUMERATED {true}					OPTIONAL,
+	up-CIoT-5GS-Optimisation-r16		ENUMERATED {true}					OPTIONAL,
+	pur-ConfigID-r16					PUR-ConfigID-r16					OPTIONAL,
+	lte-M-r16							ENUMERATED {true}					OPTIONAL,
+	iab-NodeIndication-r16				ENUMERATED {true}					OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+RegisteredMME ::=					SEQUENCE {
+	plmn-Identity						PLMN-Identity						OPTIONAL,
+	mmegi								BIT STRING (SIZE (16)),
+	mmec								MMEC
+}
+
+RegisteredAMF-r15	::=				SEQUENCE {
+	plmn-Identity-r15					PLMN-Identity						OPTIONAL,
+	amf-Identifier-r15					AMF-Identifier-r15
+}
+
+
+
+RRCEarlyDataComplete-r15 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcEarlyDataComplete-r15			RRCEarlyDataComplete-r15-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCEarlyDataComplete-r15-IEs ::=	SEQUENCE {
+	dedicatedInfoNAS-r15				DedicatedInfoNAS					OPTIONAL,	-- Need ON
+	extendedWaitTime-r15				INTEGER (1..1800)					OPTIONAL,	-- Need ON
+	idleModeMobilityControlInfo-r15		IdleModeMobilityControlInfo			OPTIONAL,	-- Need OP
+	idleModeMobilityControlInfoExt-r15	IdleModeMobilityControlInfo-v9e0	OPTIONAL,	-- Cond IdleInfoEUTRA
+	redirectedCarrierInfo-r15			RedirectedCarrierInfo-r15-IEs		OPTIONAL,	-- Need ON
+	nonCriticalExtension				RRCEarlyDataComplete-v1590-IEs	OPTIONAL
+}
+
+RRCEarlyDataComplete-v1590-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}					OPTIONAL
+}
+
+RedirectedCarrierInfo-r15-IEs ::=	CHOICE {
+	eutra-r15					ARFCN-ValueEUTRA-r9,
+	geran-r15					CarrierFreqsGERAN,
+	utra-FDD-r15				ARFCN-ValueUTRA,
+	cdma2000-HRPD-r15			CarrierFreqCDMA2000,
+	cdma2000-1xRTT-r15			CarrierFreqCDMA2000,
+	utra-TDD-r15				CarrierFreqListUTRA-TDD-r10
+}
+
+
+
+RRCEarlyDataRequest-r15 ::=		SEQUENCE {
+	criticalExtensions				CHOICE {
+		rrcEarlyDataRequest-r15			RRCEarlyDataRequest-r15-IEs,
+		criticalExtensionsFuture		CHOICE {
+			rrcEarlyDataRequest-5GC-r16		RRCEarlyDataRequest-5GC-r16-IEs,
+			criticalExtensionsFuture-r16	SEQUENCE {}
+		}
+	}
+}
+
+RRCEarlyDataRequest-r15-IEs ::=	SEQUENCE {
+	s-TMSI-r15						S-TMSI,
+	establishmentCause-r15			ENUMERATED {mo-Data, delayTolerantAccess},
+	dedicatedInfoNAS-r15				DedicatedInfoNAS,
+	nonCriticalExtension				RRCEarlyDataRequest-v1590-IEs			OPTIONAL
+}
+
+RRCEarlyDataRequest-v1590-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					RRCEarlyDataRequest-v1610-IEs	OPTIONAL
+}
+
+RRCEarlyDataRequest-v1610-IEs ::=	SEQUENCE {
+	establishmentCause-v1610			ENUMERATED {mt-Access, spare3, spare2, spare1},
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+RRCEarlyDataRequest-5GC-r16-IEs ::=	SEQUENCE {
+	ng-5G-S-TMSI-r16					NG-5G-S-TMSI-r15,
+	establishmentCause-r16				ENUMERATED {mo-Data, spare3, spare2, spare1},
+	dedicatedInfoNAS-r16				DedicatedInfoNAS,
+	lateNonCriticalExtension			OCTET STRING			OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}			OPTIONAL
+}
+
+
+
+SCGFailureInformation-r12 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			scgFailureInformation-r12			SCGFailureInformation-r12-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SCGFailureInformation-r12-IEs ::=	SEQUENCE {
+	failureReportSCG-r12				FailureReportSCG-r12			OPTIONAL,
+	nonCriticalExtension				SCGFailureInformation-v12d0a-IEs	OPTIONAL
+}
+
+SCGFailureInformation-v12d0a-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING SCGFailureInformation-v12d0b-IEs)						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+-- Late non-critical extensions:
+SCGFailureInformation-v12d0b-IEs ::= SEQUENCE {
+	failureReportSCG-v12d0				FailureReportSCG-v12d0				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+-- Regular non-critical extensions:
+FailureReportSCG-r12 ::=			SEQUENCE {
+	failureType-r12						ENUMERATED {t313-Expiry, randomAccessProblem,
+												rlc-MaxNumRetx, scg-ChangeFailure },
+	measResultServFreqList-r12			MeasResultServFreqList-r10			OPTIONAL,
+	measResultNeighCells-r12			MeasResultList2EUTRA-r9				OPTIONAL,
+	...,
+	[[	failureType-v1290				ENUMERATED {maxUL-TimingDiff-v1290}	OPTIONAL
+	]],
+	[[	measResultServFreqListExt-r13	MeasResultServFreqListExt-r13		OPTIONAL
+	]]
+}
+
+FailureReportSCG-v12d0 ::= SEQUENCE {
+	measResultNeighCells-v12d0			MeasResultList2EUTRA-v9e0			OPTIONAL
+}
+
+
+
+SCGFailureInformationNR-r15 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			scgFailureInformationNR-r15			SCGFailureInformationNR-r15-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SCGFailureInformationNR-r15-IEs ::=	SEQUENCE {
+	failureReportSCG-NR-r15				FailureReportSCG-NR-r15				OPTIONAL,
+	nonCriticalExtension					SCGFailureInformationNR-v1590-IEs	OPTIONAL
+}
+
+SCGFailureInformationNR-v1590-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension					OCTET STRING					OPTIONAL,
+	nonCriticalExtension						SEQUENCE {}					OPTIONAL
+}
+
+FailureReportSCG-NR-r15 ::=		SEQUENCE {
+	failureType-r15						ENUMERATED {
+											t310-Expiry, randomAccessProblem,
+											rlc-MaxNumRetx,
+											synchReconfigFailureSCG, scg-reconfigFailure,
+											srb3-IntegrityFailure, other-r16},
+	measResultFreqListNR-r15				MeasResultFreqListFailNR-r15		OPTIONAL,
+	measResultSCG-r15						OCTET STRING						OPTIONAL,
+	...,
+	[[	locationInfo-r16				LocationInfo-r10						OPTIONAL,
+		logMeasResultListBT-r16			LogMeasResultListBT-r15					OPTIONAL,
+		logMeasResultListWLAN-r16		LogMeasResultListWLAN-r15				OPTIONAL,
+		failureType-v1610				ENUMERATED {t312-Expiry, scg-lbtFailure,
+											beamFailureRecoveryFailure, bh-RLF-r16, spare4,
+ 													spare3, spare2, spare1}	OPTIONAL
+	]]
+}
+
+MeasResultFreqListFailNR-r15 ::=	SEQUENCE (SIZE (1..maxFreqNR-r15)) OF MeasResultFreqFailNR-r15
+
+MeasResultFreqFailNR-r15 ::=		SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueNR-r15,
+	measResultCellList-r15				MeasResultCellListNR-r15			OPTIONAL,
+	...
+}
+
+
+
+SCPTMConfiguration-r13 ::=		SEQUENCE {
+	sc-mtch-InfoList-r13			SC-MTCH-InfoList-r13,
+	scptm-NeighbourCellList-r13		SCPTM-NeighbourCellList-r13			OPTIONAL,	-- Need OP
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SCPTMConfiguration-v1340			OPTIONAL
+}
+
+SCPTMConfiguration-v1340 ::= SEQUENCE {
+	p-b-r13								INTEGER (0..3)			OPTIONAL,	-- Need ON
+	nonCriticalExtension				SEQUENCE {}				OPTIONAL
+}
+
+
+
+SCPTMConfiguration-BR-r14 ::=	SEQUENCE {
+	sc-mtch-InfoList-r14			SC-MTCH-InfoList-BR-r14,
+	scptm-NeighbourCellList-r14		SCPTM-NeighbourCellList-r13			OPTIONAL,	-- Need OP
+	p-b-r14							INTEGER (0..3)						OPTIONAL,	-- Need OR
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SCPTMConfiguration-BR-v1610			OPTIONAL
+}
+
+SCPTMConfiguration-BR-v1610 ::=	SEQUENCE {
+	sc-MTCH-InfoList-MultiTB-r16	SC-MTCH-InfoList-BR-r14,
+	multiTB-Gap-r16					ENUMERATED {sf2, sf4, sf8, sf16, sf32, sf64, sf128, spare}
+																		OPTIONAL,	-- Need OR,
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+
+
+SecurityModeCommand ::=				SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			securityModeCommand-r8				SecurityModeCommand-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SecurityModeCommand-r8-IEs ::=		SEQUENCE {
+	securityConfigSMC					SecurityConfigSMC,
+	nonCriticalExtension				SecurityModeCommand-v8a0-IEs		OPTIONAL
+}
+
+SecurityModeCommand-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+SecurityConfigSMC ::=					SEQUENCE {
+	securityAlgorithmConfig					SecurityAlgorithmConfig,
+	...
+}
+
+
+
+SecurityModeComplete ::=			SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		securityModeComplete-r8				SecurityModeComplete-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SecurityModeComplete-r8-IEs ::=		SEQUENCE {
+	nonCriticalExtension				SecurityModeComplete-v8a0-IEs		OPTIONAL
+}
+
+SecurityModeComplete-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+SecurityModeFailure ::=				SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		securityModeFailure-r8				SecurityModeFailure-r8-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SecurityModeFailure-r8-IEs ::=		SEQUENCE {
+	nonCriticalExtension				SecurityModeFailure-v8a0-IEs		OPTIONAL
+}
+
+SecurityModeFailure-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+SidelinkUEInformation-r12 ::=	SEQUENCE {
+	criticalExtensions				CHOICE {
+		c1								CHOICE {
+			sidelinkUEInformation-r12		SidelinkUEInformation-r12-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SidelinkUEInformation-r12-IEs ::=	SEQUENCE {
+	commRxInterestedFreq-r12			ARFCN-ValueEUTRA-r9				OPTIONAL,
+	commTxResourceReq-r12				SL-CommTxResourceReq-r12		OPTIONAL,
+	discRxInterest-r12					ENUMERATED {true}				OPTIONAL,
+	discTxResourceReq-r12				INTEGER (1..63)					OPTIONAL,
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				SidelinkUEInformation-v1310-IEs	OPTIONAL
+}
+
+SidelinkUEInformation-v1310-IEs ::=	SEQUENCE {
+	commTxResourceReqUC-r13				SL-CommTxResourceReq-r12				OPTIONAL,
+	commTxResourceInfoReqRelay-r13		SEQUENCE {
+		commTxResourceReqRelay-r13			SL-CommTxResourceReq-r12			OPTIONAL,
+		commTxResourceReqRelayUC-r13		SL-CommTxResourceReq-r12			OPTIONAL,
+		ue-Type-r13							ENUMERATED {relayUE, remoteUE}
+	}																			OPTIONAL,
+	discTxResourceReq-v1310			SEQUENCE {
+		carrierFreqDiscTx-r13			INTEGER (1..maxFreq)					OPTIONAL,
+		discTxResourceReqAddFreq-r13	SL-DiscTxResourceReqPerFreqList-r13		OPTIONAL
+	}																			OPTIONAL,
+	discTxResourceReqPS-r13			SL-DiscTxResourceReq-r13					OPTIONAL,
+	discRxGapReq-r13				SL-GapRequest-r13							OPTIONAL,
+	discTxGapReq-r13				SL-GapRequest-r13							OPTIONAL,
+	discSysInfoReportFreqList-r13	SL-DiscSysInfoReportFreqList-r13			OPTIONAL,
+	nonCriticalExtension			SidelinkUEInformation-v1430-IEs				OPTIONAL
+}
+
+SidelinkUEInformation-v1430-IEs ::=	SEQUENCE {
+	v2x-CommRxInterestedFreqList-r14	SL-V2X-CommFreqList-r14					OPTIONAL,
+	p2x-CommTxType-r14					ENUMERATED {true}						OPTIONAL,
+	v2x-CommTxResourceReq-r14			SL-V2X-CommTxFreqList-r14				OPTIONAL,
+	nonCriticalExtension				SidelinkUEInformation-v1530-IEs			OPTIONAL
+}
+
+SidelinkUEInformation-v1530-IEs ::=	SEQUENCE {
+	reliabilityInfoListSL-r15			SL-ReliabilityList-r15					OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}								OPTIONAL
+}
+
+SL-CommTxResourceReq-r12 ::=		SEQUENCE {
+	carrierFreq-r12						ARFCN-ValueEUTRA-r9						OPTIONAL,
+	destinationInfoList-r12				SL-DestinationInfoList-r12
+}
+
+SL-DiscTxResourceReqPerFreqList-r13 ::=	SEQUENCE (SIZE (1..maxFreq)) OF SL-DiscTxResourceReq-r13
+
+SL-DiscTxResourceReq-r13 ::=		SEQUENCE {
+	carrierFreqDiscTx-r13				INTEGER (1..maxFreq)					OPTIONAL,
+	discTxResourceReq-r13				INTEGER (1..63)
+}
+
+SL-DestinationInfoList-r12 ::=	SEQUENCE (SIZE (1..maxSL-Dest-r12)) OF SL-DestinationIdentity-r12
+
+SL-DestinationIdentity-r12 ::=	BIT STRING (SIZE (24))
+
+SL-DiscSysInfoReportFreqList-r13 ::=	SEQUENCE (SIZE (1.. maxSL-DiscSysInfoReportFreq-r13)) OF SL-DiscSysInfoReport-r13
+
+SL-V2X-CommFreqList-r14 ::=	SEQUENCE (SIZE (1..maxFreqV2X-r14)) OF INTEGER (0..maxFreqV2X-1-r14)
+
+SL-V2X-CommTxFreqList-r14 ::=	SEQUENCE (SIZE (1..maxFreqV2X-r14)) OF SL-V2X-CommTxResourceReq-r14
+
+SL-V2X-CommTxResourceReq-r14 ::=	SEQUENCE {
+	carrierFreqCommTx-r14				INTEGER (0.. maxFreqV2X-1-r14)			OPTIONAL,
+	v2x-TypeTxSync-r14					SL-TypeTxSync-r14						OPTIONAL,
+	v2x-DestinationInfoList-r14			SL-DestinationInfoList-r12				OPTIONAL
+}
+
+
+
+SystemInformation-BR-r13 ::=	SystemInformation
+
+SystemInformation-MBMS-r14 ::=	SystemInformation
+
+SystemInformation ::=				SEQUENCE {
+	criticalExtensions					CHOICE {
+		systemInformation-r8				SystemInformation-r8-IEs,
+		criticalExtensionsFuture-r15		CHOICE {
+			posSystemInformation-r15			PosSystemInformation-r15-IEs,
+			criticalExtensionsFuture			SEQUENCE {}
+		}
+	}
+}
+SystemInformation-r8-IEs ::=		SEQUENCE {
+	sib-TypeAndInfo						SEQUENCE (SIZE (1..maxSIB)) OF CHOICE {
+		sib2								SystemInformationBlockType2,
+		sib3								SystemInformationBlockType3,
+		sib4								SystemInformationBlockType4,
+		sib5								SystemInformationBlockType5,
+		sib6								SystemInformationBlockType6,
+		sib7								SystemInformationBlockType7,
+		sib8								SystemInformationBlockType8,
+		sib9								SystemInformationBlockType9,
+		sib10								SystemInformationBlockType10,
+		sib11								SystemInformationBlockType11,
+		...,
+		sib12-v920							SystemInformationBlockType12-r9,
+		sib13-v920							SystemInformationBlockType13-r9,
+		sib14-v1130							SystemInformationBlockType14-r11,
+		sib15-v1130							SystemInformationBlockType15-r11,
+		sib16-v1130							SystemInformationBlockType16-r11,
+		sib17-v1250							SystemInformationBlockType17-r12,
+		sib18-v1250							SystemInformationBlockType18-r12,
+		sib19-v1250							SystemInformationBlockType19-r12,
+		sib20-v1310							SystemInformationBlockType20-r13,
+		sib21-v1430							SystemInformationBlockType21-r14,
+		sib24-v1530							SystemInformationBlockType24-r15,
+		sib25-v1530							SystemInformationBlockType25-r15,
+		sib26-v1530							SystemInformationBlockType26-r15,
+		sib26a-v1610							SystemInformationBlockType26a-r16,
+		sib27-v1610							SystemInformationBlockType27-r16,
+		sib28-v1610							SystemInformationBlockType28-r16,
+		sib29-v1610							SystemInformationBlockType29-r16
+	},
+	nonCriticalExtension				SystemInformation-v8a0-IEs		OPTIONAL
+}
+
+SystemInformation-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+PosSystemInformation-r15-IEs ::= SEQUENCE {
+	posSIB-TypeAndInfo-r15			SEQUENCE (SIZE (1..maxSIB)) OF CHOICE {
+		posSib1-1-r15					SystemInformationBlockPos-r15,
+		posSib1-2-r15					SystemInformationBlockPos-r15,
+		posSib1-3-r15					SystemInformationBlockPos-r15,
+		posSib1-4-r15					SystemInformationBlockPos-r15,
+		posSib1-5-r15					SystemInformationBlockPos-r15,
+		posSib1-6-r15					SystemInformationBlockPos-r15,
+		posSib1-7-r15					SystemInformationBlockPos-r15,
+		posSib2-1-r15					SystemInformationBlockPos-r15,
+		posSib2-2-r15					SystemInformationBlockPos-r15,
+		posSib2-3-r15					SystemInformationBlockPos-r15,
+		posSib2-4-r15					SystemInformationBlockPos-r15,
+		posSib2-5-r15					SystemInformationBlockPos-r15,
+		posSib2-6-r15					SystemInformationBlockPos-r15,
+		posSib2-7-r15					SystemInformationBlockPos-r15,
+		posSib2-8-r15					SystemInformationBlockPos-r15,
+		posSib2-9-r15					SystemInformationBlockPos-r15,
+		posSib2-10-r15					SystemInformationBlockPos-r15,
+		posSib2-11-r15					SystemInformationBlockPos-r15,
+		posSib2-12-r15					SystemInformationBlockPos-r15,
+		posSib2-13-r15					SystemInformationBlockPos-r15,
+		posSib2-14-r15					SystemInformationBlockPos-r15,
+		posSib2-15-r15					SystemInformationBlockPos-r15,
+		posSib2-16-r15					SystemInformationBlockPos-r15,
+		posSib2-17-r15					SystemInformationBlockPos-r15,
+		posSib2-18-r15					SystemInformationBlockPos-r15,
+		posSib2-19-r15					SystemInformationBlockPos-r15,
+		posSib3-1-r15					SystemInformationBlockPos-r15,
+		...,
+		[[
+		posSib1-8-v1610					SystemInformationBlockPos-r15,
+		posSib2-20-v1610				SystemInformationBlockPos-r15,
+		posSib2-21-v1610				SystemInformationBlockPos-r15,
+		posSib2-22-v1610				SystemInformationBlockPos-r15,
+		posSib2-23-v1610				SystemInformationBlockPos-r15,
+		posSib2-24-v1610					SystemInformationBlockPos-r15,
+		posSib2-25-v1610					SystemInformationBlockPos-r15,
+		posSib4-1-v1610					SystemInformationBlockPos-r15,
+		posSib5-1-v1610					SystemInformationBlockPos-r15
+		]]
+	},
+	lateNonCriticalExtension		OCTET STRING							OPTIONAL,
+	nonCriticalExtension			SEQUENCE {}								OPTIONAL
+}
+
+
+
+SystemInformationBlockType1-BR-r13 ::=	SystemInformationBlockType1
+
+SystemInformationBlockType1 ::=		SEQUENCE {
+	cellAccessRelatedInfo				SEQUENCE {
+		plmn-IdentityList					PLMN-IdentityList,
+		trackingAreaCode					TrackingAreaCode,
+		cellIdentity						CellIdentity,
+		cellBarred							ENUMERATED {barred, notBarred},
+		intraFreqReselection				ENUMERATED {allowed, notAllowed},
+		csg-Indication						BOOLEAN,
+		csg-Identity						CSG-Identity			OPTIONAL	-- Need OR
+	},
+	cellSelectionInfo					SEQUENCE {
+		q-RxLevMin							Q-RxLevMin,
+		q-RxLevMinOffset					INTEGER (1..8)			OPTIONAL	-- Need OP
+	},
+	p-Max								P-Max						OPTIONAL,			-- Need OP
+	freqBandIndicator					FreqBandIndicator,
+	schedulingInfoList					SchedulingInfoList,
+	tdd-Config							TDD-Config					OPTIONAL,	-- Cond TDD
+	si-WindowLength						ENUMERATED {
+											ms1, ms2, ms5, ms10, ms15, ms20,
+											ms40},
+	systemInfoValueTag					INTEGER (0..31),
+	nonCriticalExtension				SystemInformationBlockType1-v890-IEs	OPTIONAL
+}
+
+SystemInformationBlockType1-v890-IEs::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING SystemInformationBlockType1-v8h0-IEs)			OPTIONAL,
+	nonCriticalExtension				SystemInformationBlockType1-v920-IEs	OPTIONAL
+}
+
+-- Late non critical extensions
+SystemInformationBlockType1-v8h0-IEs ::=	SEQUENCE {
+	multiBandInfoList					MultiBandInfoList		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SystemInformationBlockType1-v9e0-IEs	OPTIONAL
+}
+
+SystemInformationBlockType1-v9e0-IEs ::= SEQUENCE {
+	freqBandIndicator-v9e0				FreqBandIndicator-v9e0		OPTIONAL,	-- Cond FBI-max
+	multiBandInfoList-v9e0				MultiBandInfoList-v9e0		OPTIONAL,	-- Cond mFBI-max
+	nonCriticalExtension				SystemInformationBlockType1-v10j0-IEs	OPTIONAL
+}
+
+SystemInformationBlockType1-v10j0-IEs ::= SEQUENCE {
+	freqBandInfo-r10					NS-PmaxList-r10				OPTIONAL,	-- Need OR
+	multiBandInfoList-v10j0				MultiBandInfoList-v10j0		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SystemInformationBlockType1-v10l0-IEs					OPTIONAL
+}
+
+SystemInformationBlockType1-v10l0-IEs ::= SEQUENCE {
+	freqBandInfo-v10l0					NS-PmaxList-v10l0			OPTIONAL,	-- Need OR
+	multiBandInfoList-v10l0				MultiBandInfoList-v10l0		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SystemInformationBlockType1-v10x0-IEs		OPTIONAL
+}
+
+SystemInformationBlockType1-v10x0-IEs ::=	SEQUENCE {
+	-- This field is only for late non-critical extensions from Rel-10 or Rel-11 onwards
+	lateNonCriticalExtension			OCTET STRING								OPTIONAL,
+	nonCriticalExtension				SystemInformationBlockType1-v12j0-IEs		OPTIONAL
+}
+
+SystemInformationBlockType1-v12j0-IEs ::=	SEQUENCE {
+	schedulingInfoList-v12j0			SchedulingInfoList-v12j0	OPTIONAL,	-- Need OR
+	schedulingInfoListExt-r12			SchedulingInfoListExt-r12	OPTIONAL,	-- Need OR
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+-- Regular non critical extensions
+SystemInformationBlockType1-v920-IEs ::=	SEQUENCE {
+	ims-EmergencySupport-r9				ENUMERATED {true}			OPTIONAL,	-- Need OR
+	cellSelectionInfo-v920				CellSelectionInfo-v920		OPTIONAL,	-- Cond RSRQ
+	nonCriticalExtension				SystemInformationBlockType1-v1130-IEs	OPTIONAL
+}
+
+SystemInformationBlockType1-v1130-IEs ::=	SEQUENCE {
+	tdd-Config-v1130				TDD-Config-v1130			OPTIONAL,	-- Cond TDD-OR
+	cellSelectionInfo-v1130			CellSelectionInfo-v1130		OPTIONAL,	-- Cond WB-RSRQ
+	nonCriticalExtension			SystemInformationBlockType1-v1250-IEs	OPTIONAL
+}
+
+SystemInformationBlockType1-v1250-IEs ::=	SEQUENCE {
+	cellAccessRelatedInfo-v1250					SEQUENCE {
+		category0Allowed-r12						ENUMERATED {true}		OPTIONAL	-- Need OP
+	},
+	cellSelectionInfo-v1250					CellSelectionInfo-v1250		OPTIONAL,	-- Cond RSRQ2
+	freqBandIndicatorPriority-r12			ENUMERATED {true}			OPTIONAL,	-- Cond mFBI
+	nonCriticalExtension			SystemInformationBlockType1-v1310-IEs	OPTIONAL				
+}
+
+SystemInformationBlockType1-v1310-IEs ::=	SEQUENCE {
+	hyperSFN-r13								BIT STRING (SIZE (10))		OPTIONAL,	-- Need OR
+	eDRX-Allowed-r13							ENUMERATED {true}			OPTIONAL,	-- Need OR
+	cellSelectionInfoCE-r13					CellSelectionInfoCE-r13	OPTIONAL,	-- Need OP
+	bandwidthReducedAccessRelatedInfo-r13	SEQUENCE {
+		si-WindowLength-BR-r13					ENUMERATED {
+													ms20, ms40, ms60, ms80, ms120,
+													ms160, ms200, spare},
+		si-RepetitionPattern-r13				ENUMERATED {everyRF, every2ndRF, every4thRF,
+															every8thRF},
+		schedulingInfoList-BR-r13				SchedulingInfoList-BR-r13	OPTIONAL,	-- Cond SI-BR
+		fdd-DownlinkOrTddSubframeBitmapBR-r13	CHOICE {
+			subframePattern10-r13					BIT STRING (SIZE (10)),
+			subframePattern40-r13					BIT STRING (SIZE (40))
+		}																	OPTIONAL,	-- Need OP
+		fdd-UplinkSubframeBitmapBR-r13			BIT STRING (SIZE (10))		OPTIONAL,	-- Need OP
+		startSymbolBR-r13						INTEGER (1..4),
+		si-HoppingConfigCommon-r13				ENUMERATED {on,off},
+		si-ValidityTime-r13						ENUMERATED {true}	OPTIONAL,			-- Need OP
+		systemInfoValueTagList-r13				SystemInfoValueTagList-r13	OPTIONAL	-- Need OR
+	}																OPTIONAL,	-- Cond BW-reduced
+	nonCriticalExtension						SystemInformationBlockType1-v1320-IEs	OPTIONAL
+}
+
+SystemInformationBlockType1-v1320-IEs ::=	SEQUENCE {
+	freqHoppingParametersDL-r13				SEQUENCE {
+		mpdcch-pdsch-HoppingNB-r13				ENUMERATED {nb2, nb4}		OPTIONAL,	-- Need OR
+		interval-DLHoppingConfigCommonModeA-r13	CHOICE {
+			interval-FDD-r13					ENUMERATED {int1, int2, int4, int8},
+			interval-TDD-r13					ENUMERATED {int1, int5, int10, int20}
+		}																	OPTIONAL,	-- Need OR
+		interval-DLHoppingConfigCommonModeB-r13	CHOICE {
+			interval-FDD-r13					ENUMERATED {int2, int4, int8, int16},
+			interval-TDD-r13					ENUMERATED { int5, int10, int20, int40}
+		}																	OPTIONAL,	-- Need OR
+		mpdcch-pdsch-HoppingOffset-r13			INTEGER (1..maxAvailNarrowBands-r13)	OPTIONAL	-- Need OR
+	}																OPTIONAL,	-- Cond Hopping
+	nonCriticalExtension						SystemInformationBlockType1-v1350-IEs					OPTIONAL
+}
+
+SystemInformationBlockType1-v1350-IEs ::=	SEQUENCE {
+	cellSelectionInfoCE1-r13				CellSelectionInfoCE1-r13	OPTIONAL,	-- Need OP
+	nonCriticalExtension					SystemInformationBlockType1-v1360-IEs				OPTIONAL
+}
+
+SystemInformationBlockType1-v1360-IEs ::=	SEQUENCE {
+	cellSelectionInfoCE1-v1360				CellSelectionInfoCE1-v1360	OPTIONAL,	-- Cond QrxlevminCE1
+	nonCriticalExtension						SystemInformationBlockType1-v1430-IEs		OPTIONAL
+}
+
+SystemInformationBlockType1-v1430-IEs ::=	SEQUENCE {
+	eCallOverIMS-Support-r14				ENUMERATED {true}			OPTIONAL,	-- Need OR
+	tdd-Config-v1430						TDD-Config-v1430			OPTIONAL,	-- Cond TDD-OR
+	cellAccessRelatedInfoList-r14			SEQUENCE (SIZE (1..maxPLMN-1-r14)) OF
+											CellAccessRelatedInfo-r14	OPTIONAL,	-- Need OR
+	nonCriticalExtension					SystemInformationBlockType1-v1450-IEs				OPTIONAL
+}
+
+SystemInformationBlockType1-v1450-IEs ::=	SEQUENCE {
+	tdd-Config-v1450						TDD-Config-v1450		OPTIONAL,	-- Cond TDD-OR
+	nonCriticalExtension					SystemInformationBlockType1-v1530-IEs					OPTIONAL
+}
+
+SystemInformationBlockType1-v1530-IEs ::=	SEQUENCE {
+	hsdn-Cell-r15						ENUMERATED {true}			OPTIONAL,	-- Need OR
+	cellSelectionInfoCE-v1530			CellSelectionInfoCE-v1530	OPTIONAL,	-- Need OP
+	crs-IntfMitigConfig-r15				CHOICE {
+		crs-IntfMitigEnabled					NULL,
+		crs-IntfMitigNumPRBs			ENUMERATED {n6, n24}
+	}	OPTIONAL,	-- Need OR
+	cellBarred-CRS-r15					ENUMERATED {barred, notBarred},
+	plmn-IdentityList-v1530				PLMN-IdentityList-v1530		OPTIONAL,	-- Need OR
+	posSchedulingInfoList-r15			PosSchedulingInfoList-r15	OPTIONAL,	-- Need OR
+	cellAccessRelatedInfo-5GC-r15		SEQUENCE {
+		cellBarred-5GC-r15					ENUMERATED {barred, notBarred},
+		cellBarred-5GC-CRS-r15				ENUMERATED {barred, notBarred},
+		cellAccessRelatedInfoList-5GC-r15	SEQUENCE (SIZE (1..maxPLMN-r11)) OF
+											CellAccessRelatedInfo-5GC-r15
+	}				OPTIONAL,	-- Need OP
+	ims-EmergencySupport5GC-r15			ENUMERATED {true}			OPTIONAL,	-- Need OR
+	eCallOverIMS-Support5GC-r15			ENUMERATED {true}			OPTIONAL,	-- Need OR
+	nonCriticalExtension				SystemInformationBlockType1-v1540-IEs		OPTIONAL
+}
+
+SystemInformationBlockType1-v1540-IEs ::=	SEQUENCE {
+	si-posOffset-r15								ENUMERATED {true}		OPTIONAL,	-- Need ON
+	nonCriticalExtension							SystemInformationBlockType1-v1610-IEs	OPTIONAL
+}
+
+SystemInformationBlockType1-v1610-IEs ::=	SEQUENCE {
+	eDRX-Allowed-5GC-r16					ENUMERATED {true}		OPTIONAL,	-- Need OR
+	transmissionInControlChRegion-r16	ENUMERATED {true}		OPTIONAL,	-- Cond BW-reduced
+	campingAllowedInCE-r16				ENUMERATED {true}			OPTIONAL,	-- Need OR
+	plmn-IdentityList-v1610				PLMN-IdentityList-v1610		OPTIONAL,	-- Need OR
+	nonCriticalExtension					SEQUENCE {}			OPTIONAL
+}
+
+PLMN-IdentityList ::=					SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-IdentityInfo
+
+PLMN-IdentityInfo ::=					SEQUENCE {
+	plmn-Identity							PLMN-Identity,
+	cellReservedForOperatorUse				ENUMERATED {reserved, notReserved}
+}
+
+PLMN-IdentityList-v1530 ::=				SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-IdentityInfo-v1530
+
+PLMN-IdentityInfo-v1530 ::=				SEQUENCE {
+	cellReservedForOperatorUse-CRS-r15		ENUMERATED {reserved, notReserved}
+}
+
+PLMN-IdentityList-r15::=			SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-IdentityInfo-r15
+
+PLMN-IdentityList-v1610::=	SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-IdentityInfo-v1610
+
+PLMN-IdentityInfo-r15 ::=			SEQUENCE {
+	plmn-Identity-5GC-r15				CHOICE{
+		plmn-Identity-r15					PLMN-Identity,
+		plmn-Index-r15						INTEGER (1..maxPLMN-r11)
+	},
+	cellReservedForOperatorUse-r15			ENUMERATED {reserved, notReserved},
+	cellReservedForOperatorUse-CRS-r15		ENUMERATED {reserved, notReserved}
+}
+
+PLMN-IdentityInfo-v1610 ::=	SEQUENCE {
+	cp-CIoT-5GS-Optimisation-r16	ENUMERATED {true}			OPTIONAL,	-- Need OR
+	up-CIoT-5GS-Optimisation-r16	ENUMERATED {true}			OPTIONAL,	-- Need OR
+	iab-Support-r16				ENUMERATED {true}			OPTIONAL	-- Need OR
+}
+
+SchedulingInfoList ::= SEQUENCE (SIZE (1..maxSI-Message)) OF SchedulingInfo
+
+SchedulingInfoList-v12j0 ::=	SEQUENCE (SIZE (1..maxSI-Message)) OF SchedulingInfo-v12j0
+
+SchedulingInfoListExt-r12 ::=	SEQUENCE (SIZE (1..maxSI-Message)) OF SchedulingInfoExt-r12
+
+SchedulingInfo ::=	SEQUENCE {
+	si-Periodicity				SI-Periodicity-r12,
+	sib-MappingInfo				SIB-MappingInfo
+}
+
+SchedulingInfo-v12j0 ::=	SEQUENCE {
+	sib-MappingInfo-v12j0		SIB-MappingInfo-v12j0				OPTIONAL	-- Need OR
+}
+
+SchedulingInfoExt-r12 ::=	SEQUENCE {
+	si-Periodicity-r12			SI-Periodicity-r12,
+	sib-MappingInfo-r12			SIB-MappingInfo-v12j0
+}
+
+SchedulingInfoList-BR-r13 ::= SEQUENCE (SIZE (1..maxSI-Message)) OF SchedulingInfo-BR-r13
+
+SchedulingInfo-BR-r13 ::=	SEQUENCE {
+	si-Narrowband-r13		INTEGER (1..maxAvailNarrowBands-r13),
+	si-TBS-r13				ENUMERATED {b152, b208, b256, b328, b408, b504, b600, b712, b808, b936}
+}
+
+SIB-MappingInfo ::= SEQUENCE (SIZE (0..maxSIB-1)) OF SIB-Type
+
+SIB-MappingInfo-v12j0 ::=	SEQUENCE (SIZE (1..maxSIB-1)) OF SIB-Type-v12j0
+
+SIB-Type ::=						ENUMERATED {
+										sibType3, sibType4, sibType5, sibType6,
+										sibType7, sibType8, sibType9, sibType10,
+										sibType11, sibType12-v920, sibType13-v920,
+										sibType14-v1130, sibType15-v1130,
+										sibType16-v1130, sibType17-v1250, sibType18-v1250,
+										..., sibType19-v1250, sibType20-v1310, sibType21-v1430,
+										sibType24-v1530, sibType25-v1530, sibType26-v1530,
+										sibType26a-v1610, sibType27-v1610, sibType28-v1610,
+										sibType29-v1610}
+
+SIB-Type-v12j0 ::=			ENUMERATED {
+								sibType19-v1250, sibType20-v1310, sibType21-v1430,
+								sibType24-v1530, sibType25-v1530, sibType26-v1530,
+								sibType26a-v1610, sibType27-v1610, sibType28-v1610,
+								sibType29-v1610, spare6, spare5,
+								spare4, spare3, spare2, spare1, ...}
+
+SI-Periodicity-r12 ::=		ENUMERATED {rf8, rf16, rf32, rf64, rf128, rf256, rf512}
+
+SystemInfoValueTagList-r13 ::=		SEQUENCE (SIZE (1..maxSI-Message)) OF SystemInfoValueTagSI-r13
+
+SystemInfoValueTagSI-r13 ::=		INTEGER (0..3)
+
+CellSelectionInfo-v920 ::=			SEQUENCE {
+	q-QualMin-r9						Q-QualMin-r9,
+	q-QualMinOffset-r9					INTEGER (1..8)						OPTIONAL	-- Need OP
+}
+
+CellSelectionInfo-v1130 ::=			SEQUENCE {
+	q-QualMinWB-r11						Q-QualMin-r9
+}
+
+CellSelectionInfo-v1250 ::=			SEQUENCE {
+	q-QualMinRSRQ-OnAllSymbols-r12		Q-QualMin-r9
+}
+
+CellAccessRelatedInfo-r14 ::=	SEQUENCE {
+	plmn-IdentityList-r14				PLMN-IdentityList,
+	trackingAreaCode-r14				TrackingAreaCode,
+	cellIdentity-r14					CellIdentity
+}
+
+CellAccessRelatedInfo-5GC-r15 ::=	SEQUENCE {
+	plmn-IdentityList-r15			PLMN-IdentityList-r15,
+	ran-AreaCode-r15					RAN-AreaCode-r15 OPTIONAL,	-- Need OR
+	trackingAreaCode-5GC-r15			TrackingAreaCode-5GC-r15,
+	cellIdentity-5GC-r15				CellIdentity-5GC-r15
+}
+
+CellIdentity-5GC-r15 ::= CHOICE{
+	cellIdentity-r15	CellIdentity,
+	cellId-Index-r15	INTEGER (1..maxPLMN-r11)
+}
+
+PosSchedulingInfoList-r15 ::= SEQUENCE (SIZE (1..maxSI-Message)) OF PosSchedulingInfo-r15
+
+PosSchedulingInfo-r15 ::=	SEQUENCE {
+	posSI-Periodicity-r15		ENUMERATED {rf8, rf16, rf32, rf64, rf128, rf256, rf512},
+	posSIB-MappingInfo-r15		PosSIB-MappingInfo-r15
+}
+
+PosSIB-MappingInfo-r15 ::= SEQUENCE (SIZE (1..maxSIB)) OF PosSIB-Type-r15
+
+PosSIB-Type-r15 ::= SEQUENCE {
+	encrypted-r15		ENUMERATED { true }				OPTIONAL,		-- Need OP
+	gnss-id-r15			GNSS-ID-r15						OPTIONAL,		-- Need OP
+	sbas-id-r15			SBAS-ID-r15						OPTIONAL,		-- Need OP
+	posSibType-r15		ENUMERATED {	posSibType1-1,
+										posSibType1-2,
+										posSibType1-3,
+										posSibType1-4,
+										posSibType1-5,
+										posSibType1-6,
+										posSibType1-7,
+										posSibType2-1,
+										posSibType2-2,
+										posSibType2-3,
+										posSibType2-4,
+										posSibType2-5,
+										posSibType2-6,
+										posSibType2-7,
+										posSibType2-8,
+										posSibType2-9,
+										posSibType2-10,
+										posSibType2-11,
+										posSibType2-12,
+										posSibType2-13,
+										posSibType2-14,
+										posSibType2-15,
+										posSibType2-16,
+										posSibType2-17,
+										posSibType2-18,
+										posSibType2-19,
+										posSibType3-1,
+										...,
+										posSibType1-8-v1610,
+										posSibType2-20-v1610,
+										posSibType2-21-v1610,
+										posSibType2-22-v1610,
+										posSibType2-23-v1610,
+										posSibType2-24-v1610,
+										posSibType2-25-v1610,
+										posSibType4-1-v1610,
+										posSibType5-1-v1610
+	},
+	...
+}
+
+
+
+SystemInformationBlockType1-MBMS-r14 ::=	SEQUENCE {
+	cellAccessRelatedInfo-r14				SEQUENCE {
+		plmn-IdentityList-r14					PLMN-IdentityList-MBMS-r14,
+		trackingAreaCode-r14						TrackingAreaCode,
+		cellIdentity-r14							CellIdentity
+	},
+	freqBandIndicator-r14					FreqBandIndicator-r11,
+	multiBandInfoList-r14					MultiBandInfoList-r11				OPTIONAL, -- Need OR
+	schedulingInfoList-MBMS-r14			SchedulingInfoList-MBMS-r14,
+	si-WindowLength-r14						ENUMERATED {
+												ms1, ms2, ms5, ms10, ms15, ms20,ms40, ms80},
+	systemInfoValueTag-r14					INTEGER (0..31),
+	nonMBSFN-SubframeConfig-r14				NonMBSFN-SubframeConfig-r14		OPTIONAL, --Need OR
+	pdsch-ConfigCommon-r14					PDSCH-ConfigCommon,
+	systemInformationBlockType13-r14		SystemInformationBlockType13-r9	OPTIONAL, --Need OR
+	cellAccessRelatedInfoList-r14		SEQUENCE (SIZE (1..maxPLMN-1-r14)) OF
+											CellAccessRelatedInfo-r14	OPTIONAL,	-- Need OR
+	nonCriticalExtension					SEQUENCE {}							OPTIONAL
+}
+
+PLMN-IdentityList-MBMS-r14 ::=				SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-Identity
+
+SchedulingInfoList-MBMS-r14 ::= SEQUENCE (SIZE (1..maxSI-Message)) OF SchedulingInfo-MBMS-r14
+
+SchedulingInfo-MBMS-r14 ::=	SEQUENCE {
+	si-Periodicity-r14						ENUMERATED {
+												rf16, rf32, rf64, rf128, rf256, rf512},
+	sib-MappingInfo-r14						SIB-MappingInfo-MBMS-r14
+}
+
+SIB-MappingInfo-MBMS-r14 ::= SEQUENCE (SIZE (0..maxSIB-1)) OF SIB-Type-MBMS-r14
+
+SIB-Type-MBMS-r14 ::=					ENUMERATED {
+											sibType10, sibType11, sibType12-v920, sibType13-v920,
+											sibType15-v1130, sibType16-v1130, ...}
+
+
+NonMBSFN-SubframeConfig-r14 ::=			SEQUENCE {
+	radioFrameAllocationPeriod-r14		ENUMERATED {rf4, rf8, rf16, rf32, rf64, rf128, rf512},
+	radioFrameAllocationOffset-r14		INTEGER (0..7),
+	subframeAllocation-r14				BIT STRING (SIZE(9))
+}
+
+
+
+UEAssistanceInformation-r11 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ueAssistanceInformation-r11			UEAssistanceInformation-r11-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UEAssistanceInformation-r11-IEs ::=		SEQUENCE {
+	powerPrefIndication-r11				ENUMERATED	{normal, lowPowerConsumption}	OPTIONAL,
+	lateNonCriticalExtension			OCTET STRING								OPTIONAL,
+	nonCriticalExtension				UEAssistanceInformation-v1430-IEs			OPTIONAL
+}
+
+UEAssistanceInformation-v1430-IEs ::=	SEQUENCE {
+	bw-Preference-r14						BW-Preference-r14						OPTIONAL,
+	sps-AssistanceInformation-r14			SEQUENCE {
+		trafficPatternInfoListSL-r14			TrafficPatternInfoList-r14			OPTIONAL,
+		trafficPatternInfoListUL-r14			TrafficPatternInfoList-r14			OPTIONAL
+	}			OPTIONAL,
+	rlm-Report-r14							SEQUENCE {
+		rlm-Event-r14							ENUMERATED {earlyOutOfSync, earlyInSync},
+		excessRep-MPDCCH-r14					ENUMERATED {excessRep1, excessRep2}	OPTIONAL
+	}																				OPTIONAL,
+	delayBudgetReport-r14					DelayBudgetReport-r14					OPTIONAL,
+	nonCriticalExtension					UEAssistanceInformation-v1450-IEs		OPTIONAL
+}
+
+UEAssistanceInformation-v1450-IEs ::=	SEQUENCE {
+	overheatingAssistance-r14				OverheatingAssistance-r14				OPTIONAL,
+	nonCriticalExtension					UEAssistanceInformation-v1530-IEs		OPTIONAL
+}
+
+UEAssistanceInformation-v1530-IEs ::=	SEQUENCE {
+	sps-AssistanceInformation-v1530			SEQUENCE {
+		trafficPatternInfoListSL-v1530			TrafficPatternInfoList-v1530
+	}			OPTIONAL,
+	nonCriticalExtension					UEAssistanceInformation-v1610-IEs						OPTIONAL
+}
+
+UEAssistanceInformation-v1610-IEs ::=	SEQUENCE {
+	overheatingAssistance-v1610				OverheatingAssistance-v1610			OPTIONAL,
+	nonCriticalExtension						SEQUENCE {}							OPTIONAL
+}
+
+BW-Preference-r14 ::= SEQUENCE {
+	dl-Preference-r14		ENUMERATED	{mhz1dot4, mhz5, mhz20 }				OPTIONAL,
+	ul-Preference-r14		ENUMERATED	{mhz1dot4, mhz5}						OPTIONAL
+}
+
+TrafficPatternInfoList-r14 ::= SEQUENCE (SIZE (1..maxTrafficPattern-r14)) OF TrafficPatternInfo-r14
+
+TrafficPatternInfo-r14 ::=	SEQUENCE {
+	trafficPeriodicity-r14			ENUMERATED {
+										sf20, sf50, sf100, sf200, sf300, sf400, sf500,
+										sf600, sf700, sf800, sf900, sf1000},
+	timingOffset-r14				INTEGER (0..10239),
+	priorityInfoSL-r14				SL-Priority-r13								OPTIONAL,
+	logicalChannelIdentityUL-r14	INTEGER (3..10)								OPTIONAL,
+	messageSize-r14					BIT STRING (SIZE (6))
+}
+
+TrafficPatternInfoList-v1530 ::= SEQUENCE (SIZE (1..maxTrafficPattern-r14)) OF TrafficPatternInfo-v1530
+
+TrafficPatternInfo-v1530 ::=	SEQUENCE {
+	trafficDestination-r15			SL-DestinationIdentity-r12					OPTIONAL,
+	reliabilityInfoSL-r15			SL-Reliability-r15							OPTIONAL
+}
+
+DelayBudgetReport-r14::=	CHOICE {
+	type1							ENUMERATED {
+										msMinus1280, msMinus640, msMinus320, msMinus160,
+										msMinus80, msMinus60, msMinus40, msMinus20, ms0, ms20,
+												ms40, ms60, ms80, ms160, ms320, ms640, ms1280},
+
+	type2							ENUMERATED {
+										msMinus192, msMinus168,msMinus144, msMinus120,
+										msMinus96, msMinus72, msMinus48, msMinus24, ms0, ms24,
+												ms48, ms72, ms96, ms120, ms144, ms168, ms192}
+}
+
+OverheatingAssistance-r14 ::=	SEQUENCE {
+		reducedUE-Category			SEQUENCE {
+			reducedUE-CategoryDL		INTEGER (0..19),
+			reducedUE-CategoryUL		INTEGER (0..21)
+		}		OPTIONAL,
+		reducedMaxCCs				SEQUENCE {
+			reducedCCsDL				INTEGER (0..31),
+			reducedCCsUL				INTEGER (0..31)
+		}		OPTIONAL
+}
+
+OverheatingAssistance-v1610 ::=	SEQUENCE {
+		overheatingAssistanceForSCG-r16			OCTET STRING
+}
+
+
+
+UECapabilityEnquiry ::=				SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ueCapabilityEnquiry-r8				UECapabilityEnquiry-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UECapabilityEnquiry-r8-IEs ::=		SEQUENCE {
+	ue-CapabilityRequest				UE-CapabilityRequest,
+	nonCriticalExtension				UECapabilityEnquiry-v8a0-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v8a0-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				UECapabilityEnquiry-v1180-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v1180-IEs ::=	SEQUENCE {
+	requestedFrequencyBands-r11			SEQUENCE (SIZE (1..16)) OF FreqBandIndicator-r11	OPTIONAL,
+	nonCriticalExtension				UECapabilityEnquiry-v1310-IEs						OPTIONAL
+}
+
+UECapabilityEnquiry-v1310-IEs ::=	SEQUENCE {
+	requestReducedFormat-r13			ENUMERATED {true}					OPTIONAL,	-- Need ON
+	requestSkipFallbackComb-r13			ENUMERATED {true}					OPTIONAL,	-- Need ON
+	requestedMaxCCsDL-r13				INTEGER (2..32)						OPTIONAL,	-- Need ON
+	requestedMaxCCsUL-r13				INTEGER (2..32)						OPTIONAL,	-- Need ON
+	requestReducedIntNonContComb-r13	ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension				UECapabilityEnquiry-v1430-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v1430-IEs ::=	SEQUENCE {
+	requestDiffFallbackCombList-r14		BandCombinationList-r14				OPTIONAL,	-- Need ON
+	nonCriticalExtension				UECapabilityEnquiry-v1510-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v1510-IEs ::=	SEQUENCE {
+	requestedFreqBandsNR-MRDC-r15		OCTET STRING						OPTIONAL,
+	nonCriticalExtension				UECapabilityEnquiry-v1530-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v1530-IEs ::=	SEQUENCE {
+	requestSTTI-SPT-Capability-r15		ENUMERATED {true}					OPTIONAL,
+	eutra-nr-only-r15					ENUMERATED {true}					OPTIONAL,
+	nonCriticalExtension				UECapabilityEnquiry-v1550-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v1550-IEs ::=	SEQUENCE {
+	requestedCapabilityNR-r15			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				UECapabilityEnquiry-v1560-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v1560-IEs ::=	SEQUENCE {
+	requestedCapabilityCommon-r15		OCTET STRING						OPTIONAL,
+	nonCriticalExtension				UECapabilityEnquiry-v1610-IEs		OPTIONAL
+}
+
+UECapabilityEnquiry-v1610-IEs ::=	SEQUENCE {
+	rrc-SegAllowed-r16					ENUMERATED {enabled}			OPTIONAL,	-- Need ON
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+UE-CapabilityRequest ::=			SEQUENCE (SIZE (1..maxRAT-Capabilities)) OF RAT-Type
+
+
+
+UECapabilityInformation ::=			SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			ueCapabilityInformation-r8			UECapabilityInformation-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UECapabilityInformation-r8-IEs ::=	SEQUENCE {
+	ue-CapabilityRAT-ContainerList		UE-CapabilityRAT-ContainerList,
+	nonCriticalExtension				UECapabilityInformation-v8a0-IEs	OPTIONAL
+}
+
+UECapabilityInformation-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				UECapabilityInformation-v1250-IEs	OPTIONAL
+}
+
+UECapabilityInformation-v1250-IEs ::= SEQUENCE {
+	ue-RadioPagingInfo-r12				UE-RadioPagingInfo-r12				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+ULDedicatedMessageSegment-r16 ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		ulDedicatedMessageSegment-r16		ULDedicatedMessageSegment-r16-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+ULDedicatedMessageSegment-r16-IEs ::=	SEQUENCE {
+	segmentNumber-r16						INTEGER (0..15),
+	rrc-MessageSegmentContainer-r16			OCTET STRING,
+	rrc-MessageSegmentType-r16				ENUMERATED {notLastSegment, lastSegment},
+	lateNonCriticalExtension				OCTET STRING						OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}							OPTIONAL
+}
+
+
+
+UEInformationRequest-r9		::=				SEQUENCE {
+	rrc-TransactionIdentifier		RRC-TransactionIdentifier,
+	criticalExtensions				CHOICE {
+		c1								CHOICE {
+			ueInformationRequest-r9				UEInformationRequest-r9-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UEInformationRequest-r9-IEs ::=		SEQUENCE {
+	rach-ReportReq-r9					BOOLEAN,
+	rlf-ReportReq-r9					BOOLEAN,
+	nonCriticalExtension				UEInformationRequest-v930-IEs		OPTIONAL
+}
+
+UEInformationRequest-v930-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				UEInformationRequest-v1020-IEs		OPTIONAL
+}
+
+UEInformationRequest-v1020-IEs ::=	SEQUENCE {
+	logMeasReportReq-r10				ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension				UEInformationRequest-v1130-IEs		OPTIONAL
+}
+
+UEInformationRequest-v1130-IEs ::= SEQUENCE {
+	connEstFailReportReq-r11			ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension				UEInformationRequest-v1250-IEs		OPTIONAL
+}
+
+UEInformationRequest-v1250-IEs ::= SEQUENCE {
+	mobilityHistoryReportReq-r12		ENUMERATED {true}					OPTIONAL,	-- Need ON
+	nonCriticalExtension				UEInformationRequest-v1530-IEs		OPTIONAL
+}
+
+UEInformationRequest-v1530-IEs ::= SEQUENCE {
+	idleModeMeasurementReq-r15			ENUMERATED {true}					OPTIONAL,	-- Need ON
+	flightPathInfoReq-r15				FlightPathInfoReportConfig-r15		OPTIONAL,	-- Need ON
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+UEInformationResponse-r9	::=		SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ueInformationResponse-r9			UEInformationResponse-r9-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UEInformationResponse-r9-IEs ::=		SEQUENCE {
+	rach-Report-r9							RACH-Report-r16		OPTIONAL,
+	rlf-Report-r9							RLF-Report-r9			OPTIONAL,
+	nonCriticalExtension					UEInformationResponse-v930-IEs			OPTIONAL
+}
+
+-- Late non critical extensions
+UEInformationResponse-v9e0-IEs ::= SEQUENCE {
+	rlf-Report-v9e0						RLF-Report-v9e0					OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+-- Regular non critical extensions
+UEInformationResponse-v930-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING UEInformationResponse-v9e0-IEs)	OPTIONAL,
+	nonCriticalExtension				UEInformationResponse-v1020-IEs		OPTIONAL
+}
+
+UEInformationResponse-v1020-IEs ::= SEQUENCE {
+	logMeasReport-r10					LogMeasReport-r10					OPTIONAL,
+	nonCriticalExtension				UEInformationResponse-v1130-IEs		OPTIONAL
+}
+
+UEInformationResponse-v1130-IEs ::= SEQUENCE {
+	connEstFailReport-r11				ConnEstFailReport-r11				OPTIONAL,
+	nonCriticalExtension				UEInformationResponse-v1250-IEs		OPTIONAL
+}
+
+UEInformationResponse-v1250-IEs ::= SEQUENCE {
+	mobilityHistoryReport-r12			MobilityHistoryReport-r12			OPTIONAL,
+	nonCriticalExtension				UEInformationResponse-v1530-IEs		OPTIONAL
+}
+
+UEInformationResponse-v1530-IEs ::= SEQUENCE {
+	measResultListIdle-r15				MeasResultListIdle-r15			OPTIONAL,
+	flightPathInfoReport-r15			FlightPathInfoReport-r15		OPTIONAL,
+	nonCriticalExtension				UEInformationResponse-v1610-IEs		OPTIONAL
+}
+
+UEInformationResponse-v1610-IEs ::= SEQUENCE {
+	rach-Report-v1610					RACH-Report-v1610				OPTIONAL,
+	measResultListExtIdle-r16			MeasResultListExtIdle-r16		OPTIONAL,
+	measResultListIdleNR-r16			MeasResultListIdleNR-r16		OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+RACH-Report-r16 ::=					SEQUENCE {
+	numberOfPreamblesSent-r16			NumberOfPreamblesSent-r11,
+	contentionDetected-r16				BOOLEAN
+}
+
+RACH-Report-v1610 ::=	SEQUENCE {
+	initialCEL-r16 					INTEGER (0..3),
+	edt-Fallback-r16					BOOLEAN
+}
+
+RLF-Report-r9 ::=					SEQUENCE {
+	measResultLastServCell-r9			SEQUENCE {
+		rsrpResult-r9						RSRP-Range,
+		rsrqResult-r9						RSRQ-Range						OPTIONAL
+	},
+	measResultNeighCells-r9				SEQUENCE {
+		measResultListEUTRA-r9				MeasResultList2EUTRA-r9			OPTIONAL,
+		measResultListUTRA-r9				MeasResultList2UTRA-r9			OPTIONAL,
+		measResultListGERAN-r9				MeasResultListGERAN				OPTIONAL,
+		measResultsCDMA2000-r9				MeasResultList2CDMA2000-r9		OPTIONAL
+	}	OPTIONAL,
+	...,
+	[[	locationInfo-r10				LocationInfo-r10					OPTIONAL,
+		failedPCellId-r10					CHOICE {
+			cellGlobalId-r10					CellGlobalIdEUTRA,
+			pci-arfcn-r10						SEQUENCE {
+				physCellId-r10						PhysCellId,
+				carrierFreq-r10						ARFCN-ValueEUTRA
+			}
+		}																	OPTIONAL,
+		reestablishmentCellId-r10		CellGlobalIdEUTRA					OPTIONAL,
+		timeConnFailure-r10				INTEGER (0..1023)					OPTIONAL,
+		connectionFailureType-r10		ENUMERATED {rlf, hof}				OPTIONAL,
+		previousPCellId-r10				CellGlobalIdEUTRA					OPTIONAL
+	]],
+	[[	failedPCellId-v1090				SEQUENCE {
+			carrierFreq-v1090				ARFCN-ValueEUTRA-v9e0
+		}																	OPTIONAL
+	]],
+	[[	basicFields-r11					SEQUENCE {
+			c-RNTI-r11						C-RNTI,
+			rlf-Cause-r11					ENUMERATED {
+												t310-Expiry, randomAccessProblem,
+												rlc-MaxNumRetx, t312-Expiry-r12},
+			timeSinceFailure-r11			TimeSinceFailure-r11
+		}																	OPTIONAL,
+		previousUTRA-CellId-r11			SEQUENCE {
+			carrierFreq-r11					ARFCN-ValueUTRA,
+			physCellId-r11					CHOICE {
+				fdd-r11							PhysCellIdUTRA-FDD,
+				tdd-r11							PhysCellIdUTRA-TDD
+			},
+			cellGlobalId-r11				CellGlobalIdUTRA				OPTIONAL
+		}																	OPTIONAL,
+		selectedUTRA-CellId-r11			SEQUENCE {
+			carrierFreq-r11					ARFCN-ValueUTRA,
+			physCellId-r11					CHOICE {
+				fdd-r11							PhysCellIdUTRA-FDD,
+				tdd-r11							PhysCellIdUTRA-TDD
+			}
+		}																	OPTIONAL
+	]],
+	[[	failedPCellId-v1250				SEQUENCE {
+			tac-FailedPCell-r12				TrackingAreaCode
+		}																	OPTIONAL,
+		measResultLastServCell-v1250	RSRQ-Range-v1250					OPTIONAL,
+		lastServCellRSRQ-Type-r12		RSRQ-Type-r12						OPTIONAL,
+		measResultListEUTRA-v1250		MeasResultList2EUTRA-v1250			OPTIONAL
+	]],
+	[[	drb-EstablishedWithQCI-1-r13	ENUMERATED {qci1}					OPTIONAL
+	]],
+	[[	measResultLastServCell-v1360	RSRP-Range-v1360					OPTIONAL
+	]],
+	[[	logMeasResultListBT-r15			LogMeasResultListBT-r15				OPTIONAL,
+		logMeasResultListWLAN-r15		LogMeasResultListWLAN-r15			OPTIONAL
+	]],
+	[[	measResultListNR-r16			MeasResultCellListNR-r15			OPTIONAL,
+		previousNR-PCellId-r16			CellGlobalIdNR-r16					OPTIONAL,
+		failedNR-PCellId-r16			CHOICE {
+			cellGlobalId-r16				CellGlobalIdNR-r16,
+			pci-arfcn-r16					SEQUENCE {
+				physCellId-r16					PhysCellIdNR-r15,
+				carrierFreq-r16					ARFCN-ValueNR-r15
+			}
+		}																	OPTIONAL,
+		reconnectCellId-r16				CHOICE {
+			nrReconnectCellId-r16			CellGlobalIdNR-r16,
+			eutraReconnectCellId-r16		SEQUENCE {
+				cellGlobalId-r16				CellGlobalIdEUTRA,
+				trackingAreaCode-EPC-r16		TrackingAreaCode			OPTIONAL,
+				trackingAreaCode-5GC-r16		TrackingAreaCode-5GC-r15	OPTIONAL
+			}
+		}																	OPTIONAL,
+		timeUntilReconnection-r16		TimeUntilReconnection-r16			OPTIONAL
+	]],
+	[[	measResultListNR-v1640			SEQUENCE {
+			carrierFreqNR-r16				ARFCN-ValueNR-r15
+		}																	OPTIONAL,
+		measResultListExtNR-r16			MeasResultFreqListNR-r16		OPTIONAL
+	]]
+}
+
+RLF-Report-v9e0 ::=				SEQUENCE {
+	measResultListEUTRA-v9e0			MeasResultList2EUTRA-v9e0
+}
+
+MeasResultList2EUTRA-r9 ::=				SEQUENCE (SIZE (1..maxFreq)) OF MeasResult2EUTRA-r9
+
+MeasResultList2EUTRA-v9e0 ::=			SEQUENCE (SIZE (1..maxFreq)) OF MeasResult2EUTRA-v9e0
+
+MeasResultList2EUTRA-v1250 ::=			SEQUENCE (SIZE (1..maxFreq)) OF MeasResult2EUTRA-v1250
+
+MeasResult2EUTRA-r9 ::=				SEQUENCE {
+	carrierFreq-r9						ARFCN-ValueEUTRA,
+	measResultList-r9					MeasResultListEUTRA
+}
+
+MeasResult2EUTRA-v9e0 ::=			SEQUENCE {
+	carrierFreq-v9e0					ARFCN-ValueEUTRA-v9e0		OPTIONAL
+}
+
+MeasResult2EUTRA-v1250 ::=			SEQUENCE {
+	rsrq-Type-r12						RSRQ-Type-r12		OPTIONAL
+}
+
+MeasResultList2UTRA-r9 ::=			SEQUENCE (SIZE (1..maxFreq)) OF MeasResult2UTRA-r9
+
+MeasResult2UTRA-r9 ::=				SEQUENCE {
+	carrierFreq-r9						ARFCN-ValueUTRA,
+	measResultList-r9					MeasResultListUTRA
+}
+
+MeasResultList2CDMA2000-r9 ::=		SEQUENCE (SIZE (1..maxFreq)) OF MeasResult2CDMA2000-r9
+
+MeasResult2CDMA2000-r9 ::=			SEQUENCE {
+	carrierFreq-r9						CarrierFreqCDMA2000,
+	measResultList-r9					MeasResultsCDMA2000
+}
+
+LogMeasReport-r10 ::=				SEQUENCE {
+	absoluteTimeStamp-r10				AbsoluteTimeInfo-r10,
+	traceReference-r10					TraceReference-r10,
+	traceRecordingSessionRef-r10		OCTET STRING (SIZE (2)),
+	tce-Id-r10							OCTET STRING (SIZE (1)),
+	logMeasInfoList-r10					LogMeasInfoList-r10,
+	logMeasAvailable-r10				ENUMERATED {true}				OPTIONAL,
+	...,
+	[[	logMeasAvailableBT-r15			ENUMERATED {true}				OPTIONAL,
+		logMeasAvailableWLAN-r15		ENUMERATED {true}				OPTIONAL
+	]]
+}
+
+LogMeasInfoList-r10 ::=		SEQUENCE (SIZE (1..maxLogMeasReport-r10)) OF LogMeasInfo-r10
+
+LogMeasInfo-r10 ::=		SEQUENCE {
+	locationInfo-r10					LocationInfo-r10				OPTIONAL,
+	relativeTimeStamp-r10				INTEGER (0..7200),
+	servCellIdentity-r10				CellGlobalIdEUTRA,
+	measResultServCell-r10				SEQUENCE {
+		rsrpResult-r10						RSRP-Range,
+		rsrqResult-r10						RSRQ-Range
+	},
+	measResultNeighCells-r10			SEQUENCE {
+		measResultListEUTRA-r10				MeasResultList2EUTRA-r9		OPTIONAL,
+		measResultListUTRA-r10				MeasResultList2UTRA-r9		OPTIONAL,
+		measResultListGERAN-r10				MeasResultList2GERAN-r10	OPTIONAL,
+		measResultListCDMA2000-r10			MeasResultList2CDMA2000-r9	OPTIONAL
+	}	OPTIONAL,
+	...,
+	[[	measResultListEUTRA-v1090			MeasResultList2EUTRA-v9e0	OPTIONAL
+	]],
+	[[	measResultListMBSFN-r12				MeasResultListMBSFN-r12		OPTIONAL,
+		measResultServCell-v1250			RSRQ-Range-v1250			OPTIONAL,
+		servCellRSRQ-Type-r12				RSRQ-Type-r12				OPTIONAL,
+		measResultListEUTRA-v1250			MeasResultList2EUTRA-v1250	OPTIONAL
+	]],
+	[[	inDeviceCoexDetected-r13			ENUMERATED {true}			OPTIONAL
+	]],
+	[[	measResultServCell-v1360			RSRP-Range-v1360			OPTIONAL
+	]],
+	[[	logMeasResultListBT-r15				LogMeasResultListBT-r15		OPTIONAL,
+		logMeasResultListWLAN-r15			LogMeasResultListWLAN-r15	OPTIONAL
+	]],
+	[[	anyCellSelectionDetected-r15		ENUMERATED {true}			OPTIONAL
+	]],
+	[[	measResultListNR-r16				MeasResultCellListNR-r15	OPTIONAL
+	]],
+	[[	measResultListNR-v1640			SEQUENCE {
+			carrierFreqNR-r16				ARFCN-ValueNR-r15
+		}																	OPTIONAL,
+		measResultListExtNR-r16			MeasResultFreqListNR-r16		OPTIONAL
+	]]
+}
+
+MeasResultListMBSFN-r12 ::=			SEQUENCE (SIZE (1..maxMBSFN-Area)) OF MeasResultMBSFN-r12
+
+MeasResultMBSFN-r12 ::=			SEQUENCE {
+	mbsfn-Area-r12					SEQUENCE {
+		mbsfn-AreaId-r12				MBSFN-AreaId-r12,
+		carrierFreq-r12					ARFCN-ValueEUTRA-r9
+	},
+	rsrpResultMBSFN-r12				RSRP-Range,
+	rsrqResultMBSFN-r12				MBSFN-RSRQ-Range-r12,
+	signallingBLER-Result-r12		BLER-Result-r12					OPTIONAL,
+	dataBLER-MCH-ResultList-r12		DataBLER-MCH-ResultList-r12		OPTIONAL,
+	...
+}
+
+DataBLER-MCH-ResultList-r12 ::=		SEQUENCE (SIZE (1.. maxPMCH-PerMBSFN)) OF DataBLER-MCH-Result-r12
+
+DataBLER-MCH-Result-r12 ::=			SEQUENCE {
+	mch-Index-r12						INTEGER (1..maxPMCH-PerMBSFN),
+	dataBLER-Result-r12					BLER-Result-r12
+}
+
+BLER-Result-r12 ::=					SEQUENCE {
+	bler-r12							BLER-Range-r12,
+	blocksReceived-r12					SEQUENCE {
+		n-r12								BIT STRING (SIZE (3)),
+		m-r12								BIT STRING (SIZE (8))
+	}
+}
+
+BLER-Range-r12 ::=						INTEGER(0..31)
+
+MeasResultList2GERAN-r10 ::=			SEQUENCE (SIZE (1..maxCellListGERAN)) OF MeasResultListGERAN
+
+MeasResultFreqListNR-r16::=		SEQUENCE (SIZE (1..maxFreq-1-r16)) OF MeasResultFreqFailNR-r15
+
+ConnEstFailReport-r11 ::=				SEQUENCE {
+	failedCellId-r11					CellGlobalIdEUTRA,
+	locationInfo-r11					LocationInfo-r10					OPTIONAL,
+	measResultFailedCell-r11			SEQUENCE {
+		rsrpResult-r11						RSRP-Range,
+		rsrqResult-r11						RSRQ-Range						OPTIONAL
+	},
+	measResultNeighCells-r11			SEQUENCE {
+		measResultListEUTRA-r11				MeasResultList2EUTRA-r9			OPTIONAL,
+		measResultListUTRA-r11				MeasResultList2UTRA-r9			OPTIONAL,
+		measResultListGERAN-r11				MeasResultListGERAN				OPTIONAL,
+		measResultsCDMA2000-r11				MeasResultList2CDMA2000-r9		OPTIONAL
+	}	OPTIONAL,
+	numberOfPreamblesSent-r11			NumberOfPreamblesSent-r11,
+	contentionDetected-r11				BOOLEAN,
+	maxTxPowerReached-r11				BOOLEAN,
+	timeSinceFailure-r11				TimeSinceFailure-r11,
+	measResultListEUTRA-v1130			MeasResultList2EUTRA-v9e0			OPTIONAL,
+	...,
+	[[	measResultFailedCell-v1250		RSRQ-Range-v1250					OPTIONAL,
+		failedCellRSRQ-Type-r12			RSRQ-Type-r12						OPTIONAL,
+		measResultListEUTRA-v1250		MeasResultList2EUTRA-v1250			OPTIONAL
+	]],
+	[[	measResultFailedCell-v1360		RSRP-Range-v1360					OPTIONAL
+	]],
+	[[	logMeasResultListBT-r15			LogMeasResultListBT-r15				OPTIONAL,
+		logMeasResultListWLAN-r15		LogMeasResultListWLAN-r15			OPTIONAL
+	]],
+	[[	measResultListNR-r16			MeasResultCellListNR-r15			OPTIONAL
+	]],
+	[[	measResultListNR-v1640			SEQUENCE {
+			carrierFreqNR-r16				ARFCN-ValueNR-r15
+		}																	OPTIONAL,
+		measResultListExtNR-r16			MeasResultFreqListNR-r16		OPTIONAL
+	]]
+}
+
+NumberOfPreamblesSent-r11::=			INTEGER (1..200)
+
+TimeSinceFailure-r11 ::=				INTEGER (0..172800)
+
+TimeUntilReconnection-r16 ::=			INTEGER (0..172800)
+
+MobilityHistoryReport-r12 ::=	VisitedCellInfoList-r12
+
+FlightPathInfoReport-r15 ::=		SEQUENCE {
+	flightPath-r15	SEQUENCE (SIZE (1..maxWayPoint-r15)) OF WayPointLocation-r15	OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+WayPointLocation-r15 ::=			SEQUENCE {
+	wayPointLocation-r15						LocationInfo-r10,
+	timeStamp-r15							AbsoluteTimeInfo-r10		OPTIONAL
+}
+
+
+
+ULHandoverPreparationTransfer ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ulHandoverPreparationTransfer-r8		ULHandoverPreparationTransfer-r8-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+ULHandoverPreparationTransfer-r8-IEs ::= SEQUENCE {
+	cdma2000-Type						CDMA2000-Type,
+	meid								BIT STRING (SIZE (56))					OPTIONAL,
+	dedicatedInfo						DedicatedInfoCDMA2000,
+	nonCriticalExtension				ULHandoverPreparationTransfer-v8a0-IEs	OPTIONAL
+}
+
+ULHandoverPreparationTransfer-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+ULInformationTransfer ::=			SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ulInformationTransfer-r8			ULInformationTransfer-r8-IEs,
+			ulInformationTransfer-r16			ULInformationTransfer-r16-IEs,
+			spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+ULInformationTransfer-r8-IEs ::=	SEQUENCE {
+	dedicatedInfoType					CHOICE {
+		dedicatedInfoNAS					DedicatedInfoNAS,
+		dedicatedInfoCDMA2000-1XRTT			DedicatedInfoCDMA2000,
+		dedicatedInfoCDMA2000-HRPD			DedicatedInfoCDMA2000
+	},
+	nonCriticalExtension				ULInformationTransfer-v8a0-IEs		OPTIONAL
+}
+
+ULInformationTransfer-v8a0-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+ULInformationTransfer-r16-IEs ::=	SEQUENCE {
+	dedicatedInfoType-r16				CHOICE {
+		dedicatedInfoNAS-r16				DedicatedInfoNAS,
+		dedicatedInfoCDMA2000-1XRTT-r16		DedicatedInfoCDMA2000,
+		dedicatedInfoCDMA2000-HRPD-r16		DedicatedInfoCDMA2000
+	}																		OPTIONAL,	-- Need ON
+	dedicatedInfoF1c-r16				DedicatedInfoF1c-r16				OPTIONAL,	-- Need ON
+	nonCriticalExtension				ULInformationTransfer-v8a0-IEs	OPTIONAL
+}
+
+
+
+ULInformationTransferIRAT-r16 ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ulInformationTransferIRAT-r16			ULInformationTransferIRAT-r16-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+ULInformationTransferIRAT-r16-IEs ::=	SEQUENCE {
+	ul-DCCH-MessageNR-r16			OCTET STRING						OPTIONAL,
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SEQUENCE {}						OPTIONAL
+}
+
+
+
+ULInformationTransferMRDC-r15 ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ulInformationTransferMRDC-r15			ULInformationTransferMRDC-r15-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+ULInformationTransferMRDC-r15-IEs ::=	SEQUENCE {
+	ul-DCCH-MessageNR-r15			OCTET STRING						OPTIONAL,
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+
+WLANConnectionStatusReport-r13 ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			wlanConnectionStatusReport-r13		WLANConnectionStatusReport-r13-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+WLANConnectionStatusReport-r13-IEs ::=	SEQUENCE {
+	wlan-Status-r13					WLAN-Status-r13,
+	lateNonCriticalExtension		OCTET STRING							OPTIONAL,
+	nonCriticalExtension			WLANConnectionStatusReport-v1430-IEs	OPTIONAL
+}
+
+WLANConnectionStatusReport-v1430-IEs ::=	SEQUENCE {
+	wlan-Status-v1430				WLAN-Status-v1430,
+	nonCriticalExtension			SEQUENCE {}								OPTIONAL
+}
+
+
+
+TypeFFS ::= NULL					-- To be removed
+
+
+
+SetupRelease { ElementTypeParam } ::= CHOICE {
+	release			NULL,
+	setup			ElementTypeParam
+}
+
+
+
+SystemInformationBlockPos-r15 ::= SEQUENCE {
+	assistanceDataSIB-Element-r15		OCTET STRING,
+	lateNonCriticalExtension			OCTET STRING							OPTIONAL,
+	...
+}
+
+
+
+SystemInformationBlockType2 ::=		SEQUENCE {
+	ac-BarringInfo						SEQUENCE {
+		ac-BarringForEmergency				BOOLEAN,
+		ac-BarringForMO-Signalling			AC-BarringConfig				OPTIONAL,	-- Need OP
+		ac-BarringForMO-Data				AC-BarringConfig				OPTIONAL	-- Need OP
+	}																		OPTIONAL,	-- Need OP
+	radioResourceConfigCommon			RadioResourceConfigCommonSIB,
+	ue-TimersAndConstants				UE-TimersAndConstants,
+	freqInfo							SEQUENCE {
+		ul-CarrierFreq						ARFCN-ValueEUTRA				OPTIONAL,	-- Need OP
+		ul-Bandwidth						ENUMERATED {n6, n15, n25, n50, n75, n100}
+																			OPTIONAL,	-- Need OP
+		additionalSpectrumEmission			AdditionalSpectrumEmission
+	},
+	mbsfn-SubframeConfigList			MBSFN-SubframeConfigList			OPTIONAL,	-- Need OR
+	timeAlignmentTimerCommon			TimeAlignmentTimer,
+	...,
+	lateNonCriticalExtension		OCTET STRING (CONTAINING SystemInformationBlockType2-v8h0-IEs)						OPTIONAL,
+	[[	ssac-BarringForMMTEL-Voice-r9		AC-BarringConfig				OPTIONAL,	-- Need OP
+		ssac-BarringForMMTEL-Video-r9		AC-BarringConfig				OPTIONAL	-- Need OP
+	]],
+	[[	ac-BarringForCSFB-r10				AC-BarringConfig			OPTIONAL	-- Need OP
+	]],
+	[[	ac-BarringSkipForMMTELVoice-r12		ENUMERATED {true}			OPTIONAL,	-- Need OP
+		ac-BarringSkipForMMTELVideo-r12		ENUMERATED {true}			OPTIONAL,	-- Need OP
+		ac-BarringSkipForSMS-r12			ENUMERATED {true}			OPTIONAL,	-- Need OP
+		ac-BarringPerPLMN-List-r12			AC-BarringPerPLMN-List-r12	OPTIONAL	-- Need OP
+	]],
+	[[	voiceServiceCauseIndication-r12		ENUMERATED {true}			OPTIONAL	-- Need OP
+	]],
+	[[	acdc-BarringForCommon-r13			ACDC-BarringForCommon-r13		OPTIONAL,	-- Need OP
+		acdc-BarringPerPLMN-List-r13		ACDC-BarringPerPLMN-List-r13	OPTIONAL	-- Need OP
+	]],
+	[[
+		udt-RestrictingForCommon-r13		UDT-Restricting-r13				OPTIONAL,	-- Need OR
+		udt-RestrictingPerPLMN-List-r13		UDT-RestrictingPerPLMN-List-r13	OPTIONAL,	-- Need OR
+		cIoT-EPS-OptimisationInfo-r13		CIOT-EPS-OptimisationInfo-r13	OPTIONAL,	-- Need OP
+		useFullResumeID-r13					ENUMERATED {true}				OPTIONAL	-- Need OP
+	]],
+	[[	unicastFreqHoppingInd-r13			ENUMERATED {true}				OPTIONAL	-- Need OP
+	]],
+	[[	mbsfn-SubframeConfigList-v1430		MBSFN-SubframeConfigList-v1430	OPTIONAL,	-- Need OP
+		videoServiceCauseIndication-r14		ENUMERATED {true}				OPTIONAL	-- Need OP
+	]],
+	[[	plmn-InfoList-r15					PLMN-InfoList-r15				OPTIONAL	-- Need OP
+	]],
+	[[	cp-EDT-r15							ENUMERATED {true}				OPTIONAL,	-- Need OR
+		up-EDT-r15							ENUMERATED {true}				OPTIONAL,	-- Need OR
+		idleModeMeasurements-r15			ENUMERATED {true}				OPTIONAL,	-- Need OR
+		reducedCP-LatencyEnabled-r15		ENUMERATED {true}				OPTIONAL	-- Need OR
+	]],
+	[[	mbms-ROM-ServiceIndication-r15	ENUMERATED {true}				OPTIONAL	-- Need OR
+	]],
+	[[	rlos-Enabled-r16					ENUMERATED {true}				OPTIONAL,	-- Need OR
+		earlySecurityReactivation-r16		ENUMERATED {true}				OPTIONAL,	-- Need OR
+		cp-EDT-5GC-r16						ENUMERATED {true}				OPTIONAL,	-- Need OR
+		up-EDT-5GC-r16						ENUMERATED {true}				OPTIONAL,	-- Need OR
+		cp-PUR-EPC-r16						ENUMERATED {true}				OPTIONAL,	-- Need OR
+		up-PUR-EPC-r16						ENUMERATED {true}				OPTIONAL,	-- Need OR
+		cp-PUR-5GC-r16						ENUMERATED {true}				OPTIONAL,	-- Need OR
+		up-PUR-5GC-r16						ENUMERATED {true}				OPTIONAL,	-- Need OR
+		mpdcch-CQI-Reporting-r16			ENUMERATED {fourBits, both}		OPTIONAL,	-- Need OR
+		rai-ActivationEnh-r16				ENUMERATED {true}				OPTIONAL,	-- Need OR
+		idleModeMeasurementsNR-r16			ENUMERATED {true}				OPTIONAL	-- Need OR
+	]]
+}
+
+SystemInformationBlockType2-v8h0-IEs ::=	SEQUENCE {
+	multiBandInfoList				SEQUENCE (SIZE (1..maxMultiBands)) OF AdditionalSpectrumEmission	OPTIONAL,	-- Need OR
+	nonCriticalExtension			SystemInformationBlockType2-v9e0-IEs	OPTIONAL
+}
+
+SystemInformationBlockType2-v9e0-IEs ::= SEQUENCE {
+	ul-CarrierFreq-v9e0					ARFCN-ValueEUTRA-v9e0		OPTIONAL,	-- Cond ul-FreqMax
+	nonCriticalExtension				SystemInformationBlockType2-v9i0-IEs					OPTIONAL
+}
+
+SystemInformationBlockType2-v9i0-IEs ::= SEQUENCE {
+-- Following field is for any non-critical extensions from REL-9
+	nonCriticalExtension			OCTET STRING (CONTAINING SystemInformationBlockType2-v10m0-IEs)						OPTIONAL,
+	dummy		SEQUENCE {}		OPTIONAL
+}
+
+SystemInformationBlockType2-v10m0-IEs ::= SEQUENCE {
+	freqInfo-v10l0						SEQUENCE {
+		additionalSpectrumEmission-v10l0			AdditionalSpectrumEmission-v10l0
+	}														OPTIONAL,
+	multiBandInfoList-v10l0				SEQUENCE (SIZE (1..maxMultiBands)) OF
+				AdditionalSpectrumEmission-v10l0				OPTIONAL,
+	nonCriticalExtension		SystemInformationBlockType2-v10n0-IEs		OPTIONAL
+}
+
+SystemInformationBlockType2-v10n0-IEs ::= SEQUENCE {
+-- Following field is for non-critical extensions up-to REL-12
+	lateNonCriticalExtension	OCTET STRING								OPTIONAL,
+	nonCriticalExtension		SystemInformationBlockType2-v13c0-IEs		OPTIONAL
+}
+
+SystemInformationBlockType2-v13c0-IEs ::= SEQUENCE {
+	uplinkPowerControlCommon-v13c0	UplinkPowerControlCommon-v1310			OPTIONAL,	-- Need OR
+-- Following field is for non-critical extensions from REL-13
+	nonCriticalExtension			SEQUENCE {}	OPTIONAL
+}
+
+AC-BarringConfig ::=				SEQUENCE {
+	ac-BarringFactor					ENUMERATED {
+											p00, p05, p10, p15, p20, p25, p30, p40,
+											p50, p60, p70, p75, p80, p85, p90, p95},
+	ac-BarringTime						ENUMERATED {s4, s8, s16, s32, s64, s128, s256, s512},
+	ac-BarringForSpecialAC				BIT STRING (SIZE(5))
+}
+
+MBSFN-SubframeConfigList ::=		SEQUENCE (SIZE (1..maxMBSFN-Allocations)) OF MBSFN-SubframeConfig
+
+MBSFN-SubframeConfigList-v1430 ::=		SEQUENCE (SIZE (1..maxMBSFN-Allocations)) OF MBSFN-SubframeConfig-v1430
+
+AC-BarringPerPLMN-List-r12 ::=		SEQUENCE (SIZE (1.. maxPLMN-r11)) OF AC-BarringPerPLMN-r12
+
+AC-BarringPerPLMN-r12 ::=			SEQUENCE {
+	plmn-IdentityIndex-r12					INTEGER (1..maxPLMN-r11),
+	ac-BarringInfo-r12						SEQUENCE {
+		ac-BarringForEmergency-r12			BOOLEAN,
+		ac-BarringForMO-Signalling-r12		AC-BarringConfig	OPTIONAL,	-- Need OP
+		ac-BarringForMO-Data-r12			AC-BarringConfig	OPTIONAL	-- Need OP
+	}															OPTIONAL,	-- Need OP
+	ac-BarringSkipForMMTELVoice-r12		ENUMERATED {true}		OPTIONAL,	-- Need OP
+	ac-BarringSkipForMMTELVideo-r12		ENUMERATED {true}		OPTIONAL,	-- Need OP
+	ac-BarringSkipForSMS-r12			ENUMERATED {true}		OPTIONAL,	-- Need OP
+	ac-BarringForCSFB-r12				AC-BarringConfig		OPTIONAL,	-- Need OP
+	ssac-BarringForMMTEL-Voice-r12		AC-BarringConfig		OPTIONAL,	-- Need OP
+	ssac-BarringForMMTEL-Video-r12		AC-BarringConfig		OPTIONAL	-- Need OP
+}
+
+ACDC-BarringForCommon-r13 ::=			SEQUENCE {
+	acdc-HPLMNonly-r13						BOOLEAN,
+	barringPerACDC-CategoryList-r13			BarringPerACDC-CategoryList-r13
+}
+
+ACDC-BarringPerPLMN-List-r13 ::=		SEQUENCE (SIZE (1.. maxPLMN-r11)) OF ACDC-BarringPerPLMN-r13
+
+ACDC-BarringPerPLMN-r13 ::=			SEQUENCE {
+	plmn-IdentityIndex-r13				INTEGER (1..maxPLMN-r11),
+	acdc-OnlyForHPLMN-r13				BOOLEAN,
+	barringPerACDC-CategoryList-r13		BarringPerACDC-CategoryList-r13
+}
+
+BarringPerACDC-CategoryList-r13 ::= SEQUENCE (SIZE (1..maxACDC-Cat-r13)) OF BarringPerACDC-Category-r13
+
+BarringPerACDC-Category-r13 ::= SEQUENCE {
+	acdc-Category-r13				INTEGER (1..maxACDC-Cat-r13),
+	acdc-BarringConfig-r13			SEQUENCE {
+		ac-BarringFactor-r13			ENUMERATED {
+											p00, p05, p10, p15, p20, p25, p30, p40,
+											p50, p60, p70, p75, p80, p85, p90, p95},
+		ac-BarringTime-r13				ENUMERATED {s4, s8, s16, s32, s64, s128, s256, s512}
+	}										OPTIONAL	-- Need OP
+}
+
+UDT-Restricting-r13	::= SEQUENCE {
+	udt-Restricting-r13					ENUMERATED {true}			OPTIONAL, --Need OR
+	udt-RestrictingTime-r13				ENUMERATED {s4, s8, s16, s32, s64, s128, s256, s512} OPTIONAL --Need OR
+}
+
+UDT-RestrictingPerPLMN-List-r13 ::=	SEQUENCE (SIZE (1..maxPLMN-r11)) OF UDT-RestrictingPerPLMN-r13
+
+UDT-RestrictingPerPLMN-r13 ::= SEQUENCE {
+	plmn-IdentityIndex-r13			INTEGER (1..maxPLMN-r11),
+	udt-Restricting-r13				UDT-Restricting-r13			OPTIONAL	--Need OR
+}
+
+CIOT-EPS-OptimisationInfo-r13 ::=	SEQUENCE (SIZE (1.. maxPLMN-r11)) OF CIOT-OptimisationPLMN-r13
+
+CIOT-OptimisationPLMN-r13::= SEQUENCE {
+	up-CIoT-EPS-Optimisation-r13		ENUMERATED {true}			OPTIONAL,	-- Need OP
+	cp-CIoT-EPS-Optimisation-r13		ENUMERATED {true}			OPTIONAL,	-- Need OP
+	attachWithoutPDN-Connectivity-r13	ENUMERATED {true}			OPTIONAL	-- Need OP
+}
+
+PLMN-InfoList-r15 ::=				SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-Info-r15
+
+PLMN-Info-r15 ::=			SEQUENCE {
+	upperLayerIndication-r15			ENUMERATED {true}			OPTIONAL		-- Need OR
+}
+
+
+
+SystemInformationBlockType3 ::=		SEQUENCE {
+	cellReselectionInfoCommon			SEQUENCE {
+		q-Hyst								ENUMERATED {
+												dB0, dB1, dB2, dB3, dB4, dB5, dB6, dB8, dB10,
+												dB12, dB14, dB16, dB18, dB20, dB22, dB24},
+		speedStateReselectionPars			SEQUENCE {
+			mobilityStateParameters				MobilityStateParameters,
+			q-HystSF						SEQUENCE {
+				sf-Medium						ENUMERATED {
+														dB-6, dB-4, dB-2, dB0},
+				sf-High							ENUMERATED {
+														dB-6, dB-4, dB-2, dB0}
+			}
+		}																OPTIONAL		-- Need OP
+	},
+	cellReselectionServingFreqInfo		SEQUENCE {
+		s-NonIntraSearch					ReselectionThreshold		OPTIONAL,		-- Need OP
+		threshServingLow					ReselectionThreshold,
+		cellReselectionPriority				CellReselectionPriority
+	},
+	intraFreqCellReselectionInfo		SEQUENCE {
+		q-RxLevMin							Q-RxLevMin,
+		p-Max								P-Max						OPTIONAL,		-- Need OP
+		s-IntraSearch						ReselectionThreshold		OPTIONAL,		-- Need OP
+		allowedMeasBandwidth				AllowedMeasBandwidth		OPTIONAL,		-- Need OP
+		presenceAntennaPort1				PresenceAntennaPort1,
+		neighCellConfig						NeighCellConfig,
+		t-ReselectionEUTRA					T-Reselection,
+		t-ReselectionEUTRA-SF				SpeedStateScaleFactors		OPTIONAL		-- Need OP
+	},
+	...,
+	lateNonCriticalExtension				OCTET STRING (CONTAINING SystemInformationBlockType3-v10j0-IEs)	OPTIONAL,
+	[[	s-IntraSearch-v920					SEQUENCE {
+			s-IntraSearchP-r9					ReselectionThreshold,
+			s-IntraSearchQ-r9					ReselectionThresholdQ-r9
+		}																OPTIONAL,		-- Need OP
+		s-NonIntraSearch-v920				SEQUENCE {
+			s-NonIntraSearchP-r9				ReselectionThreshold,
+			s-NonIntraSearchQ-r9				ReselectionThresholdQ-r9
+		}																OPTIONAL,		-- Need OP
+		q-QualMin-r9						Q-QualMin-r9				OPTIONAL,		-- Need OP
+		threshServingLowQ-r9				ReselectionThresholdQ-r9	OPTIONAL		-- Need OP
+	]],
+	[[	q-QualMinWB-r11						Q-QualMin-r9				OPTIONAL	-- Cond WB-RSRQ
+	]],
+	[[	q-QualMinRSRQ-OnAllSymbols-r12			Q-QualMin-r9				OPTIONAL			-- Cond RSRQ
+	]],
+	[[	cellReselectionServingFreqInfo-v1310 CellReselectionServingFreqInfo-v1310	OPTIONAL,		-- Need OP
+		redistributionServingInfo-r13			RedistributionServingInfo-r13 OPTIONAL,	--Need OR
+		cellSelectionInfoCE-r13					CellSelectionInfoCE-r13		OPTIONAL,		-- Need OP
+		t-ReselectionEUTRA-CE-r13				T-ReselectionEUTRA-CE-r13	OPTIONAL		-- Need OP
+	]],
+	[[	cellSelectionInfoCE1-r13				CellSelectionInfoCE1-r13	OPTIONAL	-- Need OP
+	]],
+	[[	cellSelectionInfoCE1-v1360			CellSelectionInfoCE1-v1360	OPTIONAL		-- Cond QrxlevminCE1
+	]],
+	[[	cellReselectionInfoCommon-v1460		CellReselectionInfoCommon-v1460	OPTIONAL	-- Need OR
+	]],
+	[[	cellReselectionInfoHSDN-r15			CellReselectionInfoHSDN-r15	OPTIONAL,		-- Need OR
+		cellSelectionInfoCE-v1530			CellSelectionInfoCE-v1530		OPTIONAL,		-- Need OP
+		crs-IntfMitigNeighCellsCE-r15		ENUMERATED {enabled}		OPTIONAL		-- Need OP
+	]],
+	[[	cellReselectionServingFreqInfo-v1610	CellReselectionServingFreqInfo-v1610	OPTIONAL	-- Need OR
+	]]
+}
+
+RedistributionServingInfo-r13 ::=		SEQUENCE {
+	redistributionFactorServing-r13		INTEGER(0..10),
+	redistributionFactorCell-r13		ENUMERATED{true}				OPTIONAL,	--Need OP
+	t360-r13							ENUMERATED {min4, min8, min16, min32,infinity,
+											spare3,spare2,spare1},
+	redistrOnPagingOnly-r13				ENUMERATED {true}		OPTIONAL	--Need OP
+}
+
+CellReselectionServingFreqInfo-v1310 ::=	SEQUENCE {
+	cellReselectionSubPriority-r13				CellReselectionSubPriority-r13
+}
+
+CellReselectionServingFreqInfo-v1610 ::= SEQUENCE {
+	altCellReselectionPriority-r16		CellReselectionPriority		OPTIONAL, -- Need OR
+	altCellReselectionSubPriority-r16	CellReselectionSubPriority-r13	OPTIONAL -- Need OR
+}
+
+-- Late non critical extensions
+SystemInformationBlockType3-v10j0-IEs ::= SEQUENCE {
+	freqBandInfo-r10					NS-PmaxList-r10				OPTIONAL,	-- Need OR
+	multiBandInfoList-v10j0				MultiBandInfoList-v10j0		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SystemInformationBlockType3-v10l0-IEs					OPTIONAL
+}
+
+SystemInformationBlockType3-v10l0-IEs ::= SEQUENCE {
+	freqBandInfo-v10l0					NS-PmaxList-v10l0			OPTIONAL,	-- Need OR
+	multiBandInfoList-v10l0				MultiBandInfoList-v10l0		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+CellReselectionInfoCommon-v1460 ::=	SEQUENCE {
+	s-SearchDeltaP-r14					ENUMERATED {dB6, dB9, dB12, dB15}
+}
+
+CellReselectionInfoHSDN-r15 ::= SEQUENCE {
+	cellEquivalentSize-r15				INTEGER(2..16)
+}
+
+
+
+SystemInformationBlockType4 ::=		SEQUENCE {
+	intraFreqNeighCellList				IntraFreqNeighCellList		OPTIONAL,	-- Need OR
+	intraFreqBlackCellList				IntraFreqBlackCellList				OPTIONAL,	-- Need OR
+	csg-PhysCellIdRange					PhysCellIdRange				OPTIONAL,	-- Cond CSG
+	...,
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL,
+	[[	intraFreqNeighHSDN-CellList-r15		IntraFreqNeighHSDN-CellList-r15	OPTIONAL	-- Need OR
+	]],
+	[[	rss-ConfigCarrierInfo-r16			RSS-ConfigCarrierInfo-r16		OPTIONAL,	-- Cond RSS
+		intraFreqNeighCellList-v1610		IntraFreqNeighCellList-v1610	OPTIONAL	-- Cond RSS
+	]]
+}
+
+IntraFreqNeighCellList ::=		SEQUENCE (SIZE (1..maxCellIntra)) OF IntraFreqNeighCellInfo
+
+IntraFreqNeighCellList-v1610 ::=	SEQUENCE (SIZE (1..maxCellIntra)) OF IntraFreqNeighCellInfo-v1610
+
+IntraFreqNeighHSDN-CellList-r15 ::= SEQUENCE (SIZE (1..maxCellIntra)) OF PhysCellIdRange
+
+IntraFreqNeighCellInfo ::=		SEQUENCE {
+	physCellId								PhysCellId,
+	q-OffsetCell							Q-OffsetRange,
+	...
+}
+
+IntraFreqNeighCellInfo-v1610 ::=	SEQUENCE {
+	rss-MeasPowerBias-r16				RSS-MeasPowerBias-r16
+}
+
+IntraFreqBlackCellList ::=		SEQUENCE (SIZE (1..maxCellBlack)) OF PhysCellIdRange
+
+
+
+SystemInformationBlockType5 ::=		SEQUENCE {
+	interFreqCarrierFreqList			InterFreqCarrierFreqList,
+	...,
+	lateNonCriticalExtension				OCTET STRING	(CONTAINING SystemInformationBlockType5-v8h0-IEs)				OPTIONAL,
+	[[	interFreqCarrierFreqList-v1250	InterFreqCarrierFreqList-v1250		OPTIONAL,	-- Need OR
+		interFreqCarrierFreqListExt-r12	InterFreqCarrierFreqListExt-r12	OPTIONAL	-- Need OR
+	]],
+	[[	interFreqCarrierFreqListExt-v1280	InterFreqCarrierFreqListExt-v1280	OPTIONAL	-- Need OR
+	]],
+	[[	interFreqCarrierFreqList-v1310		InterFreqCarrierFreqList-v1310		OPTIONAL,	-- Need OR
+		interFreqCarrierFreqListExt-v1310	InterFreqCarrierFreqListExt-v1310	OPTIONAL	-- Need OR
+	]],
+	[[	interFreqCarrierFreqList-v1350		InterFreqCarrierFreqList-v1350	OPTIONAL,	-- Need OR
+	interFreqCarrierFreqListExt-v1350	InterFreqCarrierFreqListExt-v1350	OPTIONAL	-- Need OR
+	]],
+	[[	interFreqCarrierFreqListExt-v1360	InterFreqCarrierFreqListExt-v1360	OPTIONAL	-- Need OR
+	]],
+	[[	scptm-FreqOffset-r14				INTEGER (1..8)					OPTIONAL	-- Need OP
+	]],
+	[[	interFreqCarrierFreqList-v1530		InterFreqCarrierFreqList-v1530		OPTIONAL,	-- Need OR
+		interFreqCarrierFreqListExt-v1530	InterFreqCarrierFreqListExt-v1530	OPTIONAL,	-- Need OR
+		measIdleConfigSIB-r15				MeasIdleConfigSIB-r15			OPTIONAL	-- Need OR
+	]],
+	[[	interFreqCarrierFreqList-v1610		InterFreqCarrierFreqList-v1610		OPTIONAL,	-- Need OR
+		interFreqCarrierFreqListExt-v1610	InterFreqCarrierFreqListExt-v1610	OPTIONAL,	-- Need OR
+		measIdleConfigSIB-NR-r16			MeasIdleConfigSIB-NR-r16			OPTIONAL	-- Need OR
+	]]
+}
+
+-- Late non critical extensions
+SystemInformationBlockType5-v8h0-IEs ::=	SEQUENCE {
+	interFreqCarrierFreqList-v8h0 SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v8h0				OPTIONAL,	-- Need OP
+	nonCriticalExtension			SystemInformationBlockType5-v9e0-IEs							OPTIONAL
+}
+
+SystemInformationBlockType5-v9e0-IEs ::=	SEQUENCE {
+	interFreqCarrierFreqList-v9e0	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v9e0				OPTIONAL,	-- Need OR
+	nonCriticalExtension			SystemInformationBlockType5-v10j0-IEs	OPTIONAL
+}
+
+SystemInformationBlockType5-v10j0-IEs ::=	SEQUENCE {
+	interFreqCarrierFreqList-v10j0	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v10j0				OPTIONAL,	-- Need OR
+	nonCriticalExtension			SystemInformationBlockType5-v10l0-IEs		OPTIONAL
+}
+
+SystemInformationBlockType5-v10l0-IEs ::=	SEQUENCE {
+	interFreqCarrierFreqList-v10l0	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v10l0				OPTIONAL,	-- Need OR
+	nonCriticalExtension			SystemInformationBlockType5-v13a0-IEs			OPTIONAL
+}
+
+SystemInformationBlockType5-v13a0-IEs ::=	SEQUENCE {
+	-- Late non critical extensions from REL-10 upto REL-12
+	lateNonCriticalExtension		OCTET STRING					OPTIONAL,	-- Need OR
+	interFreqCarrierFreqList-v13a0	InterFreqCarrierFreqList-v13a0	OPTIONAL,	-- Need OR
+	-- Late non critical extensions from REL-13
+	nonCriticalExtension			SEQUENCE {}						OPTIONAL
+}
+
+InterFreqCarrierFreqList ::=		SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo
+
+InterFreqCarrierFreqList-v1250 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1250
+
+InterFreqCarrierFreqList-v1310 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1310
+
+InterFreqCarrierFreqList-v1350 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1350
+
+InterFreqCarrierFreqList-v13a0 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1360
+
+InterFreqCarrierFreqList-v1530 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1530
+
+InterFreqCarrierFreqList-v1610 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1610
+
+InterFreqCarrierFreqListExt-r12 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-r12
+
+InterFreqCarrierFreqListExt-v1280 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v10j0
+
+InterFreqCarrierFreqListExt-v1310 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1310
+
+InterFreqCarrierFreqListExt-v1350 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1350
+
+InterFreqCarrierFreqListExt-v1360 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1360
+
+InterFreqCarrierFreqListExt-v1530 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1530
+
+InterFreqCarrierFreqListExt-v1610 ::=	SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-v1610
+
+InterFreqCarrierFreqInfo ::=	SEQUENCE {
+	dl-CarrierFreq						ARFCN-ValueEUTRA,
+	q-RxLevMin							Q-RxLevMin,
+	p-Max								P-Max							OPTIONAL,		-- Need OP
+	t-ReselectionEUTRA					T-Reselection,
+	t-ReselectionEUTRA-SF				SpeedStateScaleFactors			OPTIONAL,		-- Need OP
+	threshX-High						ReselectionThreshold,
+	threshX-Low							ReselectionThreshold,
+	allowedMeasBandwidth				AllowedMeasBandwidth,
+	presenceAntennaPort1				PresenceAntennaPort1,
+	cellReselectionPriority				CellReselectionPriority			OPTIONAL,		-- Need OP
+	neighCellConfig						NeighCellConfig,
+	q-OffsetFreq						Q-OffsetRange					DEFAULT dB0,
+	interFreqNeighCellList				InterFreqNeighCellList			OPTIONAL,		-- Need OR
+	interFreqBlackCellList				InterFreqBlackCellList			OPTIONAL,		-- Need OR
+	...,
+	[[	q-QualMin-r9					Q-QualMin-r9					OPTIONAL,		-- Need OP
+		threshX-Q-r9					SEQUENCE {
+			threshX-HighQ-r9				ReselectionThresholdQ-r9,
+			threshX-LowQ-r9					ReselectionThresholdQ-r9
+		}																OPTIONAL		-- Cond RSRQ
+	]],
+	[[	q-QualMinWB-r11					Q-QualMin-r9					OPTIONAL	-- Cond WB-RSRQ
+	]]
+}
+
+InterFreqCarrierFreqInfo-v8h0 ::=		SEQUENCE {
+	multiBandInfoList					MultiBandInfoList				OPTIONAL	-- Need OR
+}
+
+InterFreqCarrierFreqInfo-v9e0 ::=	SEQUENCE {
+	dl-CarrierFreq-v9e0					ARFCN-ValueEUTRA-v9e0	OPTIONAL,	-- Cond dl-FreqMax
+	multiBandInfoList-v9e0				MultiBandInfoList-v9e0	OPTIONAL	-- Need OR
+}
+
+InterFreqCarrierFreqInfo-v10j0 ::=	SEQUENCE {
+	freqBandInfo-r10					NS-PmaxList-r10				OPTIONAL,	-- Need OR
+	multiBandInfoList-v10j0				MultiBandInfoList-v10j0		OPTIONAL	-- Need OR
+}
+
+InterFreqCarrierFreqInfo-v10l0 ::=	SEQUENCE {
+	freqBandInfo-v10l0					NS-PmaxList-v10l0			OPTIONAL,	-- Need OR
+	multiBandInfoList-v10l0				MultiBandInfoList-v10l0		OPTIONAL	-- Need OR
+}
+
+InterFreqCarrierFreqInfo-v1250 ::=		SEQUENCE {
+	reducedMeasPerformance-r12		ENUMERATED {true}		OPTIONAL,		-- Need OP
+	q-QualMinRSRQ-OnAllSymbols-r12	Q-QualMin-r9					OPTIONAL	-- Cond RSRQ2
+}
+
+InterFreqCarrierFreqInfo-r12 ::=		SEQUENCE {
+	dl-CarrierFreq-r12					ARFCN-ValueEUTRA-r9,
+	q-RxLevMin-r12						Q-RxLevMin,
+	p-Max-r12							P-Max							OPTIONAL,		-- Need OP
+	t-ReselectionEUTRA-r12				T-Reselection,
+	t-ReselectionEUTRA-SF-r12			SpeedStateScaleFactors			OPTIONAL,		-- Need OP
+	threshX-High-r12					ReselectionThreshold,
+	threshX-Low-r12						ReselectionThreshold,
+	allowedMeasBandwidth-r12			AllowedMeasBandwidth,
+	presenceAntennaPort1-r12			PresenceAntennaPort1,
+	cellReselectionPriority-r12			CellReselectionPriority			OPTIONAL,		-- Need OP
+	neighCellConfig-r12					NeighCellConfig,
+	q-OffsetFreq-r12					Q-OffsetRange					DEFAULT dB0,
+	interFreqNeighCellList-r12			InterFreqNeighCellList			OPTIONAL,		-- Need OR
+	interFreqBlackCellList-r12			InterFreqBlackCellList			OPTIONAL,		-- Need OR
+	q-QualMin-r12						Q-QualMin-r9					OPTIONAL,		-- Need OP
+	threshX-Q-r12						SEQUENCE {
+		threshX-HighQ-r12					ReselectionThresholdQ-r9,
+		threshX-LowQ-r12					ReselectionThresholdQ-r9
+	}																	OPTIONAL,	-- Cond RSRQ
+	q-QualMinWB-r12						Q-QualMin-r9					OPTIONAL,	-- Cond WB-RSRQ
+	multiBandInfoList-r12				MultiBandInfoList-r11			OPTIONAL,	-- Need OR
+	reducedMeasPerformance-r12			ENUMERATED {true}				OPTIONAL,	-- Need OP
+	q-QualMinRSRQ-OnAllSymbols-r12		Q-QualMin-r9					OPTIONAL,	-- Cond RSRQ2
+...
+}
+
+InterFreqCarrierFreqInfo-v1310	::=	SEQUENCE {
+	cellReselectionSubPriority-r13		CellReselectionSubPriority-r13		OPTIONAL,		-- Need OP
+	redistributionInterFreqInfo-r13		RedistributionInterFreqInfo-r13		OPTIONAL, --Need OP
+	cellSelectionInfoCE-r13				CellSelectionInfoCE-r13			OPTIONAL,	-- Need OP
+	t-ReselectionEUTRA-CE-r13			T-ReselectionEUTRA-CE-r13		OPTIONAL	-- Need OP
+}
+
+InterFreqCarrierFreqInfo-v1350	::= SEQUENCE {
+	cellSelectionInfoCE1-r13			CellSelectionInfoCE1-r13			OPTIONAL	-- Need OP
+}
+
+InterFreqCarrierFreqInfo-v1360	::= SEQUENCE {
+	cellSelectionInfoCE1-v1360		CellSelectionInfoCE1-v1360	OPTIONAL	-- Cond QrxlevminCE1
+}
+
+InterFreqCarrierFreqInfo-v1530	::= SEQUENCE {
+	hsdn-Indication-r15					BOOLEAN,
+	interFreqNeighHSDN-CellList-r15		InterFreqNeighHSDN-CellList-r15		OPTIONAL,	-- Need OR
+	cellSelectionInfoCE-v1530			CellSelectionInfoCE-v1530			OPTIONAL	-- Need OP
+}
+
+InterFreqCarrierFreqInfo-v1610	::= SEQUENCE {
+	altCellReselectionPriority-r16		CellReselectionPriority		OPTIONAL,	-- Need OR
+	altCellReselectionSubPriority-r16	CellReselectionSubPriority-r13	OPTIONAL,	-- Need OR
+	rss-ConfigCarrierInfo-r16				RSS-ConfigCarrierInfo-r16		OPTIONAL,	-- Cond RSS
+	interFreqNeighCellList-v1610			InterFreqNeighCellList-v1610	OPTIONAL	-- Cond RSS
+}
+
+InterFreqNeighCellList ::=			SEQUENCE (SIZE (1..maxCellInter)) OF InterFreqNeighCellInfo
+
+InterFreqNeighCellList-v1610 ::=		SEQUENCE (SIZE (1..maxCellInter)) OF InterFreqNeighCellInfo-v1610
+
+InterFreqNeighHSDN-CellList-r15 ::= SEQUENCE (SIZE (1..maxCellInter)) OF PhysCellIdRange
+
+InterFreqNeighCellInfo ::=			SEQUENCE {
+	physCellId							PhysCellId,
+	q-OffsetCell						Q-OffsetRange
+}
+
+InterFreqNeighCellInfo-v1610 ::= SEQUENCE {
+	rss-MeasPowerBias-r16			RSS-MeasPowerBias-r16
+}
+
+InterFreqBlackCellList ::=			SEQUENCE (SIZE (1..maxCellBlack)) OF PhysCellIdRange
+
+RedistributionInterFreqInfo-r13 ::=		SEQUENCE {
+	redistributionFactorFreq-r13			RedistributionFactor-r13	OPTIONAL,	--Need OP
+	redistributionNeighCellList-r13			RedistributionNeighCellList-r13		OPTIONAL	--Need OP
+}
+
+RedistributionNeighCellList-r13 ::=		SEQUENCE (SIZE (1..maxCellInter)) OF RedistributionNeighCell-r13
+
+RedistributionNeighCell-r13 ::=		SEQUENCE {
+	physCellId-r13									PhysCellId,
+	redistributionFactorCell-r13					RedistributionFactor-r13
+}
+
+RedistributionFactor-r13 ::=	INTEGER(1..10)
+
+
+
+SystemInformationBlockType6 ::=		SEQUENCE {
+	carrierFreqListUTRA-FDD				CarrierFreqListUTRA-FDD			OPTIONAL,		-- Need OR
+	carrierFreqListUTRA-TDD				CarrierFreqListUTRA-TDD			OPTIONAL,		-- Need OR
+	t-ReselectionUTRA					T-Reselection,
+	t-ReselectionUTRA-SF				SpeedStateScaleFactors			OPTIONAL,		-- Need OP
+	...,
+	lateNonCriticalExtension			OCTET STRING	(CONTAINING SystemInformationBlockType6-v8h0-IEs)					OPTIONAL,
+	[[	carrierFreqListUTRA-FDD-v1250 SEQUENCE (SIZE (1..maxUTRA-FDD-Carrier)) OF
+										CarrierFreqInfoUTRA-v1250		OPTIONAL,	-- Cond UTRA-FDD
+		carrierFreqListUTRA-TDD-v1250 SEQUENCE (SIZE (1..maxUTRA-TDD-Carrier)) OF
+										CarrierFreqInfoUTRA-v1250		OPTIONAL,	-- Cond UTRA-TDD
+		carrierFreqListUTRA-FDD-Ext-r12	CarrierFreqListUTRA-FDD-Ext-r12 OPTIONAL,	-- Cond UTRA-FDD
+		carrierFreqListUTRA-TDD-Ext-r12	CarrierFreqListUTRA-TDD-Ext-r12 OPTIONAL		-- Cond UTRA-TDD
+	]]
+}
+
+SystemInformationBlockType6-v8h0-IEs ::=	SEQUENCE {
+	carrierFreqListUTRA-FDD-v8h0 SEQUENCE (SIZE (1..maxUTRA-FDD-Carrier)) OF CarrierFreqInfoUTRA-FDD-v8h0 OPTIONAL,	-- Cond UTRA-FDD
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+CarrierFreqInfoUTRA-v1250 ::=		SEQUENCE {
+	reducedMeasPerformance-r12		ENUMERATED {true}		OPTIONAL		-- Need OP
+}
+
+CarrierFreqListUTRA-FDD ::=		SEQUENCE (SIZE (1..maxUTRA-FDD-Carrier)) OF CarrierFreqUTRA-FDD
+
+CarrierFreqUTRA-FDD ::=				SEQUENCE {
+	carrierFreq							ARFCN-ValueUTRA,
+	cellReselectionPriority				CellReselectionPriority			OPTIONAL,		-- Need OP
+	threshX-High						ReselectionThreshold,
+	threshX-Low							ReselectionThreshold,
+	q-RxLevMin							INTEGER (-60..-13),
+	p-MaxUTRA							INTEGER (-50..33),
+	q-QualMin							INTEGER (-24..0),
+	...,
+	[[	threshX-Q-r9					SEQUENCE {
+			threshX-HighQ-r9				ReselectionThresholdQ-r9,
+			threshX-LowQ-r9					ReselectionThresholdQ-r9
+		}																OPTIONAL		-- Cond RSRQ
+	]]
+}
+
+CarrierFreqInfoUTRA-FDD-v8h0 ::=			SEQUENCE {
+	multiBandInfoList					SEQUENCE (SIZE (1..maxMultiBands)) OF FreqBandIndicator-UTRA-FDD				OPTIONAL	-- Need OR
+}
+
+CarrierFreqListUTRA-FDD-Ext-r12 ::=	SEQUENCE (SIZE (1..maxUTRA-FDD-Carrier)) OF
+									CarrierFreqUTRA-FDD-Ext-r12
+
+CarrierFreqUTRA-FDD-Ext-r12 ::=				SEQUENCE {
+	carrierFreq-r12						ARFCN-ValueUTRA,
+	cellReselectionPriority-r12			CellReselectionPriority			OPTIONAL,	-- Need OP
+	threshX-High-r12					ReselectionThreshold,
+	threshX-Low-r12						ReselectionThreshold,
+	q-RxLevMin-r12						INTEGER (-60..-13),
+	p-MaxUTRA-r12						INTEGER (-50..33),
+	q-QualMin-r12						INTEGER (-24..0),
+	threshX-Q-r12						SEQUENCE {
+			threshX-HighQ-r12				ReselectionThresholdQ-r9,
+			threshX-LowQ-r12				ReselectionThresholdQ-r9
+	}																OPTIONAL,		-- Cond RSRQ
+	multiBandInfoList-r12				SEQUENCE (SIZE (1..maxMultiBands)) OF FreqBandIndicator-UTRA-FDD				OPTIONAL,	-- Need OR
+	reducedMeasPerformance-r12			ENUMERATED {true}				OPTIONAL,	-- Need OP
+	...
+}
+
+CarrierFreqListUTRA-TDD ::=		SEQUENCE (SIZE (1..maxUTRA-TDD-Carrier)) OF CarrierFreqUTRA-TDD
+
+CarrierFreqUTRA-TDD ::=				SEQUENCE {
+	carrierFreq							ARFCN-ValueUTRA,
+	cellReselectionPriority				CellReselectionPriority			OPTIONAL,		-- Need OP
+	threshX-High						ReselectionThreshold,
+	threshX-Low							ReselectionThreshold,
+	q-RxLevMin							INTEGER (-60..-13),
+	p-MaxUTRA							INTEGER (-50..33),
+	...
+}
+
+CarrierFreqListUTRA-TDD-Ext-r12 ::=	SEQUENCE (SIZE (1..maxUTRA-TDD-Carrier)) OF
+									CarrierFreqUTRA-TDD-r12
+
+CarrierFreqUTRA-TDD-r12 ::=	SEQUENCE {
+	carrierFreq-r12						ARFCN-ValueUTRA,
+	cellReselectionPriority-r12			CellReselectionPriority			OPTIONAL,		-- Need OP
+	threshX-High-r12					ReselectionThreshold,
+	threshX-Low-r12						ReselectionThreshold,
+	q-RxLevMin-r12						INTEGER (-60..-13),
+	p-MaxUTRA-r12						INTEGER (-50..33),
+	reducedMeasPerformance-r12			ENUMERATED {true}				OPTIONAL,	-- Need OP
+	...
+}
+
+FreqBandIndicator-UTRA-FDD ::=				INTEGER (1..86)
+
+
+
+SystemInformationBlockType7 ::=		SEQUENCE {
+	t-ReselectionGERAN					T-Reselection,
+	t-ReselectionGERAN-SF				SpeedStateScaleFactors				OPTIONAL,	-- Need OR
+	carrierFreqsInfoList				CarrierFreqsInfoListGERAN			OPTIONAL,	-- Need OR
+	...,
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL
+}
+
+CarrierFreqsInfoListGERAN ::=			SEQUENCE (SIZE (1..maxGNFG)) OF CarrierFreqsInfoGERAN
+
+CarrierFreqsInfoGERAN ::=			SEQUENCE {
+	carrierFreqs						CarrierFreqsGERAN,
+	commonInfo							SEQUENCE {
+		cellReselectionPriority				CellReselectionPriority			OPTIONAL,	-- Need OP
+		ncc-Permitted						BIT STRING (SIZE (8)),
+		q-RxLevMin							INTEGER (0..45),
+		p-MaxGERAN							INTEGER (0..39)					OPTIONAL,	-- Need OP
+		threshX-High						ReselectionThreshold,
+		threshX-Low							ReselectionThreshold
+	},
+	...
+}
+
+
+
+SystemInformationBlockType8 ::=		SEQUENCE {
+	systemTimeInfo						SystemTimeInfoCDMA2000				OPTIONAL,	-- Need OR
+	searchWindowSize					INTEGER (0..15)						OPTIONAL,	-- Need OR
+	parametersHRPD						SEQUENCE {
+		preRegistrationInfoHRPD				PreRegistrationInfoHRPD,
+		cellReselectionParametersHRPD		CellReselectionParametersCDMA2000	OPTIONAL -- Need OR
+	}																		OPTIONAL,	-- Need OR
+	parameters1XRTT						SEQUENCE {
+		csfb-RegistrationParam1XRTT			CSFB-RegistrationParam1XRTT		OPTIONAL,	-- Need OP
+		longCodeState1XRTT					BIT STRING (SIZE (42))			OPTIONAL,	-- Need OR
+		cellReselectionParameters1XRTT		CellReselectionParametersCDMA2000	OPTIONAL -- Need OR
+	}																		OPTIONAL,	-- Need OR
+	...,
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	[[	csfb-SupportForDualRxUEs-r9			BOOLEAN							OPTIONAL,	-- Need OR
+		cellReselectionParametersHRPD-v920	CellReselectionParametersCDMA2000-v920	OPTIONAL,	-- Cond NCL-HRPD
+		cellReselectionParameters1XRTT-v920	CellReselectionParametersCDMA2000-v920	OPTIONAL,	-- Cond NCL-1XRTT
+		csfb-RegistrationParam1XRTT-v920	CSFB-RegistrationParam1XRTT-v920		OPTIONAL,	-- Cond REG-1XRTT
+		ac-BarringConfig1XRTT-r9			AC-BarringConfig1XRTT-r9	OPTIONAL	-- Cond REG-1XRTT
+	]],
+	[[	csfb-DualRxTxSupport-r10			ENUMERATED {true}			OPTIONAL	-- Cond REG-1XRTT
+	]],
+	[[	sib8-PerPLMN-List-r11				SIB8-PerPLMN-List-r11		OPTIONAL	-- Need OR
+	]]
+}
+
+CellReselectionParametersCDMA2000 ::= SEQUENCE {
+	bandClassList						BandClassListCDMA2000,
+	neighCellList						NeighCellListCDMA2000,
+	t-ReselectionCDMA2000			T-Reselection,
+	t-ReselectionCDMA2000-SF			SpeedStateScaleFactors				OPTIONAL	-- Need OP
+}
+
+CellReselectionParametersCDMA2000-r11 ::= SEQUENCE {
+	bandClassList						BandClassListCDMA2000,
+	neighCellList-r11					SEQUENCE (SIZE (1..16)) OF NeighCellCDMA2000-r11,
+	t-ReselectionCDMA2000				T-Reselection,
+	t-ReselectionCDMA2000-SF			SpeedStateScaleFactors				OPTIONAL	-- Need OP
+}
+
+CellReselectionParametersCDMA2000-v920 ::= SEQUENCE {
+	neighCellList-v920						NeighCellListCDMA2000-v920
+}
+
+NeighCellListCDMA2000 ::=			SEQUENCE (SIZE (1..16)) OF NeighCellCDMA2000
+
+NeighCellCDMA2000 ::=	SEQUENCE {
+	bandClass							BandclassCDMA2000,
+	neighCellsPerFreqList				NeighCellsPerBandclassListCDMA2000
+}
+
+NeighCellCDMA2000-r11 ::=	SEQUENCE {
+	bandClass							BandclassCDMA2000,
+	neighFreqInfoList-r11				SEQUENCE (SIZE (1..16)) OF NeighCellsPerBandclassCDMA2000-r11
+}
+
+NeighCellsPerBandclassListCDMA2000 ::= SEQUENCE (SIZE (1..16)) OF NeighCellsPerBandclassCDMA2000
+
+NeighCellsPerBandclassCDMA2000 ::=	SEQUENCE {
+	arfcn								ARFCN-ValueCDMA2000,
+	physCellIdList						PhysCellIdListCDMA2000
+}
+
+NeighCellsPerBandclassCDMA2000-r11 ::=	SEQUENCE {
+	arfcn								ARFCN-ValueCDMA2000,
+	physCellIdList-r11					SEQUENCE (SIZE (1..40)) OF PhysCellIdCDMA2000
+}
+
+NeighCellListCDMA2000-v920 ::=		SEQUENCE (SIZE (1..16)) OF NeighCellCDMA2000-v920
+
+NeighCellCDMA2000-v920 ::=			SEQUENCE {
+	neighCellsPerFreqList-v920			NeighCellsPerBandclassListCDMA2000-v920
+}
+
+NeighCellsPerBandclassListCDMA2000-v920 ::= SEQUENCE (SIZE (1..16)) OF NeighCellsPerBandclassCDMA2000-v920
+
+NeighCellsPerBandclassCDMA2000-v920 ::=	SEQUENCE {
+	physCellIdList-v920					PhysCellIdListCDMA2000-v920
+}
+
+PhysCellIdListCDMA2000 ::=			SEQUENCE (SIZE (1..16)) OF PhysCellIdCDMA2000
+
+PhysCellIdListCDMA2000-v920 ::=		SEQUENCE (SIZE (0..24)) OF PhysCellIdCDMA2000
+
+BandClassListCDMA2000 ::=			SEQUENCE (SIZE (1..maxCDMA-BandClass)) OF BandClassInfoCDMA2000
+
+BandClassInfoCDMA2000 ::=	SEQUENCE {
+	bandClass							BandclassCDMA2000,
+	cellReselectionPriority				CellReselectionPriority				OPTIONAL,	-- Need OP
+	threshX-High						INTEGER (0..63),
+	threshX-Low							INTEGER (0..63),
+	...
+}
+
+AC-BarringConfig1XRTT-r9 ::=		SEQUENCE {
+	ac-Barring0to9-r9					INTEGER (0..63),
+	ac-Barring10-r9						INTEGER (0..7),
+	ac-Barring11-r9						INTEGER (0..7),
+	ac-Barring12-r9						INTEGER (0..7),
+	ac-Barring13-r9						INTEGER (0..7),
+	ac-Barring14-r9						INTEGER (0..7),
+	ac-Barring15-r9						INTEGER (0..7),
+	ac-BarringMsg-r9					INTEGER (0..7),
+	ac-BarringReg-r9					INTEGER (0..7),
+	ac-BarringEmg-r9					INTEGER (0..7)
+}
+
+SIB8-PerPLMN-List-r11 ::=			SEQUENCE (SIZE (1..maxPLMN-r11)) OF SIB8-PerPLMN-r11
+
+SIB8-PerPLMN-r11 ::=				SEQUENCE {
+	plmn-Identity-r11					INTEGER (1..maxPLMN-r11),
+	parametersCDMA2000-r11				CHOICE {
+		explicitValue						ParametersCDMA2000-r11,
+		defaultValue						NULL
+	}
+}
+
+ParametersCDMA2000-r11 ::=			SEQUENCE {
+	systemTimeInfo-r11					CHOICE	{
+		explicitValue						SystemTimeInfoCDMA2000,
+		defaultValue						NULL
+	}																OPTIONAL,	-- Need OR
+	searchWindowSize-r11				INTEGER (0..15),
+	parametersHRPD-r11					SEQUENCE {
+		preRegistrationInfoHRPD-r11			PreRegistrationInfoHRPD,
+		cellReselectionParametersHRPD-r11	CellReselectionParametersCDMA2000-r11	OPTIONAL -- Need OR
+	}		OPTIONAL,	-- Need OR
+	parameters1XRTT-r11					SEQUENCE {
+		csfb-RegistrationParam1XRTT-r11		CSFB-RegistrationParam1XRTT			OPTIONAL, -- Need OP
+		csfb-RegistrationParam1XRTT-Ext-r11	CSFB-RegistrationParam1XRTT-v920	OPTIONAL, -- Cond REG-1XRTT-PerPLMN
+		longCodeState1XRTT-r11				BIT STRING (SIZE (42))	OPTIONAL, -- Cond PerPLMN-LC
+		cellReselectionParameters1XRTT-r11	CellReselectionParametersCDMA2000-r11	OPTIONAL, -- Need OR
+		ac-BarringConfig1XRTT-r11			AC-BarringConfig1XRTT-r9			OPTIONAL, -- Cond REG-1XRTT-PerPLMN
+		csfb-SupportForDualRxUEs-r11		BOOLEAN								OPTIONAL, -- Need OR
+		csfb-DualRxTxSupport-r11			ENUMERATED {true}			OPTIONAL -- Cond REG-1XRTT-PerPLMN
+	}		OPTIONAL,	-- Need OR
+	...
+}
+
+
+
+SystemInformationBlockType9 ::=		SEQUENCE {
+	hnb-Name							OCTET STRING (SIZE(1..48))		OPTIONAL,	-- Need OR
+	...,
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL
+}
+
+
+
+SystemInformationBlockType10 ::=	SEQUENCE {
+	messageIdentifier					BIT STRING (SIZE (16)),
+	serialNumber						BIT STRING (SIZE (16)),
+	warningType							OCTET STRING (SIZE (2)),
+	dummy								OCTET STRING (SIZE (50))	OPTIONAL,		-- Need OP
+	...,
+	lateNonCriticalExtension			OCTET STRING				OPTIONAL
+}
+
+
+
+SystemInformationBlockType11 ::=	SEQUENCE {
+	messageIdentifier					BIT STRING (SIZE (16)),
+	serialNumber						BIT STRING (SIZE (16)),
+	warningMessageSegmentType			ENUMERATED {notLastSegment, lastSegment},
+	warningMessageSegmentNumber			INTEGER (0..63),
+	warningMessageSegment				OCTET STRING,
+	dataCodingScheme					OCTET STRING (SIZE (1))		OPTIONAL,	-- Cond Segment1
+	...,
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL
+}
+
+
+
+SystemInformationBlockType12-r9 ::=	SEQUENCE {
+	messageIdentifier-r9				BIT STRING (SIZE (16)),
+	serialNumber-r9						BIT STRING (SIZE (16)),
+	warningMessageSegmentType-r9		ENUMERATED {notLastSegment, lastSegment},
+	warningMessageSegmentNumber-r9		INTEGER (0..63),
+	warningMessageSegment-r9			OCTET STRING,
+	dataCodingScheme-r9					OCTET STRING (SIZE (1))		OPTIONAL,	-- Cond Segment1
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	...,
+	[[	warningAreaCoordinatesSegment-r15		OCTET STRING	OPTIONAL	-- Need OR
+	]]
+}
+
+
+
+SystemInformationBlockType13-r9 ::=	SEQUENCE {
+	mbsfn-AreaInfoList-r9				MBSFN-AreaInfoList-r9,
+	notificationConfig-r9				MBMS-NotificationConfig-r9,
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	...,
+	[[	
+	notificationConfig-v1430			MBMS-NotificationConfig-v1430		OPTIONAL
+	]],
+	[[
+	mbsfn-AreaInfoList-r16				MBSFN-AreaInfoList-r16		OPTIONAL	-- Need OR
+	]]
+}
+
+
+
+SystemInformationBlockType14-r11 ::=	SEQUENCE {
+	eab-Param-r11							CHOICE {
+		eab-Common-r11							EAB-Config-r11,
+		eab-PerPLMN-List-r11					SEQUENCE (SIZE (1..maxPLMN-r11)) OF EAB-ConfigPLMN-r11
+	}														OPTIONAL, -- Need OR
+	lateNonCriticalExtension				OCTET STRING			OPTIONAL,
+	...,
+	[[	eab-PerRSRP-r15					ENUMERATED {thresh0, thresh1, thresh2, thresh3}	OPTIONAL	-- Need OR
+	]]
+}
+
+EAB-ConfigPLMN-r11 ::=				SEQUENCE {
+	eab-Config-r11						EAB-Config-r11				OPTIONAL -- Need OR
+}
+
+EAB-Config-r11 ::=					SEQUENCE {
+	eab-Category-r11					ENUMERATED {a, b, c},
+	eab-BarringBitmap-r11				BIT STRING (SIZE (10))
+}
+
+
+
+SystemInformationBlockType15-r11 ::=	SEQUENCE {
+	mbms-SAI-IntraFreq-r11					MBMS-SAI-List-r11				OPTIONAL,	-- Need OR
+	mbms-SAI-InterFreqList-r11				MBMS-SAI-InterFreqList-r11		OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...,
+	[[	mbms-SAI-InterFreqList-v1140		MBMS-SAI-InterFreqList-v1140	OPTIONAL	-- Cond InterFreq
+	]],
+	[[	mbms-IntraFreqCarrierType-r14		MBMS-CarrierType-r14			OPTIONAL,	-- Need OR
+		mbms-InterFreqCarrierTypeList-r14	
+											MBMS-InterFreqCarrierTypeList-r14	OPTIONAL	-- Need OR
+	]]
+}
+
+MBMS-SAI-List-r11 ::=					SEQUENCE (SIZE (1..maxSAI-MBMS-r11)) OF MBMS-SAI-r11
+
+MBMS-SAI-r11 ::=						INTEGER (0..65535)
+
+MBMS-SAI-InterFreqList-r11 ::=			SEQUENCE (SIZE (1..maxFreq)) OF MBMS-SAI-InterFreq-r11
+
+MBMS-SAI-InterFreqList-v1140 ::=		SEQUENCE (SIZE (1..maxFreq)) OF MBMS-SAI-InterFreq-v1140
+
+MBMS-SAI-InterFreq-r11 ::=				SEQUENCE {
+	dl-CarrierFreq-r11						ARFCN-ValueEUTRA-r9,
+	mbms-SAI-List-r11						MBMS-SAI-List-r11
+}
+
+MBMS-SAI-InterFreq-v1140 ::=			SEQUENCE {
+		multiBandInfoList-r11				MultiBandInfoList-r11			OPTIONAL	-- Need OR
+}
+
+MBMS-InterFreqCarrierTypeList-r14 ::=	SEQUENCE (SIZE (1..maxFreq)) OF MBMS-CarrierType-r14
+
+MBMS-CarrierType-r14 ::=				SEQUENCE {
+	carrierType-r14							ENUMERATED {mbms, fembmsMixed, fembmsDedicated},
+	frameOffset-r14							INTEGER (0..3)					OPTIONAL	-- Need OR
+}
+
+
+
+SystemInformationBlockType16-r11 ::=		SEQUENCE {
+	timeInfo-r11							SEQUENCE {
+		timeInfoUTC-r11						INTEGER (0..549755813887),
+		dayLightSavingTime-r11				BIT STRING (SIZE (2))		OPTIONAL,	-- Need OR
+		leapSeconds-r11						INTEGER (-127..128)			OPTIONAL,	-- Need OR
+		localTimeOffset-r11					INTEGER (-63..64)			OPTIONAL	-- Need OR
+	}																	OPTIONAL,	-- Need OR
+	lateNonCriticalExtension			OCTET STRING				OPTIONAL,
+	...,
+	[[	timeReferenceInfo-r15				TimeReferenceInfo-r15	OPTIONAL	-- Need OR
+	]]
+}
+
+
+
+SystemInformationBlockType17-r12 ::=	SEQUENCE {
+	wlan-OffloadInfoPerPLMN-List-r12		SEQUENCE (SIZE (1..maxPLMN-r11)) OF
+										WLAN-OffloadInfoPerPLMN-r12			OPTIONAL, -- Need OR
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL,
+	...
+}
+
+WLAN-OffloadInfoPerPLMN-r12 ::=			SEQUENCE {
+		wlan-OffloadConfigCommon-r12		WLAN-OffloadConfig-r12		OPTIONAL,	-- Need OR
+		wlan-Id-List-r12					WLAN-Id-List-r12			OPTIONAL,	-- Need OR
+		...
+}
+
+WLAN-Id-List-r12 ::=				SEQUENCE (SIZE (1..maxWLAN-Id-r12)) OF WLAN-Identifiers-r12
+
+WLAN-Identifiers-r12 ::=			SEQUENCE {
+	ssid-r12						OCTET STRING (SIZE (1..32))		OPTIONAL,	-- Need OR
+	bssid-r12						OCTET STRING (SIZE (6))			OPTIONAL,	-- Need OR
+	hessid-r12						OCTET STRING (SIZE (6))			OPTIONAL,	-- Need OR
+	...
+}
+
+
+
+SystemInformationBlockType18-r12 ::= SEQUENCE {
+	commConfig-r12						SEQUENCE {
+		commRxPool-r12						SL-CommRxPoolList-r12,
+		commTxPoolNormalCommon-r12			SL-CommTxPoolList-r12			OPTIONAL,	-- Need OR
+		commTxPoolExceptional-r12			SL-CommTxPoolList-r12			OPTIONAL,	-- Need OR
+		commSyncConfig-r12					SL-SyncConfigList-r12		OPTIONAL	-- Need OR
+	}																		OPTIONAL,	-- Need OR
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	...,
+	[[	commTxPoolNormalCommonExt-r13			SL-CommTxPoolListExt-r13	OPTIONAL,	-- Need OR
+		commTxResourceUC-ReqAllowed-r13			ENUMERATED {true}		OPTIONAL,	-- Need OR
+		commTxAllowRelayCommon-r13				ENUMERATED {true}			OPTIONAL	-- Need OR
+	]]
+}
+
+
+
+SystemInformationBlockType19-r12 ::= SEQUENCE {
+	discConfig-r12						SEQUENCE {
+		discRxPool-r12						SL-DiscRxPoolList-r12,
+		discTxPoolCommon-r12				SL-DiscTxPoolList-r12			OPTIONAL,	-- Need OR
+		discTxPowerInfo-r12				SL-DiscTxPowerInfoList-r12	OPTIONAL,	-- Cond Tx
+		discSyncConfig-r12					SL-SyncConfigList-r12		OPTIONAL	-- Need OR
+	}																		OPTIONAL,	-- Need OR
+	discInterFreqList-r12				SL-CarrierFreqInfoList-r12		OPTIONAL,	-- Need OR
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	...,
+	[[	discConfig-v1310				SEQUENCE {
+			discInterFreqList-v1310			SL-CarrierFreqInfoList-v1310	OPTIONAL,	-- Need OR
+			gapRequestsAllowedCommon		ENUMERATED {true}			OPTIONAL	-- Need OR
+		}																OPTIONAL,	-- Need OR
+		discConfigRelay-r13				SEQUENCE {
+			relayUE-Config-r13				SL-DiscConfigRelayUE-r13,
+			remoteUE-Config-r13				SL-DiscConfigRemoteUE-r13
+		}																OPTIONAL,	-- Need OR
+		discConfigPS-13					SEQUENCE {
+			discRxPoolPS-r13				SL-DiscRxPoolList-r12,
+			discTxPoolPS-Common-r13			SL-DiscTxPoolList-r12		OPTIONAL	-- Need OR
+		}																OPTIONAL	-- Need OR
+	]]
+}
+
+SL-CarrierFreqInfoList-r12 ::=	SEQUENCE (SIZE (1..maxFreq)) OF SL-CarrierFreqInfo-r12
+
+SL-CarrierFreqInfoList-v1310 ::=	SEQUENCE (SIZE (1..maxFreq)) OF SL-CarrierFreqInfo-v1310
+
+SL-CarrierFreqInfo-r12::=		SEQUENCE {
+	carrierFreq-r12					ARFCN-ValueEUTRA-r9,
+	plmn-IdentityList-r12			PLMN-IdentityList4-r12			OPTIONAL	-- Need OP
+}
+
+SL-DiscConfigRelayUE-r13	::= SEQUENCE {	
+	threshHigh-r13			RSRP-RangeSL4-r13						OPTIONAL,	-- Need OR
+	threshLow-r13			RSRP-RangeSL4-r13						OPTIONAL,	-- Need OR
+	hystMax-r13				ENUMERATED {dB0, dB3, dB6, dB9, dB12, dBinf}	OPTIONAL,	-- Cond ThreshHigh
+	hystMin-r13				ENUMERATED {dB0, dB3, dB6, dB9, dB12}	OPTIONAL	-- Cond ThreshLow
+}
+
+SL-DiscConfigRemoteUE-r13	::= SEQUENCE {	
+	threshHigh-r13			RSRP-RangeSL4-r13						OPTIONAL,	-- Need OR
+	hystMax-r13				ENUMERATED {dB0, dB3, dB6, dB9, dB12}	OPTIONAL,	-- Cond ThreshHigh
+	reselectionInfoIC-r13	ReselectionInfoRelay-r13
+}
+
+ReselectionInfoRelay-r13 ::=	SEQUENCE {
+	q-RxLevMin-r13					Q-RxLevMin,
+	-- Note that the mapping of invidual values may be different for PC5, but the granularity/
+	-- number of values is same as for Uu
+	filterCoefficient-r13			FilterCoefficient,
+	minHyst-r13					ENUMERATED {dB0, dB3,
+										dB6, dB9, dB12, dBinf}	OPTIONAL	-- Need OR
+}
+
+SL-CarrierFreqInfo-v1310::=	SEQUENCE {
+	discResourcesNonPS-r13			SL-ResourcesInterFreq-r13		OPTIONAL,	-- Need OR
+	discResourcesPS-r13				SL-ResourcesInterFreq-r13		OPTIONAL,	-- Need OR
+	discConfigOther-r13			SL-DiscConfigOtherInterFreq-r13		OPTIONAL,	-- Need OR
+	...
+}
+
+PLMN-IdentityList4-r12 ::=	SEQUENCE (SIZE (1..maxPLMN-r11)) OF	PLMN-IdentityInfo2-r12
+
+PLMN-IdentityInfo2-r12 ::=		CHOICE	{
+	plmn-Index-r12					INTEGER (1..maxPLMN-r11),
+	plmnIdentity-r12				PLMN-Identity
+}
+
+SL-DiscTxResourcesInterFreq-r13 ::=	CHOICE {
+	acquireSI-FromCarrier-r13		NULL,
+	discTxPoolCommon-r13			SL-DiscTxPoolList-r12,
+	requestDedicated-r13			NULL,
+	noTxOnCarrier-r13				NULL
+}
+
+SL-DiscConfigOtherInterFreq-r13::=	SEQUENCE {
+	txPowerInfo-r13					SL-DiscTxPowerInfoList-r12			OPTIONAL,	-- Cond Tx
+	refCarrierCommon-r13			ENUMERATED {pCell}					OPTIONAL,	-- Need OR
+	discSyncConfig-r13				SL-SyncConfigListNFreq-r13			OPTIONAL,	-- Need OR
+	discCellSelectionInfo-r13		CellSelectionInfoNFreq-r13			OPTIONAL	-- Need OR
+}
+
+SL-ResourcesInterFreq-r13 ::= SEQUENCE {
+	discRxResourcesInterFreq-r13	SL-DiscRxPoolList-r12				OPTIONAL,	-- Need OR
+	discTxResourcesInterFreq-r13	SL-DiscTxResourcesInterFreq-r13		OPTIONAL	-- Need OR
+}
+
+
+
+SystemInformationBlockType20-r13 ::=	SEQUENCE {
+	sc-mcch-RepetitionPeriod-r13		ENUMERATED {rf2, rf4, rf8, rf16, rf32, rf64, rf128, rf256},
+	sc-mcch-Offset-r13				INTEGER (0..10),
+	sc-mcch-FirstSubframe-r13		INTEGER (0..9),
+	sc-mcch-duration-r13			INTEGER (2..9)	OPTIONAL,
+	sc-mcch-ModificationPeriod-r13	ENUMERATED {rf2, rf4, rf8, rf16, rf32, rf64, rf128, rf256,
+										rf512, rf1024, r2048, rf4096, rf8192, rf16384, rf32768,
+												rf65536},
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	...,
+	[[	br-BCCH-Config-r14					SEQUENCE {
+			dummy								ENUMERATED {rf1},
+			dummy2								ENUMERATED {rf1},
+			mpdcch-Narrowband-SC-MCCH-r14		INTEGER (1..maxAvailNarrowBands-r13),
+			mpdcch-NumRepetition-SC-MCCH-r14	ENUMERATED {r1, r2, r4, r8, r16,
+															r32, r64, r128, r256},
+			mpdcch-StartSF-SC-MCCH-r14			CHOICE {
+				fdd-r14								ENUMERATED {v1, v1dot5, v2, v2dot5, v4,
+																v5, v8, v10},
+				tdd-r14								ENUMERATED {v1, v2, v4, v5, v8, v10, v20}
+			},
+			mpdcch-PDSCH-HoppingConfig-SC-MCCH-r14	ENUMERATED {off, ce-ModeA, ce-ModeB},
+			sc-mcch-CarrierFreq-r14				ARFCN-ValueEUTRA-r9,
+			sc-mcch-Offset-BR-r14				INTEGER (0..10),
+			sc-mcch-RepetitionPeriod-BR-r14		ENUMERATED {rf32, rf128, rf512, rf1024,
+													rf2048, rf4096, rf8192, rf16384},
+			sc-mcch-ModificationPeriod-BR-r14	ENUMERATED { rf32, rf128, rf256, rf512, rf1024,
+													rf2048, rf4096, rf8192, rf16384, rf32768,
+													rf65536, rf131072, rf262144, rf524288,
+													rf1048576}
+		}																	OPTIONAL,	-- Need OR
+		sc-mcch-SchedulingInfo-r14			SC-MCCH-SchedulingInfo-r14		OPTIONAL,	-- Need OP
+		pdsch-maxNumRepetitionCEmodeA-SC-MTCH-r14
+											ENUMERATED { r16, r32 }		OPTIONAL,	-- Need OR
+		pdsch-maxNumRepetitionCEmodeB-SC-MTCH-r14
+											ENUMERATED {
+												r192, r256, r384, r512, r768, r1024,
+												r1536, r2048}				OPTIONAL	-- Need OR
+	]],
+	[[	sc-mcch-RepetitionPeriod-v1470		ENUMERATED {rf1}				OPTIONAL,	-- Need OR
+		sc-mcch-ModificationPeriod-v1470	ENUMERATED {rf1}				OPTIONAL	-- Need OR
+	]]
+}
+
+SC-MCCH-SchedulingInfo-r14::=	SEQUENCE	{
+	onDurationTimerSCPTM-r14			ENUMERATED {psf10, psf20, psf100, psf300,
+												psf500, psf1000, psf1200, psf1600},
+	drx-InactivityTimerSCPTM-r14		ENUMERATED {psf0, psf1, psf2, psf4, psf8, psf16,
+												psf32, psf64, psf128, psf256, ps512,
+												psf1024, psf2048, psf4096, psf8192, psf16384},
+	schedulingPeriodStartOffsetSCPTM-r14	CHOICE {
+		sf10									INTEGER(0..9),
+		sf20									INTEGER(0..19),
+		sf32									INTEGER(0..31),
+		sf40									INTEGER(0..39),
+		sf64									INTEGER(0..63),
+		sf80									INTEGER(0..79),
+		sf128									INTEGER(0..127),
+		sf160									INTEGER(0..159),
+		sf256									INTEGER(0..255),
+		sf320									INTEGER(0..319),
+		sf512									INTEGER(0..511),
+		sf640									INTEGER(0..639),
+		sf1024									INTEGER(0..1023),
+		sf2048									INTEGER(0..2047),
+		sf4096									INTEGER(0..4095),
+		sf8192									INTEGER(0..8191)
+	},
+	...
+}
+
+
+
+SystemInformationBlockType21-r14 ::= SEQUENCE {
+	sl-V2X-ConfigCommon-r14				SL-V2X-ConfigCommon-r14				OPTIONAL,	-- Need OR
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	...,
+	[[	anchorCarrierFreqListNR-r16		SL-NR-AnchorCarrierFreqList-r16		OPTIONAL	-- Need OR
+	]]
+}
+
+SL-V2X-ConfigCommon-r14 ::=		SEQUENCE {
+	v2x-CommRxPool-r14					SL-CommRxPoolListV2X-r14			OPTIONAL,	-- Need OR
+	v2x-CommTxPoolNormalCommon-r14		SL-CommTxPoolListV2X-r14			OPTIONAL,	-- Need OR
+	p2x-CommTxPoolNormalCommon-r14		SL-CommTxPoolListV2X-r14			OPTIONAL,	-- Need OR
+	v2x-CommTxPoolExceptional-r14		SL-CommResourcePoolV2X-r14			OPTIONAL,	-- Need OR
+	v2x-SyncConfig-r14					SL-SyncConfigListV2X-r14			OPTIONAL,	-- Need OR
+	v2x-InterFreqInfoList-r14			SL-InterFreqInfoListV2X-r14			OPTIONAL,	-- Need OR
+	v2x-ResourceSelectionConfig-r14		SL-CommTxPoolSensingConfig-r14		OPTIONAL,	-- Need OR
+	zoneConfig-r14						SL-ZoneConfig-r14					OPTIONAL,	-- Need OR
+	typeTxSync-r14						SL-TypeTxSync-r14					OPTIONAL,	-- Need OR
+	thresSL-TxPrioritization-r14		SL-Priority-r13						OPTIONAL,	-- Need OR
+	anchorCarrierFreqList-r14			SL-AnchorCarrierFreqList-V2X-r14	OPTIONAL,	-- Need OR
+	offsetDFN-r14						INTEGER (0..1000)					OPTIONAL,	-- Need OR
+	cbr-CommonTxConfigList-r14			SL-CBR-CommonTxConfigList-r14		OPTIONAL	-- Need OR
+}
+
+
+
+
+SystemInformationBlockType24-r15 ::=	SEQUENCE {
+	carrierFreqListNR-r15				CarrierFreqListNR-r15				OPTIONAL,		-- Need OR
+	t-ReselectionNR-r15					T-Reselection,
+	t-ReselectionNR-SF-r15				SpeedStateScaleFactors				OPTIONAL,	-- Need OR
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	...,
+	[[	carrierFreqListNR-v1610			CarrierFreqListNR-v1610		OPTIONAL    -- Need OR
+	]]
+}
+
+CarrierFreqListNR-r15 ::=		SEQUENCE (SIZE (1..maxFreq)) OF CarrierFreqNR-r15
+
+CarrierFreqListNR-v1610 ::=		SEQUENCE (SIZE (1..maxFreq)) OF CarrierFreqNR-v1610
+
+CarrierFreqNR-r15 ::=				SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueNR-r15,
+	multiBandInfoList-r15				MultiFrequencyBandListNR-r15		OPTIONAL,	-- Need OR
+	multiBandInfoListSUL-r15			MultiFrequencyBandListNR-r15		OPTIONAL,	-- Need OR
+	measTimingConfig-r15				MTC-SSB-NR-r15						OPTIONAL,	-- Need OR
+	subcarrierSpacingSSB-r15			ENUMERATED {kHz15, kHz30, kHz120, kHz240},
+	ss-RSSI-Measurement-r15				SS-RSSI-Measurement-r15		OPTIONAL,		-- Cond RSRQ2
+	cellReselectionPriority-r15			CellReselectionPriority		OPTIONAL,		-- Need OP
+	cellReselectionSubPriority-r15		CellReselectionSubPriority-r13	OPTIONAL,	-- Need OR
+	threshX-High-r15					ReselectionThreshold,
+	threshX-Low-r15						ReselectionThreshold,
+	threshX-Q-r15						SEQUENCE {
+			threshX-HighQ-r15				ReselectionThresholdQ-r9,
+			threshX-LowQ-r15				ReselectionThresholdQ-r9
+		}																OPTIONAL,	-- Cond RSRQ
+	q-RxLevMin-r15						INTEGER (-70..-22),
+	q-RxLevMinSUL-r15					INTEGER (-70..-22)				OPTIONAL,		-- Need OR
+	p-MaxNR-r15							P-MaxNR-r15,
+	ns-PmaxListNR-r15					NS-PmaxListNR-r15					OPTIONAL,	-- Need OR
+	q-QualMin-r15						INTEGER (-43..-12)				OPTIONAL,		-- Need OP
+	deriveSSB-IndexFromCell-r15			BOOLEAN,
+	maxRS-IndexCellQual-r15				MaxRS-IndexCellQualNR-r15		OPTIONAL,		-- Need OR
+	threshRS-Index-r15					ThresholdListNR-r15				OPTIONAL,		-- Need OR
+	...,
+	[[	multiBandNsPmaxListNR-v1550		MultiBandNsPmaxListNR-1-v1550	OPTIONAL,	-- Need OR
+		multiBandNsPmaxListNR-SUL-v1550	MultiBandNsPmaxListNR-v1550		OPTIONAL,	-- Need OR
+		ssb-ToMeasure-r15				SSB-ToMeasure-r15				OPTIONAL		-- Need OR
+	]]
+}
+
+CarrierFreqNR-v1610 ::=		SEQUENCE {
+	smtc2-LP-r16						MTC-SSB2-LP-NR-r16				OPTIONAL,	 -- Need OR
+	ssb-PositionQCL-CommonNR-r16	SSB-PositionQCL-RelationNR-r16	OPTIONAL,	-- Cond SharedSpectrum
+	whiteCellListNR-r16				WhiteCellListNR-r16					OPTIONAL,	-- Cond SharedSpectrum
+	highSpeedCarrierNR-r16			ENUMERATED {true}				OPTIONAL	  -- Need OR
+}
+
+MultiBandNsPmaxListNR-1-v1550	::=	SEQUENCE (SIZE (1.. maxMultiBandsNR-1-r15)) OF NS-PmaxListNR-r15
+
+MultiBandNsPmaxListNR-v1550	::=	SEQUENCE (SIZE (1.. maxMultiBandsNR-r15)) OF NS-PmaxListNR-r15
+
+WhiteCellListNR-r16 ::=			SEQUENCE (SIZE (1..maxCellWhiteNR-r16)) OF PhysCellIdNR-r15
+
+
+
+SystemInformationBlockType25-r15 ::=	SEQUENCE {
+	uac-BarringForCommon-r15				UAC-BarringPerCatList-r15				OPTIONAL,	-- Need OP
+	uac-BarringPerPLMN-List-r15			UAC-BarringPerPLMN-List-r15				OPTIONAL,	-- Need OP
+	uac-BarringInfoSetList-r15			UAC-BarringInfoSetList-r15,
+	uac-AC1-SelectAssistInfo-r15		CHOICE {
+		plmnCommon-r15							UAC-AC1-SelectAssistInfo-r15,
+		individualPLMNList-r15	SEQUENCE (SIZE (2..maxPLMN-r11)) OF UAC-AC1-SelectAssistInfo-r15
+		}			OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING								OPTIONAL,
+	...,
+	[[	ab-PerRSRP-r16					ENUMERATED {thresh0, thresh1, thresh2, thresh3}	OPTIONAL	-- Need OR
+	]],
+	[[
+		uac-AC1-SelectAssistInfo-r16 SEQUENCE (SIZE (2..maxPLMN-r11)) OF UAC-AC1-SelectAssistInfo-r16 OPTIONAL    -- Need OR
+	]]
+}
+
+UAC-BarringPerPLMN-List-r15::=	SEQUENCE (SIZE (1.. maxPLMN-r11)) OF UAC-BarringPerPLMN-r15
+
+UAC-BarringPerPLMN-r15 ::=	SEQUENCE {
+	plmn-IdentityIndex-r15		INTEGER (1.. maxPLMN-r11),
+	uac-AC-BarringListType-r15		CHOICE{
+		uac-ImplicitAC-BarringList-r15		SEQUENCE (SIZE(maxAccessCat-1-r15)) OF UAC-BarringInfoSetIndex-r15,
+		uac-ExplicitAC-BarringList-r15		UAC-BarringPerCatList-r15
+		}					OPTIONAL	-- Need OR
+}
+
+UAC-BarringPerCatList-r15 ::= SEQUENCE (SIZE (1..maxAccessCat-1-r15)) OF UAC-BarringPerCat-r15
+
+UAC-BarringPerCat-r15 ::= SEQUENCE {
+	accessCategory-r15					INTEGER (1..maxAccessCat-1-r15),
+	uac-barringInfoSetIndex-r15		UAC-BarringInfoSetIndex-r15
+}
+
+UAC-BarringInfoSetIndex-r15 ::=	INTEGER (1..maxBarringInfoSet-r15)
+UAC-BarringInfoSetList-r15 ::=		SEQUENCE (SIZE (1..maxBarringInfoSet-r15)) OF UAC-BarringInfoSet-r15
+
+
+UAC-BarringInfoSet-r15 ::= SEQUENCE {
+	uac-BarringFactor-r15		ENUMERATED {
+									p00, p05, p10, p15, p20, p25, p30, p40,
+									p50, p60, p70, p75, p80, p85, p90, p95},
+	uac-BarringTime-r15			ENUMERATED {s4, s8, s16, s32, s64, s128, s256, s512},
+	uac-BarringForAccessIdentity-r15			BIT STRING (SIZE(7))
+}
+
+UAC-AC1-SelectAssistInfo-r15::=	ENUMERATED {a, b, c}
+
+UAC-AC1-SelectAssistInfo-r16::= ENUMERATED {a, b, c, notConfigured}
+
+
+
+SystemInformationBlockType26-r15 ::= SEQUENCE {
+	v2x-InterFreqInfoList-r15			SL-InterFreqInfoListV2X-r14			OPTIONAL,	-- Need OR
+	cbr-pssch-TxConfigList-r15			SL-CBR-PPPP-TxConfigList-r15		OPTIONAL,	-- Need OR
+	v2x-PacketDuplicationConfig-r15		SL-V2X-PacketDuplicationConfig-r15	OPTIONAL,	-- Need OR
+	syncFreqList-r15					SL-V2X-SyncFreqList-r15				OPTIONAL,	-- Need OR
+	slss-TxMultiFreq-r15				ENUMERATED{true}					OPTIONAL,	-- Need OR
+	v2x-FreqSelectionConfigList-r15		SL-V2X-FreqSelectionConfigList-r15	OPTIONAL,	-- Need OR
+	threshS-RSSI-CBR-r15				INTEGER (0..45)						OPTIONAL,	-- Need OR
+	...,
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL
+}
+
+
+
+SystemInformationBlockType26a-r16 ::= SEQUENCE {
+	plmn-InfoList-r16						PLMN-InfoList-r16,
+	bandListENDC-r16						BandListENDC-r16,
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL,
+	...
+}
+
+BandListENDC-r16 ::=		SEQUENCE (SIZE (1.. maxBandsENDC-r16)) OF FreqBandIndicatorNR-r15
+
+PLMN-InfoList-r16 ::=		SEQUENCE (SIZE (0..maxPLMN-r11)) OF PLMN-Info-r16
+
+PLMN-Info-r16 ::=			SEQUENCE {
+	nr-BandList-r16				BIT STRING (SIZE(maxBandsENDC-r16))	OPTIONAL		-- Need OR
+}
+
+
+
+SystemInformationBlockType27-r16 ::=	SEQUENCE {
+	carrierFreqListNBIOT-r16				CarrierFreqListNBIOT-r16		OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...
+}
+
+CarrierFreqListNBIOT-r16 ::=				SEQUENCE (SIZE (1.. maxFreqNBIOT-r16)) OF	CarrierFreqNBIOT-r16
+
+
+CarrierFreqNBIOT-r16 ::=		SEQUENCE {
+	carrierFreq-r16					ARFCN-ValueEUTRA-r9,
+	carrierFreqOffset-r16			ENUMERATED {v-10, v-9, v-8dot5, v-8, v-7, v-6, v-5, v-4dot5,
+												v-4,v-3, v-2, v-1, v-0dot5,	v0, v1, v2, v3, v3dot5,
+												v4, v5, v6, v7, v7dot5, v8, v9}
+}
+
+
+
+SystemInformationBlockType28-r16 ::= SEQUENCE {
+	segmentNumber-r16					INTEGER (0..63),
+	segmentType-r16						ENUMERATED {notLastSegment,lastSegment},
+	segmentContainer-r16				OCTET STRING,
+	lateNonCriticalExtension			OCTET STRING				OPTIONAL,
+	...
+}
+
+
+
+SystemInformationBlockType29-r16 ::= SEQUENCE {
+	resourceReservationConfigCommonDL-r16	ResourceReservationConfigDL-r16	OPTIONAL,	-- Need OR
+	resourceReservationConfigCommonUL-r16	ResourceReservationConfigUL-r16	OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...
+}
+
+
+
+Alpha-r12 ::= ENUMERATED {al0, al04, al05, al06, al07, al08, al09, al1}
+
+
+
+AntennaInfoCommon ::=				SEQUENCE {
+	antennaPortsCount					ENUMERATED {an1, an2, an4, spare1}
+}
+
+AntennaInfoDedicated ::=			SEQUENCE {
+	transmissionMode					ENUMERATED {
+											tm1, tm2, tm3, tm4, tm5, tm6,
+											tm7, tm8-v920},
+	codebookSubsetRestriction			CHOICE {
+		n2TxAntenna-tm3						BIT STRING (SIZE (2)),
+		n4TxAntenna-tm3						BIT STRING (SIZE (4)),
+		n2TxAntenna-tm4						BIT STRING (SIZE (6)),
+		n4TxAntenna-tm4						BIT STRING (SIZE (64)),
+		n2TxAntenna-tm5						BIT STRING (SIZE (4)),
+		n4TxAntenna-tm5						BIT STRING (SIZE (16)),
+		n2TxAntenna-tm6						BIT STRING (SIZE (4)),
+		n4TxAntenna-tm6						BIT STRING (SIZE (16))
+	}		OPTIONAL,															-- Cond TM
+	ue-TransmitAntennaSelection			CHOICE{
+		release							NULL,
+		setup							ENUMERATED {closedLoop, openLoop}
+	}
+}
+
+AntennaInfoDedicated-v920 ::=		SEQUENCE {
+	codebookSubsetRestriction-v920		CHOICE {
+		n2TxAntenna-tm8-r9					BIT STRING (SIZE (6)),
+		n4TxAntenna-tm8-r9					BIT STRING (SIZE (32))
+	}		OPTIONAL															-- Cond TM8
+}
+
+AntennaInfoDedicated-r10 ::=		SEQUENCE {
+	transmissionMode-r10				ENUMERATED {
+											tm1, tm2, tm3, tm4, tm5, tm6, tm7, tm8-v920,
+											tm9-v1020, tm10-v1130, spare6, spare5, spare4,
+											spare3, spare2, spare1},
+	codebookSubsetRestriction-r10		BIT STRING			OPTIONAL,			-- Cond TMX
+	ue-TransmitAntennaSelection		CHOICE{
+		release							NULL,
+		setup							ENUMERATED {closedLoop, openLoop}
+	}
+}
+
+AntennaInfoDedicated-v10i0::=	SEQUENCE {
+	maxLayersMIMO-r10			ENUMERATED {twoLayers, fourLayers, eightLayers}		OPTIONAL	-- Need OR
+}
+
+AntennaInfoDedicated-v1250 ::=		SEQUENCE {
+	alternativeCodebookEnabledFor4TX-r12	BOOLEAN
+}
+
+AntennaInfoDedicated-v1430 ::=		SEQUENCE {
+	ce-UE-TxAntennaSelection-config-r14			ENUMERATED {on}		OPTIONAL	-- Need OR
+}
+
+AntennaInfoDedicatedSTTI-r15 ::=	CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		transmissionModeDL-MBSFN-r15		ENUMERATED {tm9, tm10}		OPTIONAL,	-- Need OR
+		transmissionModeDL-nonMBSFN-r15	ENUMERATED {tm1, tm2, tm3, tm4, tm6, tm8, tm9,
+														tm10}		OPTIONAL,	--_Need OR
+		codebookSubsetRestriction			CHOICE {
+			n2TxAntenna-tm3-r15					BIT STRING (SIZE (2)),
+			n4TxAntenna-tm3-r15					BIT STRING (SIZE (4)),
+			n2TxAntenna-tm4-r15					BIT STRING (SIZE (6)),
+			n4TxAntenna-tm4-r15					BIT STRING (SIZE (64)),
+			n2TxAntenna-tm5-r15					BIT STRING (SIZE (4)),
+			n4TxAntenna-tm5-r15					BIT STRING (SIZE (16)),
+			n2TxAntenna-tm6-r15					BIT STRING (SIZE (4)),
+			n4TxAntenna-tm6-r15					BIT STRING (SIZE (16)),
+			n2TxAntenna-tm8-r15					BIT STRING (SIZE (6)),
+			n4TxAntenna-tm8-r15					BIT STRING (SIZE (64)),
+			n2TxAntenna-tm9and10-r15			BIT STRING (SIZE (6)),
+			n4TxAntenna-tm9and10-r15			BIT STRING (SIZE (96)),
+			n8TxAntenna-tm9and10-r15			BIT STRING (SIZE (109))
+		}		OPTIONAL,															-- Cond TM
+		maxLayersMIMO-STTI-r15			ENUMERATED {twoLayers, fourLayers}	OPTIONAL, -- Need OR
+		slotSubslotPDSCH-TxDiv-2Layer-r15	BOOLEAN,
+		slotSubslotPDSCH-TxDiv-4Layer-r15	BOOLEAN
+	}
+}
+
+AntennaInfoDedicated-v1530 ::=		CHOICE {
+	release								NULL,
+	setup								CHOICE {
+		ue-TxAntennaSelection-SRS-1T4R-Config-r15			NULL,	
+		ue-TxAntennaSelection-SRS-2T4R-NrOfPairs-r15			ENUMERATED {two, three}
+	}
+}
+
+
+
+AntennaInfoUL-r10 ::=		SEQUENCE {
+	transmissionModeUL-r10				ENUMERATED {tm1, tm2, spare6, spare5,
+													spare4, spare3, spare2, spare1}	OPTIONAL,	-- Need OR
+	fourAntennaPortActivated-r10			ENUMERATED {setup}			OPTIONAL		-- Need OR
+}
+
+AntennaInfoUL-STTI-r15 ::=	SEQUENCE {
+	transmissionModeUL-STTI-r15			ENUMERATED {tm1, tm2}		OPTIONAL	-- Need OR
+}
+
+
+
+AUL-Config-r15 ::=	CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		aul-CRNTI-r15							C-RNTI,
+		aul-Subframes-r15						BIT STRING (SIZE (40)),
+		aul-HARQ-Processes-r15					INTEGER (1..16),
+		transmissionModeUL-AUL-r15				ENUMERATED {tm1,tm2},	
+		aul-StartingFullBW-InsideMCOT-r15		BIT STRING (SIZE (5)),
+		aul-StartingFullBW-OutsideMCOT-r15		BIT STRING (SIZE (7)),
+		aul-StartingPartialBW-InsideMCOT-r15	ENUMERATED {o34, o43, o52, o61, oOS1},
+		aul-StartingPartialBW-OutsideMCOT-r15	ENUMERATED {o16, o25, o34, o43, o52, o61, oOS1},
+		aul-RetransmissionTimer-r15				ENUMERATED {psf4, psf5, psf6, psf8, psf10, psf12, psf20, psf28, psf37, psf44, psf68, psf84, psf100,
+												psf116, psf132, psf164, psf324},
+		endingSymbolAUL-r15						INTEGER(12..13),
+		subframeOffsetCOT-Sharing-r15			INTEGER(2..4),
+		contentionWindowSizeTimer-r15			ENUMERATED {n0, n5, n10}
+	}
+}
+
+
+
+CQI-ReportAperiodic-r10	::=		CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		cqi-ReportModeAperiodic-r10			CQI-ReportModeAperiodic,
+		aperiodicCSI-Trigger-r10			SEQUENCE {	
+			trigger1-r10					BIT STRING (SIZE (8)),
+			trigger2-r10					BIT STRING (SIZE (8))
+		}																	OPTIONAL	-- Need OR
+	}
+}
+
+CQI-ReportAperiodic-v1250	::=		CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		aperiodicCSI-Trigger-v1250			SEQUENCE {	
+			trigger-SubframeSetIndicator-r12	ENUMERATED {s1, s2},
+			trigger1-SubframeSetIndicator-r12	BIT STRING (SIZE (8)),
+			trigger2-SubframeSetIndicator-r12	BIT STRING (SIZE (8))
+		}
+	}
+}
+
+CQI-ReportAperiodic-v1310	::=		CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		aperiodicCSI-Trigger-v1310			SEQUENCE {	
+			trigger1-r13					BIT STRING (SIZE (32)),
+			trigger2-r13					BIT STRING (SIZE (32)),
+			trigger3-r13					BIT STRING (SIZE (32)),
+			trigger4-r13					BIT STRING (SIZE (32)),
+			trigger5-r13					BIT STRING (SIZE (32)),
+			trigger6-r13					BIT STRING (SIZE (32))
+		}																	OPTIONAL,	-- Need ON
+		aperiodicCSI-Trigger2-r13		CHOICE {
+			release							NULL,
+			setup						SEQUENCE {	
+				trigger1-SubframeSetIndicator-r13	BIT STRING (SIZE (32)),
+				trigger2-SubframeSetIndicator-r13	BIT STRING (SIZE (32)),
+				trigger3-SubframeSetIndicator-r13	BIT STRING (SIZE (32)),
+				trigger4-SubframeSetIndicator-r13	BIT STRING (SIZE (32)),
+				trigger5-SubframeSetIndicator-r13	BIT STRING (SIZE (32)),
+				trigger6-SubframeSetIndicator-r13	BIT STRING (SIZE (32))
+			}
+		}																	OPTIONAL	-- Need ON
+	}
+}
+
+CQI-ReportAperiodicProc-r11	::=		SEQUENCE {
+	cqi-ReportModeAperiodic-r11			CQI-ReportModeAperiodic,
+	trigger01-r11						BOOLEAN,
+	trigger10-r11						BOOLEAN,
+	trigger11-r11						BOOLEAN
+}
+
+CQI-ReportAperiodicProc-v1310	::=		SEQUENCE {
+	trigger001-r13						BOOLEAN,
+	trigger010-r13						BOOLEAN,
+	trigger011-r13						BOOLEAN,
+	trigger100-r13						BOOLEAN,
+	trigger101-r13						BOOLEAN,
+	trigger110-r13						BOOLEAN,
+	trigger111-r13						BOOLEAN
+}
+
+CQI-ReportAperiodicHybrid-r14	::=		SEQUENCE {
+	triggers-r14						CHOICE {
+		oneBit-r14							SEQUENCE {
+			trigger1-Indicator-r14				BIT STRING (SIZE (8))
+		},
+		twoBit-r14							SEQUENCE {
+			trigger01-Indicator-r14				BIT STRING (SIZE (8)),
+			trigger10-Indicator-r14				BIT STRING (SIZE (8)),
+			trigger11-Indicator-r14				BIT STRING (SIZE (8))
+		},
+		threeBit-r14						SEQUENCE {
+			trigger001-Indicator-r14			BIT STRING (SIZE (32)),
+			trigger010-Indicator-r14			BIT STRING (SIZE (32)),
+			trigger011-Indicator-r14			BIT STRING (SIZE (32)),
+			trigger100-Indicator-r14			BIT STRING (SIZE (32)) ,
+			trigger101-Indicator-r14			BIT STRING (SIZE (32)),
+			trigger110-Indicator-r14			BIT STRING (SIZE (32)),
+			trigger111-Indicator-r14			BIT STRING (SIZE (32))
+		}
+	}																OPTIONAL	-- Need OR
+}
+
+CQI-ReportModeAperiodic ::=				ENUMERATED {
+											rm12, rm20, rm22, rm30, rm31,
+											rm32-v1250, rm10-v1310, rm11-v1310
+}
+
+
+
+CQI-ReportBoth-r11 ::=			SEQUENCE {
+	csi-IM-ConfigToReleaseList-r11		CSI-IM-ConfigToReleaseList-r11	OPTIONAL,	-- Need ON
+	csi-IM-ConfigToAddModList-r11		CSI-IM-ConfigToAddModList-r11	OPTIONAL,	-- Need ON
+	csi-ProcessToReleaseList-r11		CSI-ProcessToReleaseList-r11	OPTIONAL,	-- Need ON
+	csi-ProcessToAddModList-r11			CSI-ProcessToAddModList-r11		OPTIONAL	-- Need ON
+}
+
+CQI-ReportBoth-v1250 ::=			SEQUENCE {
+	csi-IM-ConfigToReleaseListExt-r12		CSI-IM-ConfigId-v1250	OPTIONAL,	-- Need ON
+	csi-IM-ConfigToAddModListExt-r12		CSI-IM-ConfigExt-r12	OPTIONAL	-- Need ON
+}
+
+CQI-ReportBoth-v1310 ::=			SEQUENCE {
+	csi-IM-ConfigToReleaseListExt-r13	CSI-IM-ConfigToReleaseListExt-r13	OPTIONAL,	-- Need ON
+	csi-IM-ConfigToAddModListExt-r13	CSI-IM-ConfigToAddModListExt-r13	OPTIONAL	-- Need ON
+}
+
+CSI-IM-ConfigToAddModList-r11 ::=		SEQUENCE (SIZE (1..maxCSI-IM-r11)) OF CSI-IM-Config-r11
+
+CSI-IM-ConfigToAddModListExt-r13 ::=	SEQUENCE (SIZE (1..maxCSI-IM-v1310)) OF CSI-IM-ConfigExt-r12
+
+CSI-IM-ConfigToReleaseList-r11 ::=		SEQUENCE (SIZE (1..maxCSI-IM-r11)) OF CSI-IM-ConfigId-r11
+
+CSI-IM-ConfigToReleaseListExt-r13 ::=	SEQUENCE (SIZE (1..maxCSI-IM-v1310)) OF CSI-IM-ConfigId-v1310
+
+CSI-ProcessToAddModList-r11 ::=		SEQUENCE (SIZE (1..maxCSI-Proc-r11)) OF CSI-Process-r11
+
+CSI-ProcessToReleaseList-r11 ::=	SEQUENCE (SIZE (1..maxCSI-Proc-r11)) OF CSI-ProcessId-r11
+
+CQI-ReportBothProc-r11 ::=			SEQUENCE {
+	ri-Ref-CSI-ProcessId-r11			CSI-ProcessId-r11				OPTIONAL,		-- Need OR
+	pmi-RI-Report-r11					ENUMERATED {setup}				OPTIONAL		-- Need OR
+}
+
+
+
+CQI-ReportConfig ::=				SEQUENCE {
+	cqi-ReportModeAperiodic			CQI-ReportModeAperiodic	OPTIONAL,			-- Need OR
+	nomPDSCH-RS-EPRE-Offset				INTEGER (-1..6),
+	cqi-ReportPeriodic				CQI-ReportPeriodic	OPTIONAL				-- Need ON
+}
+
+CQI-ReportConfig-v920 ::=		SEQUENCE {
+	cqi-Mask-r9						ENUMERATED {setup}		OPTIONAL,		-- Cond cqi-Setup
+	pmi-RI-Report-r9				ENUMERATED {setup}		OPTIONAL		-- Cond PMIRI
+}
+
+CQI-ReportConfig-r10 ::=	SEQUENCE {
+	cqi-ReportAperiodic-r10				CQI-ReportAperiodic-r10			OPTIONAL,	-- Need ON
+	nomPDSCH-RS-EPRE-Offset			INTEGER (-1..6),
+	cqi-ReportPeriodic-r10				CQI-ReportPeriodic-r10			OPTIONAL,	-- Need ON
+	pmi-RI-Report-r9					ENUMERATED {setup}				OPTIONAL,	-- Cond PMIRIPCell
+	csi-SubframePatternConfig-r10		CHOICE {
+		release							NULL,
+		setup							SEQUENCE {
+			csi-MeasSubframeSet1-r10			MeasSubframePattern-r10,
+			csi-MeasSubframeSet2-r10			MeasSubframePattern-r10
+		}
+	}																	OPTIONAL	-- Need ON
+}
+
+CQI-ReportConfig-v1130 ::=	SEQUENCE {
+	cqi-ReportPeriodic-v1130			CQI-ReportPeriodic-v1130,
+	cqi-ReportBoth-r11					CQI-ReportBoth-r11
+}
+
+CQI-ReportConfig-v1250 ::=		SEQUENCE {
+	csi-SubframePatternConfig-r12		CHOICE {
+		release							NULL,
+		setup							SEQUENCE {
+			csi-MeasSubframeSets-r12			BIT STRING (SIZE (10))
+		}
+	}																OPTIONAL,	-- Need ON
+	cqi-ReportBoth-v1250					CQI-ReportBoth-v1250		OPTIONAL,	-- Need ON
+	cqi-ReportAperiodic-v1250	CQI-ReportAperiodic-v1250		OPTIONAL,	-- Need ON
+	altCQI-Table-r12			ENUMERATED {
+									allSubframes, csi-SubframeSet1,
+									csi-SubframeSet2, spare1}		OPTIONAL		-- Need OP
+}
+
+CQI-ReportConfig-v1310 ::=			SEQUENCE {
+		cqi-ReportBoth-v1310				CQI-ReportBoth-v1310		OPTIONAL,	-- Need ON
+		cqi-ReportAperiodic-v1310			CQI-ReportAperiodic-v1310	OPTIONAL,		-- Need ON
+		cqi-ReportPeriodic-v1310			CQI-ReportPeriodic-v1310	OPTIONAL		-- Need ON
+}
+
+CQI-ReportConfig-v1320 ::=			SEQUENCE {
+		cqi-ReportPeriodic-v1320			CQI-ReportPeriodic-v1320	OPTIONAL	-- Need ON
+}
+
+CQI-ReportConfig-v1430 ::=			SEQUENCE {
+		cqi-ReportAperiodicHybrid-r14		CQI-ReportAperiodicHybrid-r14	OPTIONAL	-- Need ON
+}
+
+CQI-ReportConfig-v1530 ::=		SEQUENCE {
+	altCQI-Table-1024QAM-r15		ENUMERATED {
+										allSubframes, csi-SubframeSet1,
+										csi-SubframeSet2, spare1}		OPTIONAL		-- Need OP
+}
+
+CQI-ReportConfig-r15 ::=	CHOICE {
+	release					NULL,
+	setup					SEQUENCE {
+		cqi-ReportConfig-r10			CQI-ReportConfig-r10			OPTIONAL,		-- Need ON
+		cqi-ReportConfig-v1130			CQI-ReportConfig-v1130			OPTIONAL,		-- Need ON
+		cqi-ReportConfigPCell-v1250		CQI-ReportConfig-v1250			OPTIONAL,		-- Need ON
+		cqi-ReportConfig-v1310			CQI-ReportConfig-v1310			OPTIONAL,		-- Need ON
+		cqi-ReportConfig-v1320			CQI-ReportConfig-v1320			OPTIONAL,		-- Need ON
+		cqi-ReportConfig-v1430			CQI-ReportConfig-v1430			OPTIONAL,		-- Need ON
+		altCQI-Table-1024QAM-r15		ENUMERATED {allSubframes, csi-SubframeSet1,
+										csi-SubframeSet2, spare1}		OPTIONAL		-- Need OP
+	}
+}
+
+CQI-ReportConfigSCell-r10 ::=				SEQUENCE {
+	cqi-ReportModeAperiodic-r10			CQI-ReportModeAperiodic OPTIONAL,			-- Need OR
+	nomPDSCH-RS-EPRE-Offset-r10				INTEGER (-1..6),
+	cqi-ReportPeriodicSCell-r10			CQI-ReportPeriodic-r10			OPTIONAL,	-- Need ON
+	pmi-RI-Report-r10					ENUMERATED {setup}				OPTIONAL	-- Cond PMIRISCell
+}
+
+CQI-ReportConfigSCell-r15 ::=			SEQUENCE {
+	cqi-ReportPeriodicSCell-r15				CQI-ReportPeriodicSCell-r15		OPTIONAL,	-- Need ON
+	altCQI-Table-1024QAM-r15				ENUMERATED {allSubframes, csi-SubframeSet1,
+											csi-SubframeSet2, spare1}		OPTIONAL		-- Need OP
+}
+
+
+
+CQI-ReportPeriodic ::=		CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		cqi-PUCCH-ResourceIndex				INTEGER (0..1185),
+		cqi-pmi-ConfigIndex					INTEGER (0..1023),
+		cqi-FormatIndicatorPeriodic			CHOICE {
+			widebandCQI							NULL,
+			subbandCQI							SEQUENCE {
+				k									INTEGER (1..4)
+			}
+		},
+		ri-ConfigIndex						INTEGER (0..1023)	OPTIONAL,				-- Need OR
+		simultaneousAckNackAndCQI			BOOLEAN
+	}
+}
+
+CQI-ReportPeriodic-r10 ::=		CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		cqi-PUCCH-ResourceIndex-r10			INTEGER (0..1184),
+		cqi-PUCCH-ResourceIndexP1-r10		INTEGER (0..1184)				OPTIONAL,	-- Need OR
+		cqi-pmi-ConfigIndex				INTEGER (0..1023),
+		cqi-FormatIndicatorPeriodic-r10		CHOICE {
+			widebandCQI-r10						SEQUENCE {
+				csi-ReportMode-r10		ENUMERATED {submode1, submode2}		OPTIONAL	-- Need OR
+			},
+			subbandCQI-r10						SEQUENCE {
+				k								INTEGER (1..4),
+				periodicityFactor-r10				ENUMERATED {n2, n4}
+			}
+		},
+		ri-ConfigIndex					INTEGER (0..1023)		OPTIONAL,				-- Need OR
+		simultaneousAckNackAndCQI		BOOLEAN,
+		cqi-Mask-r9						ENUMERATED {setup}		OPTIONAL,				-- Need OR
+		csi-ConfigIndex-r10				CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+				cqi-pmi-ConfigIndex2-r10		INTEGER (0..1023),
+				ri-ConfigIndex2-r10				INTEGER (0..1023)		OPTIONAL		-- Need OR
+			}
+		}		OPTIONAL																-- Need ON
+	}
+}
+
+
+CQI-ReportPeriodic-v1130 ::=	SEQUENCE {
+	simultaneousAckNackAndCQI-Format3-r11		ENUMERATED {setup}		OPTIONAL,	-- Need OR
+	cqi-ReportPeriodicProcExtToReleaseList-r11	CQI-ReportPeriodicProcExtToReleaseList-r11	OPTIONAL,	-- Need ON
+	cqi-ReportPeriodicProcExtToAddModList-r11	CQI-ReportPeriodicProcExtToAddModList-r11	OPTIONAL	-- Need ON
+}
+
+CQI-ReportPeriodic-v1310 ::=	SEQUENCE {
+	cri-ReportConfig-r13			CRI-ReportConfig-r13				OPTIONAL,	-- Need OR
+	simultaneousAckNackAndCQI-Format4-Format5-r13		ENUMERATED {setup}		OPTIONAL -- Need OR
+}
+
+CQI-ReportPeriodic-v1320 ::=	SEQUENCE {
+	periodicityFactorWB-r13			ENUMERATED {n2, n4}			OPTIONAL		-- Need OR
+}
+
+CQI-ReportPeriodicSCell-r15 ::=	CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		cqi-pmi-ConfigIndexDormant-r15		INTEGER (0..1023),
+		ri-ConfigIndexDormant-r15			INTEGER (0..1023)		OPTIONAL,		-- Need OR
+		csi-SubframePatternDormant-r15		CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+				csi-MeasSubframeSet1-r15			MeasSubframePattern-r10,
+				csi-MeasSubframeSet2-r15			MeasSubframePattern-r10
+			}
+		}																OPTIONAL,	-- Need ON
+		cqi-FormatIndicatorDormant-r15	CHOICE {
+			widebandCQI-r15				SEQUENCE {
+				csi-ReportMode-r15			ENUMERATED {submode1, submode2}	OPTIONAL	-- Need OR
+			},
+			subbandCQI-r15				SEQUENCE {
+				k-r15						INTEGER (1..4),
+				periodicityFactor-r15		ENUMERATED {n2, n4}
+			}
+		}															OPTIONAL		-- Need OR
+	}
+}
+
+CQI-ReportPeriodicProcExtToAddModList-r11 ::=		SEQUENCE (SIZE (1..maxCQI-ProcExt-r11)) OF CQI-ReportPeriodicProcExt-r11
+
+CQI-ReportPeriodicProcExtToReleaseList-r11 ::=	SEQUENCE (SIZE (1..maxCQI-ProcExt-r11)) OF CQI-ReportPeriodicProcExtId-r11
+
+CQI-ReportPeriodicProcExt-r11 ::=		SEQUENCE {
+	cqi-ReportPeriodicProcExtId-r11	CQI-ReportPeriodicProcExtId-r11,
+	cqi-pmi-ConfigIndex-r11			INTEGER (0..1023),
+	cqi-FormatIndicatorPeriodic-r11	CHOICE {
+		widebandCQI-r11				SEQUENCE {
+			csi-ReportMode-r11			ENUMERATED {submode1, submode2}	OPTIONAL	-- Need OR
+		},
+		subbandCQI-r11				SEQUENCE {
+			k							INTEGER (1..4),
+			periodicityFactor-r11		ENUMERATED {n2, n4}
+		}
+	},
+	ri-ConfigIndex-r11				INTEGER (0..1023)					OPTIONAL,	-- Need OR
+	csi-ConfigIndex-r11				CHOICE {
+		release							NULL,
+		setup							SEQUENCE {
+			cqi-pmi-ConfigIndex2-r11		INTEGER (0..1023),
+			ri-ConfigIndex2-r11				INTEGER (0..1023)		OPTIONAL		-- Need OR
+		}
+	}																OPTIONAL,		-- Need ON
+	...,
+	[[	cri-ReportConfig-r13			CRI-ReportConfig-r13				OPTIONAL	-- Need ON
+	]],
+	[[	periodicityFactorWB-r13			ENUMERATED {n2, n4}			OPTIONAL		-- Need ON
+	]]
+}
+
+CQI-ShortConfigSCell-r15 ::= CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		cqi-pmi-ConfigIndexShort-r15	INTEGER (0..1023),
+		ri-ConfigIndexShort-r15			INTEGER (0..1023)		OPTIONAL,		-- Need OR
+		cqi-FormatIndicatorShort-r15	CHOICE {
+			widebandCQI-Short-r15			SEQUENCE {
+				csi-ReportModeShort-r15		ENUMERATED {submode1, submode2}	OPTIONAL	-- Need OR
+			},
+			subbandCQI-Short-r15		SEQUENCE {
+				k-r15						INTEGER (1..4),
+				periodicityFactor-r15		ENUMERATED {n2, n4}
+			}
+		}															OPTIONAL		-- Need OR
+	}
+}
+
+CRI-ReportConfig-r13 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		cri-ConfigIndex-r13					CRI-ConfigIndex-r13,
+		cri-ConfigIndex2-r13				CRI-ConfigIndex-r13	OPTIONAL	-- Need OR
+	}
+}
+
+CRI-ConfigIndex-r13 ::=				INTEGER (0..1023)
+
+
+
+CQI-ReportPeriodicProcExtId-r11 ::=					INTEGER (1..maxCQI-ProcExt-r11)
+
+
+
+CrossCarrierSchedulingConfig-r10 ::=		SEQUENCE {
+	schedulingCellInfo-r10				CHOICE {
+		own-r10								SEQUENCE {					-- No cross carrier scheduling
+			cif-Presence-r10						BOOLEAN
+		},
+		other-r10								SEQUENCE {					-- Cross carrier scheduling
+			schedulingCellId-r10				ServCellIndex-r10,
+			pdsch-Start-r10						INTEGER (1..4)
+		}
+	}
+}
+
+CrossCarrierSchedulingConfig-r13 ::=		SEQUENCE {
+	schedulingCellInfo-r13				CHOICE {
+		own-r13								SEQUENCE {					-- No cross carrier scheduling
+			cif-Presence-r13						BOOLEAN
+		},
+		other-r13							SEQUENCE {					-- Cross carrier scheduling
+			schedulingCellId-r13				ServCellIndex-r13,
+			pdsch-Start-r13						INTEGER (1..4),
+			cif-InSchedulingCell-r13				INTEGER (1..7)
+		}
+	}
+}
+
+CrossCarrierSchedulingConfigLAA-UL-r14 ::=		SEQUENCE {
+	schedulingCellId-r14							ServCellIndex-r13,
+	cif-InSchedulingCell-r14						INTEGER (1..7)
+}
+
+
+CRS-ChEstMPDCCH-ConfigCommon-r16 ::=		SEQUENCE {
+	powerRatio-r16		ENUMERATED {dB-4dot77, dB-3, dB-1dot77, dB0, dB1, dB2, dB3, dB4dot77}
+}
+
+CRS-ChEstMPDCCH-ConfigDedicated-r16 ::=		SEQUENCE {
+	powerRatio-r16				ENUMERATED {dB-4dot77, dB-3, dB-1dot77, dB0, dB1, dB2, dB3,
+											dB4dot77}	OPTIONAL, -- Cond setup
+	localizedMappingType-r16	ENUMERATED {predefined, csi-Based, reciprocityBased}
+											DEFAULT	predefined
+}
+
+
+
+CSI-IM-Config-r11 ::=		SEQUENCE {
+	csi-IM-ConfigId-r11			CSI-IM-ConfigId-r11,
+	resourceConfig-r11			INTEGER (0..31),
+	subframeConfig-r11			INTEGER (0..154),
+	...,
+	[[	interferenceMeasRestriction-r13		BOOLEAN		OPTIONAL	-- Need ON
+	]]
+}
+
+CSI-IM-ConfigExt-r12 ::=		SEQUENCE {
+	csi-IM-ConfigId-v1250			CSI-IM-ConfigId-v1250,
+	resourceConfig-r12			INTEGER (0..31),
+	subframeConfig-r12			INTEGER (0..154),
+	...,
+	[[	interferenceMeasRestriction-r13	BOOLEAN				OPTIONAL,	-- Need ON
+		csi-IM-ConfigId-v1310		CSI-IM-ConfigId-v1310	OPTIONAL	-- Need ON
+	]]
+}
+
+
+
+CSI-IM-ConfigId-r11 ::=					INTEGER (1..maxCSI-IM-r11)
+CSI-IM-ConfigId-r12 ::=					INTEGER (1..maxCSI-IM-r12)
+CSI-IM-ConfigId-v1250 ::=				INTEGER (maxCSI-IM-r12)
+CSI-IM-ConfigId-v1310 ::=				INTEGER (minCSI-IM-r13..maxCSI-IM-r13)
+CSI-IM-ConfigId-r13 ::=					INTEGER (1..maxCSI-IM-r13)
+
+
+
+CSI-Process-r11 ::=		SEQUENCE {
+	csi-ProcessId-r11			CSI-ProcessId-r11,
+	csi-RS-ConfigNZPId-r11		CSI-RS-ConfigNZPId-r11,
+	csi-IM-ConfigId-r11			CSI-IM-ConfigId-r11,
+	p-C-AndCBSRList-r11			P-C-AndCBSR-Pair-r13a,
+	cqi-ReportBothProc-r11		CQI-ReportBothProc-r11					OPTIONAL,		-- Need OR
+	cqi-ReportPeriodicProcId-r11	INTEGER (0..maxCQI-ProcExt-r11)		OPTIONAL,		-- Need OR
+	cqi-ReportAperiodicProc-r11	CQI-ReportAperiodicProc-r11				OPTIONAL,		-- Need OR
+	...,
+	[[	alternativeCodebookEnabledFor4TXProc-r12	ENUMERATED {true}	OPTIONAL,	-- Need ON
+		csi-IM-ConfigIdList-r12		CHOICE {
+			release						NULL,
+			setup						SEQUENCE (SIZE (1..2)) OF CSI-IM-ConfigId-r12
+		}																OPTIONAL,	-- Need ON
+		cqi-ReportAperiodicProc2-r12	CHOICE {
+			release						NULL,
+			setup						CQI-ReportAperiodicProc-r11
+		}																OPTIONAL	-- Need ON
+	]],
+	[[	cqi-ReportAperiodicProc-v1310	CHOICE {
+			release							NULL,
+			setup							CQI-ReportAperiodicProc-v1310
+		}																OPTIONAL,		-- Need ON
+		cqi-ReportAperiodicProc2-v1310	CHOICE {
+			release							NULL,
+			setup							CQI-ReportAperiodicProc-v1310
+		}																OPTIONAL,		-- Need ON
+		eMIMO-Type-r13					CSI-RS-ConfigEMIMO-r13			OPTIONAL		-- Need ON
+	]],
+	[[	dummy				CSI-RS-ConfigEMIMO-v1430		OPTIONAL,		-- Need ON
+		eMIMO-Hybrid-r14				CSI-RS-ConfigEMIMO-Hybrid-r14		OPTIONAL,	-- Need ON
+		advancedCodebookEnabled-r14		BOOLEAN							OPTIONAL		-- Need ON
+	]],
+	[[	eMIMO-Type-v1480				CSI-RS-ConfigEMIMO-v1480		OPTIONAL		-- Need ON
+	]],
+	[[	feCOMP-CSI-Enabled-v1530		BOOLEAN							OPTIONAL,		-- Need ON
+		eMIMO-Type-v1530				CSI-RS-ConfigEMIMO-v1530		OPTIONAL		-- Need ON
+	]]
+}
+
+
+
+CSI-ProcessId-r11 ::=		INTEGER (1..maxCSI-Proc-r11)
+
+
+
+CSI-RS-Config-r10 ::=		SEQUENCE {
+	csi-RS-r10					CHOICE {
+		release						NULL,
+		setup						SEQUENCE {
+			antennaPortsCount-r10			ENUMERATED {an1, an2, an4, an8},
+			resourceConfig-r10				INTEGER (0..31),
+			subframeConfig-r10				INTEGER (0..154),
+			p-C-r10							INTEGER (-8..15)
+		}
+	}																OPTIONAL,			-- Need ON
+	zeroTxPowerCSI-RS-r10		ZeroTxPowerCSI-RS-Conf-r12			OPTIONAL			-- Need ON
+}
+
+CSI-RS-Config-v1250 ::=		SEQUENCE {
+	zeroTxPowerCSI-RS2-r12		ZeroTxPowerCSI-RS-Conf-r12			OPTIONAL,			-- Need ON
+	ds-ZeroTxPowerCSI-RS-r12		CHOICE {
+		release							NULL,
+		setup							SEQUENCE {
+			zeroTxPowerCSI-RS-List-r12	SEQUENCE (SIZE (1..maxDS-ZTP-CSI-RS-r12)) OF ZeroTxPowerCSI-RS-r12
+		}
+	}															OPTIONAL				-- Need ON
+}
+
+CSI-RS-Config-v1310 ::=		SEQUENCE {
+	eMIMO-Type-r13				CSI-RS-ConfigEMIMO-r13			OPTIONAL	-- Need ON
+}
+
+CSI-RS-Config-v1430 ::=		SEQUENCE {
+	dummy								CSI-RS-ConfigEMIMO-v1430			OPTIONAL,	-- Need ON
+	eMIMO-Hybrid-r14					CSI-RS-ConfigEMIMO-Hybrid-r14		OPTIONAL,	-- Need ON
+	advancedCodebookEnabled-r14		BOOLEAN								OPTIONAL	-- Need ON
+}
+
+CSI-RS-Config-v1480 ::=		SEQUENCE {
+	eMIMO-Type-v1480				CSI-RS-ConfigEMIMO-v1480			OPTIONAL	-- Need ON
+}
+
+CSI-RS-Config-v1530 ::=		SEQUENCE {
+	eMIMO-Type-v1530				CSI-RS-ConfigEMIMO-v1530			OPTIONAL	-- Need ON
+}
+
+CSI-RS-Config-r15 ::=		CHOICE {
+	release					NULL,
+	setup					SEQUENCE {
+		csi-RS-Config-r10			CSI-RS-Config-r10				OPTIONAL,		-- Need ON
+		csi-RS-Config-v1250		CSI-RS-Config-v1250			OPTIONAL,		-- Need ON
+		csi-RS-Config-v1310		CSI-RS-Config-v1310			OPTIONAL,		-- Need ON
+		csi-RS-Config-v1430		CSI-RS-Config-v1430			OPTIONAL		-- Need ON
+	}
+}
+
+ZeroTxPowerCSI-RS-Conf-r12 ::=	CHOICE {
+		release							NULL,
+		setup							ZeroTxPowerCSI-RS-r12
+}
+
+ZeroTxPowerCSI-RS-r12 ::=	SEQUENCE {
+	zeroTxPowerResourceConfigList-r12		BIT STRING (SIZE (16)),
+	zeroTxPowerSubframeConfig-r12			INTEGER (0..154)
+}
+
+
+
+CSI-RS-ConfigBeamformed-r13 ::=			SEQUENCE	{
+	csi-RS-ConfigNZPIdListExt-r13			SEQUENCE (SIZE (1..7)) OF CSI-RS-ConfigNZPId-r13	OPTIONAL,	-- Need OR
+	csi-IM-ConfigIdList-r13					SEQUENCE (SIZE (1..8)) OF CSI-IM-ConfigId-r13	OPTIONAL,	-- Need OR
+	p-C-AndCBSR-PerResourceConfigList-r13	SEQUENCE (SIZE (1..8)) OF P-C-AndCBSR-Pair-r13	OPTIONAL,	-- Need OR
+	ace-For4Tx-PerResourceConfigList-r13	SEQUENCE (SIZE (1..7)) OF BOOLEAN	OPTIONAL,	-- Need OR
+	alternativeCodebookEnabledBeamformed-r13	ENUMERATED {true}	OPTIONAL,	-- Need OR
+	channelMeasRestriction-r13				ENUMERATED {on}			OPTIONAL	-- Need OR
+}
+
+CSI-RS-ConfigBeamformed-r14 ::=		SEQUENCE {
+	csi-RS-ConfigNZPIdListExt-r14			SEQUENCE (SIZE (1..7)) OF CSI-RS-ConfigNZPId-r13	OPTIONAL,	-- Need OR
+	csi-IM-ConfigIdList-r14					SEQUENCE (SIZE (1..8)) OF CSI-IM-ConfigId-r13	OPTIONAL,	-- Need OR
+	p-C-AndCBSR-PerResourceConfigList-r14	SEQUENCE (SIZE (1..8)) OF P-C-AndCBSR-Pair-r13	OPTIONAL,	-- Need OR
+	ace-For4Tx-PerResourceConfigList-r14	SEQUENCE (SIZE (1..7)) OF BOOLEAN	OPTIONAL,	-- Need OR
+	alternativeCodebookEnabledBeamformed-r14	ENUMERATED {true}	OPTIONAL,	-- Need OR
+	channelMeasRestriction-r14				ENUMERATED {on}			OPTIONAL,	-- Need OR
+	csi-RS-ConfigNZP-ApList-r14				SEQUENCE (SIZE (1..8)) OF CSI-RS-ConfigNZP-r11
+																			OPTIONAL,	-- Need OR
+	nzp-ResourceConfigOriginal-v1430	CSI-RS-Config-NZP-v1430		OPTIONAL,	-- Need OR
+	csi-RS-NZP-Activation-r14				CSI-RS-ConfigNZP-Activation-r14	OPTIONAL		-- Need OR
+}
+
+CSI-RS-ConfigBeamformed-v1430::=		SEQUENCE {
+	csi-RS-ConfigNZP-ApList-r14				SEQUENCE (SIZE (1..8)) OF CSI-RS-ConfigNZP-r11
+																			OPTIONAL,	-- Need OR
+	nzp-ResourceConfigOriginal-v1430	CSI-RS-Config-NZP-v1430		OPTIONAL,	-- Need OR
+	csi-RS-NZP-Activation-r14				CSI-RS-ConfigNZP-Activation-r14	OPTIONAL		-- Need OR
+}
+
+CSI-RS-Config-NZP-v1430::=		SEQUENCE {
+	transmissionComb-r14					NZP-TransmissionComb-r14	OPTIONAL,	-- Need OR
+	frequencyDensity-r14					NZP-FrequencyDensity-r14	OPTIONAL	-- Need OR
+}
+
+CSI-RS-ConfigNZP-Activation-r14::=		SEQUENCE {
+	csi-RS-NZP-mode-r14						ENUMERATED {semiPersistent, aperiodic},
+	activatedResources-r14					INTEGER (0..4)
+}
+
+
+
+CSI-RS-ConfigEMIMO-r13 ::=	CHOICE {
+	release						NULL,
+	setup						CHOICE {
+		nonPrecoded-r13				CSI-RS-ConfigNonPrecoded-r13,
+		beamformed-r13				CSI-RS-ConfigBeamformed-r13
+	}
+}
+
+CSI-RS-ConfigEMIMO-v1430 ::=	CHOICE {
+	release						NULL,
+	setup						CHOICE {
+		nonPrecoded-v1430				CSI-RS-ConfigNonPrecoded-v1430,
+		beamformed-v1430				CSI-RS-ConfigBeamformed-v1430
+	}
+}
+
+CSI-RS-ConfigEMIMO-v1480 ::=	CHOICE {
+	release						NULL,
+	setup						CHOICE {
+		nonPrecoded-v1480				CSI-RS-ConfigNonPrecoded-v1480,
+		beamformed-v1480				CSI-RS-ConfigBeamformed-v1430
+	}
+}
+
+CSI-RS-ConfigEMIMO-v1530 ::=	CHOICE {
+	release						NULL,
+	setup						CHOICE {
+		nonPrecoded-v1530				CSI-RS-ConfigNonPrecoded-v1530
+	}
+}
+
+CSI-RS-ConfigEMIMO2-r14 ::=	CHOICE {
+	release						NULL,
+	setup						CSI-RS-ConfigBeamformed-r14
+}
+
+CSI-RS-ConfigEMIMO-Hybrid-r14 ::=	CHOICE {
+	release						NULL,
+	setup						SEQUENCE {
+		periodicityOffsetIndex-r14			INTEGER (0..1023)				OPTIONAL,	-- Need OR
+		eMIMO-Type2-r14						CSI-RS-ConfigEMIMO2-r14		OPTIONAL	-- Need ON
+	}
+}
+
+
+
+
+CSI-RS-ConfigNonPrecoded-r13 ::=		SEQUENCE {
+	p-C-AndCBSRList-r13						P-C-AndCBSR-Pair-r13			OPTIONAL,	-- Need OR
+	codebookConfigN1-r13					ENUMERATED {n1, n2, n3, n4, n8},
+	codebookConfigN2-r13					ENUMERATED {n1, n2, n3, n4, n8},
+	codebookOverSamplingRateConfig-O1-r13	ENUMERATED {n4, n8}				OPTIONAL,	-- Need OR
+	codebookOverSamplingRateConfig-O2-r13	ENUMERATED {n4, n8}				OPTIONAL,	-- Need OR
+	codebookConfig-r13						INTEGER (1..4),
+	csi-IM-ConfigIdList-r13					SEQUENCE (SIZE (1..2)) OF CSI-IM-ConfigId-r13	OPTIONAL,	-- Need OR
+	csi-RS-ConfigNZP-EMIMO-r13				CSI-RS-ConfigNZP-EMIMO-r13		OPTIONAL	-- Need ON
+}
+
+CSI-RS-ConfigNonPrecoded-v1430::=		SEQUENCE {
+	csi-RS-ConfigNZP-EMIMO-v1430			CSI-RS-ConfigNZP-EMIMO-v1430	OPTIONAL,	-- Need ON
+	codebookConfigN1-v1430					ENUMERATED {n5, n6, n7, n10, n12, n14, n16},
+	codebookConfigN2-v1430					ENUMERATED {n5, n6, n7},
+	nzp-ResourceConfigTM9-Original-v1430	CSI-RS-Config-NZP-v1430
+}
+
+CSI-RS-ConfigNonPrecoded-v1480::=		SEQUENCE {
+	csi-RS-ConfigNZP-EMIMO-v1480			CSI-RS-ConfigNZP-EMIMO-v1430	OPTIONAL,	-- Need ON
+	codebookConfigN1-v1480					ENUMERATED {n5, n6, n7, n10, n12, n14, n16}		OPTIONAL,	-- Need OR
+	codebookConfigN2-r1480					ENUMERATED {n5, n6, n7}			OPTIONAL,	-- Need OR
+	nzp-ResourceConfigTM9-Original-v1480	CSI-RS-Config-NZP-v1430
+}
+
+CSI-RS-ConfigNonPrecoded-v1530 ::=			SEQUENCE {
+	p-C-AndCBSRList-r15						P-C-AndCBSR-Pair-r15			OPTIONAL	-- Need OR
+}
+
+
+
+CSI-RS-ConfigNZP-r11 ::=		SEQUENCE {
+	csi-RS-ConfigNZPId-r11			CSI-RS-ConfigNZPId-r11,
+	antennaPortsCount-r11			ENUMERATED {an1, an2, an4, an8},
+	resourceConfig-r11				INTEGER (0..31),
+	subframeConfig-r11				INTEGER (0..154),
+	scramblingIdentity-r11			INTEGER (0..503),
+	qcl-CRS-Info-r11				SEQUENCE {
+		qcl-ScramblingIdentity-r11		INTEGER (0..503),
+		crs-PortsCount-r11				ENUMERATED {n1, n2, n4, spare1},
+		mbsfn-SubframeConfigList-r11	CHOICE {
+				release						NULL,
+				setup						SEQUENCE {
+					subframeConfigList			MBSFN-SubframeConfigList
+				}
+		}																OPTIONAL	-- Need ON
+	}																	OPTIONAL,	-- Need OR
+	...,
+	[[	csi-RS-ConfigNZPId-v1310		CSI-RS-ConfigNZPId-v1310		OPTIONAL	-- Need ON
+	]],
+	[[	transmissionComb-r14			NZP-TransmissionComb-r14		OPTIONAL,	-- Need OR
+		frequencyDensity-r14			NZP-FrequencyDensity-r14		OPTIONAL	-- Need OR
+	]],
+	[[	mbsfn-SubframeConfigList-v1430	CHOICE {
+				release						NULL,
+				setup						SEQUENCE {
+					subframeConfigList-v1430	MBSFN-SubframeConfigList-v1430
+				}
+		}																OPTIONAL	-- Need OP
+	]]
+}
+
+CSI-RS-ConfigNZP-EMIMO-r13 ::=	CHOICE {
+	release						NULL,
+	setup						SEQUENCE {
+		nzp-resourceConfigList-r13		SEQUENCE (SIZE (1..2)) OF NZP-ResourceConfig-r13,
+		cdmType-r13						ENUMERATED {cdm2, cdm4}	OPTIONAL	-- Need OR
+		}
+}
+
+CSI-RS-ConfigNZP-EMIMO-v1430 ::=	SEQUENCE {
+	-- All extensions are for Non-Precoded so could be grouped by setup/ release choice
+	nzp-resourceConfigListExt-r14	SEQUENCE (SIZE (0..4)) OF NZP-ResourceConfig-r13,
+	cdmType-v1430					ENUMERATED {cdm8 }			OPTIONAL	-- Need OR
+}
+
+NZP-ResourceConfig-r13 ::=	SEQUENCE {
+	resourceConfig-r13				ResourceConfig-r13,
+	...,
+	[[	transmissionComb-r14		NZP-TransmissionComb-r14		OPTIONAL,	-- Need OR
+		frequencyDensity-r14		NZP-FrequencyDensity-r14		OPTIONAL	-- Need OR
+	]]
+}
+
+ResourceConfig-r13 ::=				INTEGER (0..31)
+
+NZP-TransmissionComb-r14 ::=			INTEGER (0..2)
+NZP-FrequencyDensity-r14 ::=			ENUMERATED {d1, d2, d3}
+
+
+
+CSI-RS-ConfigNZPId-r11 ::=					INTEGER (1..maxCSI-RS-NZP-r11)
+CSI-RS-ConfigNZPId-v1310 ::=				INTEGER (minCSI-RS-NZP-r13..maxCSI-RS-NZP-r13)
+CSI-RS-ConfigNZPId-r13 ::=					INTEGER (1..maxCSI-RS-NZP-r13)
+
+
+
+CSI-RS-ConfigZP-r11 ::=		SEQUENCE {
+	csi-RS-ConfigZPId-r11		CSI-RS-ConfigZPId-r11,
+	resourceConfigList-r11		BIT STRING (SIZE (16)),
+	subframeConfig-r11			INTEGER (0..154),
+	...
+}
+
+CSI-RS-ConfigZP-ApList-r14 ::=	CHOICE {
+	release							NULL,
+	setup							SEQUENCE (SIZE (1.. maxCSI-RS-ZP-r11)) OF CSI-RS-ConfigZP-r11
+}
+
+
+
+CSI-RS-ConfigZPId-r11 ::=					INTEGER (1..maxCSI-RS-ZP-r11)
+
+
+
+DataInactivityTimer-r14 ::=				ENUMERATED {
+											s1, s2, s3, s5, s7, s10, s15, s20, s40, s50, s60,
+											s80, s100, s120, s150, s180}
+
+
+
+DMRS-Config-r11 ::=		CHOICE {
+	release						NULL,
+	setup						SEQUENCE {
+		scramblingIdentity-r11		INTEGER (0..503),
+		scramblingIdentity2-r11		INTEGER (0..503)
+	}
+}
+DMRS-Config-v1310 ::=			SEQUENCE {
+		dmrs-tableAlt-r13				ENUMERATED {true}			OPTIONAL	-- Need OR
+}
+
+
+
+DRB-Identity ::=					INTEGER (1..32)
+
+
+
+EPDCCH-Config-r11 ::=		SEQUENCE{
+	config-r11		CHOICE {
+		release						NULL,
+		setup						SEQUENCE {
+			subframePatternConfig-r11	CHOICE {
+				release						NULL,
+				setup						SEQUENCE {
+					subframePattern-r11			MeasSubframePattern-r10
+				}
+			}																OPTIONAL, -- Need ON
+			startSymbol-r11				INTEGER (1..4)						OPTIONAL, -- Need OP
+			setConfigToReleaseList-r11	EPDCCH-SetConfigToReleaseList-r11	OPTIONAL, -- Need ON
+			setConfigToAddModList-r11	EPDCCH-SetConfigToAddModList-r11	OPTIONAL -- Need ON
+		}
+	}
+}
+
+EPDCCH-SetConfigToAddModList-r11 ::= SEQUENCE (SIZE(1..maxEPDCCH-Set-r11)) OF EPDCCH-SetConfig-r11
+
+EPDCCH-SetConfigToReleaseList-r11 ::= SEQUENCE (SIZE(1..maxEPDCCH-Set-r11)) OF EPDCCH-SetConfigId-r11
+
+EPDCCH-SetConfig-r11 ::=		SEQUENCE {
+	setConfigId-r11					EPDCCH-SetConfigId-r11,
+	transmissionType-r11			ENUMERATED {localised, distributed},
+	resourceBlockAssignment-r11		SEQUENCE{
+		numberPRB-Pairs-r11				ENUMERATED {n2, n4, n8},
+		resourceBlockAssignment-r11		BIT STRING (SIZE(4..38))
+	},
+	dmrs-ScramblingSequenceInt-r11	INTEGER (0..503),
+	pucch-ResourceStartOffset-r11	INTEGER (0..2047),
+	re-MappingQCL-ConfigId-r11		PDSCH-RE-MappingQCL-ConfigId-r11	OPTIONAL, -- Need OR
+	...,
+	[[	csi-RS-ConfigZPId2-r12		CHOICE {
+			release							NULL,
+			setup							CSI-RS-ConfigZPId-r11
+		}															OPTIONAL	-- Need ON
+	]],
+	[[	numberPRB-Pairs-v1310			CHOICE {
+			release							NULL,
+			setup							ENUMERATED {n6}
+		}															OPTIONAL,	-- Need ON
+		mpdcch-config-r13				CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+				csi-NumRepetitionCE-r13			ENUMERATED {sf1, sf2, sf4, sf8, sf16, sf32},
+				mpdcch-pdsch-HoppingConfig-r13	ENUMERATED {on,off},
+				mpdcch-StartSF-UESS-r13			CHOICE {
+					fdd-r13							ENUMERATED {v1, v1dot5, v2, v2dot5, v4,
+																v5, v8, v10},
+					tdd-r13							ENUMERATED {v1, v2, v4, v5, v8, v10,
+																v20, spare1}
+				},
+				mpdcch-NumRepetition-r13		ENUMERATED {r1, r2, r4, r8, r16,
+															r32, r64, r128, r256},
+				mpdcch-Narrowband-r13			INTEGER (1.. maxAvailNarrowBands-r13)
+			}
+		}															OPTIONAL	-- Need ON
+	]]
+}
+
+EPDCCH-SetConfigId-r11 ::=	INTEGER (0..1)
+
+
+
+EIMTA-MainConfig-r12 ::=	CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		eimta-RNTI-r12				C-RNTI,
+		eimta-CommandPeriodicity-r12	ENUMERATED {sf10, sf20, sf40, sf80},
+		eimta-CommandSubframeSet-r12	BIT STRING (SIZE(10))
+	}
+}
+
+EIMTA-MainConfigServCell-r12 ::=	CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		eimta-UL-DL-ConfigIndex-r12			INTEGER (1..5),
+		eimta-HARQ-ReferenceConfig-r12		ENUMERATED {sa2, sa4, sa5},
+		mbsfn-SubframeConfigList-v1250		CHOICE {
+				release								NULL,
+				setup								SEQUENCE {
+				subframeConfigList-r12				MBSFN-SubframeConfigList
+			}
+		}
+	}
+}
+
+
+
+GWUS-Config-r16 ::=				SEQUENCE {
+	groupAlternation-r16			ENUMERATED {true}				OPTIONAL,	-- Need OR
+	commonSequence-r16				ENUMERATED {g0, g126}			OPTIONAL,	-- Need OR
+	timeParameters-r16				GWUS-TimeParameters-r16			OPTIONAL,	-- Cond NoWUSr15
+	resourceConfigDRX-r16			GWUS-ResourceConfig-r16,
+	resourceConfig-eDRX-Short-r16	GWUS-ResourceConfig-r16			OPTIONAL,	-- Need OP
+	resourceConfig-eDRX-Long-r16	GWUS-ResourceConfig-r16			OPTIONAL,	-- Cond TimeOffset
+	probThreshList-r16				GWUS-ProbThreshList-r16		OPTIONAL, 	-- Cond ProbabilityBased
+	groupNarrowBandList-r16			GWUS-GroupNarrowBandList-r16	OPTIONAL -- Need OR
+}
+
+GWUS-TimeParameters-r16 ::=		SEQUENCE {
+	maxDurationFactor-r16			ENUMERATED {one32th, one16th, one8th, one4th},
+	numPOs-r16						ENUMERATED {n1, n2, n4, spare1}			DEFAULT n1,
+	timeOffsetDRX-r16				ENUMERATED {ms40, ms80, ms160, ms240},
+	timeOffset-eDRX-Short-r16		ENUMERATED {ms40, ms80, ms160, ms240},
+	timeOffset-eDRX-Long-r16		ENUMERATED {ms1000, ms2000}				OPTIONAL,	-- Need OP
+	numDRX-CyclesRelaxed-r16		ENUMERATED {n1, n2, n4, n8}				OPTIONAL,	-- Need OR
+	powerBoost-r16					ENUMERATED {dB0, dB1dot8, dB3, dB4dot8}	OPTIONAL,	-- Need OR
+	...
+}
+
+GWUS-ResourceConfig-r16 ::=		SEQUENCE {
+	resourceMappingPattern-r16		CHOICE {
+		resourceLocationWithWUS			ENUMERATED {primary, secondary, primary3FDM},
+		resourceLocationWithoutWUS		ENUMERATED {n0, n2}
+	},
+	numGroupsList-r16				GWUS-NumGroupsList-r16			OPTIONAL,	-- Need OP
+	groupsForServiceList-r16		GWUS-GroupsForServiceList-r16	OPTIONAL	-- Cond ProbabilityBased
+}
+
+GWUS-GroupsForServiceList-r16 ::=	SEQUENCE (SIZE (1..maxGWUS-ProbThresholds-r16)) OF INTEGER (1..maxGWUS-Groups-1-r16)
+
+GWUS-GroupNarrowBandList-r16 ::=	SEQUENCE (SIZE (1..maxAvailNarrowBands-r13)) OF BOOLEAN
+
+GWUS-NumGroupsList-r16 ::= 		SEQUENCE (SIZE (1..maxGWUS-Resources-r16)) OF GWUS-NumGroups-r16
+
+GWUS-ProbThreshList-r16 ::=		SEQUENCE (SIZE (1..maxGWUS-ProbThresholds-r16)) OF GWUS-PagingProbThresh-r16
+
+GWUS-NumGroups-r16 ::=			ENUMERATED {n1, n2, n4, n8}
+
+GWUS-PagingProbThresh-r16 ::=	ENUMERATED {p20, p30, p40, p50, p60, p70, p80, p90}
+
+
+
+LogicalChannelConfig ::=			SEQUENCE {
+	ul-SpecificParameters				SEQUENCE {
+		priority							INTEGER (1..16),
+		prioritisedBitRate					ENUMERATED {
+												kBps0, kBps8, kBps16, kBps32, kBps64, kBps128,
+												kBps256, infinity, kBps512-v1020, kBps1024-v1020,
+												kBps2048-v1020, spare5, spare4, spare3, spare2,
+												spare1},
+		bucketSizeDuration					ENUMERATED {
+												ms50, ms100, ms150, ms300, ms500, ms1000, spare2,
+												spare1},
+		logicalChannelGroup					INTEGER (0..3)			OPTIONAL			-- Need OR
+	}		OPTIONAL,																	-- Cond UL
+	...,
+	[[	logicalChannelSR-Mask-r9			ENUMERATED {setup}		OPTIONAL		-- Cond SRmask
+	]],
+	[[	logicalChannelSR-Prohibit-r12		BOOLEAN					OPTIONAL		-- Need ON
+	]],
+	[[	laa-UL-Allowed-r14					BOOLEAN					OPTIONAL,		-- Need ON
+		bitRateQueryProhibitTimer-r14	ENUMERATED {
+											s0, s0dot4, s0dot8, s1dot6, s3, s6, s12,
+											s30}				OPTIONAL		--Need OR
+	]],
+	[[	allowedTTI-Lengths-r15		CHOICE	{
+			release			NULL,
+			setup			SEQUENCE {
+				shortTTI-r15		BOOLEAN,
+				subframeTTI-r15		BOOLEAN
+			}
+		}										OPTIONAL,								-- Need ON
+		logicalChannelSR-Restriction-r15 CHOICE	{
+			release			NULL,
+			setup			ENUMERATED {spucch, pucch}
+		}										OPTIONAL,								-- Need ON
+		channelAccessPriority-r15			CHOICE {
+			release									NULL,
+			setup									INTEGER (1..4)
+		}										OPTIONAL,		-- Need ON
+		lch-CellRestriction-r15				BIT STRING (SIZE (maxServCell-r13)) OPTIONAL -- Need ON
+	]],
+	[[
+		bitRateMultiplier-r16		ENUMERATED {x40, x70, x100, x200}	OPTIONAL	-- Need OR
+	]]
+}
+
+
+
+LWA-Configuration-r13 ::=		CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		lwa-Config-r13					LWA-Config-r13
+	}
+}
+
+LWA-Config-r13 ::=	SEQUENCE {
+	lwa-MobilityConfig-r13			WLAN-MobilityConfig-r13		OPTIONAL,	-- Need ON
+	lwa-WT-Counter-r13				INTEGER (0..65535)			OPTIONAL,	-- Need ON
+	...,
+	[[	wt-MAC-Address-r14		OCTET STRING (SIZE (6))	OPTIONAL	-- Need ON
+	]]
+}
+
+
+
+LWIP-Configuration-r13 ::=		CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		lwip-Config-r13					LWIP-Config-r13
+	}
+}
+
+LWIP-Config-r13 ::=	SEQUENCE {
+	lwip-MobilityConfig-r13			WLAN-MobilityConfig-r13		OPTIONAL,	-- Need ON
+	tunnelConfigLWIP-r13			TunnelConfigLWIP-r13		OPTIONAL,	-- Need ON
+	...
+}
+
+
+
+MAC-MainConfig ::=					SEQUENCE {
+	ul-SCH-Config						SEQUENCE {
+		maxHARQ-Tx							ENUMERATED {
+												n1, n2, n3, n4, n5, n6, n7, n8,
+												n10, n12, n16, n20, n24, n28,
+												spare2, spare1}		OPTIONAL,	-- Need ON
+		periodicBSR-Timer					PeriodicBSR-Timer-r12	OPTIONAL,	-- Need ON
+		retxBSR-Timer						RetxBSR-Timer-r12,
+		ttiBundling							BOOLEAN
+	}																OPTIONAL,	-- Need ON
+	drx-Config							DRX-Config					OPTIONAL,	-- Need ON
+	timeAlignmentTimerDedicated			TimeAlignmentTimer,
+	phr-Config							CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			periodicPHR-Timer					ENUMERATED {sf10, sf20, sf50, sf100, sf200,
+															sf500, sf1000, infinity},
+			prohibitPHR-Timer					ENUMERATED {sf0, sf10, sf20, sf50, sf100,
+																sf200, sf500, sf1000},
+			dl-PathlossChange					ENUMERATED {dB1, dB3, dB6, infinity}
+		}
+	}																OPTIONAL,	-- Need ON
+	...,
+	[[	sr-ProhibitTimer-r9					INTEGER (0..7)			OPTIONAL	-- Need ON
+	]],
+	[[	mac-MainConfig-v1020				SEQUENCE {
+			sCellDeactivationTimer-r10			ENUMERATED {
+													rf2, rf4, rf8, rf16, rf32, rf64, rf128,
+													spare}			OPTIONAL,	-- Need OP
+			extendedBSR-Sizes-r10				ENUMERATED {setup}		OPTIONAL,	-- Need OR
+			extendedPHR-r10						ENUMERATED {setup}		OPTIONAL	-- Need OR
+		}															OPTIONAL	-- Need ON
+	]],
+	[[	stag-ToReleaseList-r11				STAG-ToReleaseList-r11	OPTIONAL,	-- Need ON
+		stag-ToAddModList-r11				STAG-ToAddModList-r11	OPTIONAL,	-- Need ON
+		drx-Config-v1130					DRX-Config-v1130		OPTIONAL	-- Need ON
+	]],
+	[[	e-HARQ-Pattern-r12					BOOLEAN					OPTIONAL,	-- Need ON
+		dualConnectivityPHR					CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				phr-ModeOtherCG-r12					ENUMERATED {real, virtual}
+			}
+		}														OPTIONAL,	-- Need ON
+		logicalChannelSR-Config-r12		CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				logicalChannelSR-ProhibitTimer-r12		ENUMERATED {sf20, sf40, sf64, sf128, sf512, sf1024, sf2560, spare1}
+			}
+		}															OPTIONAL		-- Need ON
+	]],
+	[[	drx-Config-v1310					DRX-Config-v1310		OPTIONAL,		-- Need ON
+		extendedPHR2-r13					BOOLEAN		OPTIONAL,		-- Need ON
+		eDRX-Config-CycleStartOffset-r13	CHOICE {
+			release							NULL,
+			setup
+											CHOICE {
+			sf5120									INTEGER(0..1),
+			sf10240									INTEGER(0..3)
+			}
+		}										OPTIONAL	-- Need ON
+	]],
+	[[	drx-Config-r13						CHOICE {
+			release								NULL,
+			setup								DRX-Config-r13
+		}															OPTIONAL	-- Need ON
+	]],
+	[[	skipUplinkTx-r14					CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				skipUplinkTxSPS-r14					ENUMERATED {true}		OPTIONAL,	-- Need OR
+				skipUplinkTxDynamic-r14				ENUMERATED {true}		OPTIONAL	-- Need OR
+			}
+		}															OPTIONAL,	-- Need ON
+		dataInactivityTimerConfig-r14		CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				dataInactivityTimer-r14				DataInactivityTimer-r14
+			}
+		}												OPTIONAL	-- Need ON
+	]],
+	[[	rai-Activation-r14					ENUMERATED {true}			OPTIONAL	-- Need OR
+	]],
+	[[	shortTTI-AndSPT-r15				CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+				drx-Config-r15					DRX-Config-r15				OPTIONAL, -- Need ON
+				periodicBSR-Timer-r15			ENUMERATED {
+													sf1, sf5, sf10, sf16, sf20, sf32, sf40,
+													sf64, sf80, sf128, sf160, sf320, sf640,
+													sf1280, sf2560, infinity}
+																			OPTIONAL, -- Need ON
+				proc-Timeline-r15				ENUMERATED {nplus4set1, nplus6set1,
+												nplus6set2, nplus8set2 }	OPTIONAL, -- Need ON
+				ssr-ProhibitTimer-r15			INTEGER (0..7)				OPTIONAL -- Need ON
+			}
+		}																	OPTIONAL, -- Need ON
+		mpdcch-UL-HARQ-ACK-FeedbackConfig-r15	BOOLEAN		OPTIONAL,	-- Need ON
+		dormantStateTimers-r15				CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				sCellHibernationTimer-r15			ENUMERATED {
+					rf2, rf4, rf8, rf16, rf32, rf64, rf128, spare}		OPTIONAL,	-- Need OR
+				dormantSCellDeactivationTimer-r15	ENUMERATED {
+					rf2, rf4, rf8, rf16, rf32, rf64,
+					rf128, rf320, rf640, rf1280, rf2560,
+					rf5120, rf10240, spare3, spare2, spare1}			OPTIONAL	-- Need OR
+			}
+		}																 OPTIONAL	-- Need ON
+	]],
+	[[	ce-ETWS-CMAS-RxInConn-r16				ENUMERATED {true}		OPTIONAL	-- Need OR
+	]]
+}
+
+MAC-MainConfigSCell-r11 ::=			SEQUENCE {
+	stag-Id-r11							STAG-Id-r11		OPTIONAL,	-- Need OP
+	...
+}
+
+DRX-Config ::=						CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		onDurationTimer						ENUMERATED {
+												psf1, psf2, psf3, psf4, psf5, psf6,
+												psf8, psf10, psf20, psf30, psf40,
+												psf50, psf60, psf80, psf100,
+												psf200},
+		drx-InactivityTimer					ENUMERATED {
+												psf1, psf2, psf3, psf4, psf5, psf6,
+												psf8, psf10, psf20, psf30, psf40,
+												psf50, psf60, psf80, psf100,
+												psf200, psf300, psf500, psf750,
+												psf1280, psf1920, psf2560, psf0-v1020,
+												spare9, spare8, spare7, spare6,
+												spare5, spare4, spare3, spare2,
+												spare1},
+		drx-RetransmissionTimer				ENUMERATED {
+												psf1, psf2, psf4, psf6, psf8, psf16,
+												psf24, psf33},
+		longDRX-CycleStartOffset		CHOICE {
+			sf10							INTEGER(0..9),
+			sf20							INTEGER(0..19),
+			sf32							INTEGER(0..31),
+			sf40							INTEGER(0..39),
+			sf64							INTEGER(0..63),
+			sf80							INTEGER(0..79),
+			sf128							INTEGER(0..127),
+			sf160							INTEGER(0..159),
+			sf256							INTEGER(0..255),
+			sf320							INTEGER(0..319),
+			sf512							INTEGER(0..511),
+			sf640							INTEGER(0..639),
+			sf1024							INTEGER(0..1023),
+			sf1280							INTEGER(0..1279),
+			sf2048							INTEGER(0..2047),
+			sf2560							INTEGER(0..2559)
+		},
+		shortDRX							SEQUENCE {
+			shortDRX-Cycle						ENUMERATED	{
+													sf2, sf5, sf8, sf10, sf16, sf20,
+													sf32, sf40, sf64, sf80, sf128, sf160,
+													sf256, sf320, sf512, sf640},
+			drxShortCycleTimer					INTEGER (1..16)
+		}		OPTIONAL													-- Need OR
+	}
+}
+
+DRX-Config-v1130 ::=					SEQUENCE {
+	drx-RetransmissionTimer-v1130			ENUMERATED {psf0-v1130}	OPTIONAL,	--Need OR
+	longDRX-CycleStartOffset-v1130			CHOICE {
+		sf60-v1130								INTEGER(0..59),
+		sf70-v1130								INTEGER(0..69)
+	}																OPTIONAL,	--Need OR
+	shortDRX-Cycle-v1130					ENUMERATED	{sf4-v1130}	OPTIONAL	--Need OR
+}
+DRX-Config-v1310 ::=					SEQUENCE {
+	longDRX-CycleStartOffset-v1310		SEQUENCE {
+		sf60-v1310								INTEGER(0..59)
+	}																OPTIONAL	--Need OR	
+}
+
+DRX-Config-r13 ::=					SEQUENCE {
+	onDurationTimer-v1310					ENUMERATED {psf300, psf400, psf500, psf600,
+													psf800, psf1000, psf1200, psf1600}
+													OPTIONAL,	--Need OR
+	drx-RetransmissionTimer-v1310			ENUMERATED {psf40, psf64, psf80, psf96, psf112,
+													psf128, psf160, psf320}
+														OPTIONAL,	--Need OR
+	drx-ULRetransmissionTimer-r13			ENUMERATED {psf0, psf1, psf2, psf4, psf6, psf8, psf16,
+														psf24, psf33, psf40, psf64, psf80, psf96,
+														psf112, psf128, psf160, psf320}
+														OPTIONAL	--Need OR
+}
+
+DRX-Config-r15 ::=					SEQUENCE {
+	drx-RetransmissionTimerShortTTI-r15		ENUMERATED {
+													tti10, tti20, tti40, tti64, tti80, tti96,
+													tti112,tti128, tti160, tti320} OPTIONAL, --Need OR
+	drx-UL-RetransmissionTimerShortTTI-r15	ENUMERATED {
+												tti0, tti1, tti2, tti4, tti6, tti8, tti16,
+												tti24, tti33, tti40, tti64, tti80, tti96, tti112,
+												tti128, tti160, tti320}	OPTIONAL --Need OR
+}
+
+PeriodicBSR-Timer-r12 ::=					ENUMERATED {
+												sf5, sf10, sf16, sf20, sf32, sf40, sf64, sf80,
+												sf128, sf160, sf320, sf640, sf1280, sf2560,
+												infinity, spare1}
+
+RetxBSR-Timer-r12 ::=							ENUMERATED {
+												sf320, sf640, sf1280, sf2560, sf5120,
+												sf10240, spare2, spare1}
+
+STAG-ToReleaseList-r11 ::=	SEQUENCE (SIZE (1..maxSTAG-r11)) OF STAG-Id-r11
+
+STAG-ToAddModList-r11 ::=	SEQUENCE (SIZE (1..maxSTAG-r11)) OF STAG-ToAddMod-r11
+
+STAG-ToAddMod-r11 ::=		SEQUENCE {
+	stag-Id-r11					STAG-Id-r11,
+	timeAlignmentTimerSTAG-r11	TimeAlignmentTimer,
+	...
+}
+
+STAG-Id-r11::=				INTEGER (1..maxSTAG-r11)
+
+
+
+P-C-AndCBSR-r11 ::=	SEQUENCE {
+	p-C-r11						INTEGER (-8..15),
+	codebookSubsetRestriction-r11	BIT STRING
+}
+
+P-C-AndCBSR-r13 ::=	SEQUENCE {
+	p-C-r13						INTEGER (-8..15),
+	cbsr-Selection-r13			CHOICE{
+		nonPrecoded-r13				SEQUENCE {
+			codebookSubsetRestriction1-r13				BIT STRING,
+			codebookSubsetRestriction2-r13				BIT STRING
+		},
+		beamformedK1a-r13			SEQUENCE {
+			codebookSubsetRestriction3-r13				BIT STRING
+		},
+		beamformedKN-r13			SEQUENCE {
+			codebookSubsetRestriction-r13				BIT STRING
+		}
+	},
+	...
+}
+
+P-C-AndCBSR-r15 ::=	SEQUENCE {
+	p-C-r15						INTEGER (-8..15),
+	codebookSubsetRestriction4-r15	BIT STRING
+}
+
+P-C-AndCBSR-Pair-r13a ::=	SEQUENCE (SIZE (1..2)) OF P-C-AndCBSR-r11
+
+P-C-AndCBSR-Pair-r13 ::=	SEQUENCE (SIZE (1..2)) OF P-C-AndCBSR-r13
+
+P-C-AndCBSR-Pair-r15 ::=	SEQUENCE (SIZE (1..2)) OF P-C-AndCBSR-r15
+
+
+
+PDCCH-ConfigSCell-r13 ::=		SEQUENCE {
+	skipMonitoringDCI-format0-1A-r13	ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+PDCCH-ConfigLAA-r14 ::=		SEQUENCE {
+	maxNumberOfSchedSubframes-Format0B-r14	ENUMERATED {sf2, sf3, sf4}	OPTIONAL,		-- Need OR
+	maxNumberOfSchedSubframes-Format4B-r14	ENUMERATED {sf2, sf3, sf4}	OPTIONAL,		-- Need OR
+	skipMonitoringDCI-Format0A-r14				ENUMERATED {true}		OPTIONAL,		-- Need OR
+	skipMonitoringDCI-Format4A-r14				ENUMERATED {true}		OPTIONAL,		-- Need OR
+	pdcch-CandidateReductions-Format0A-r14		
+								PDCCH-CandidateReductions-r13			OPTIONAL,		-- Need ON
+	pdcch-CandidateReductions-Format4A-r14		
+								PDCCH-CandidateReductionsLAA-UL-r14		OPTIONAL,	-- Need ON
+	pdcch-CandidateReductions-Format0B-r14		
+								PDCCH-CandidateReductionsLAA-UL-r14		OPTIONAL,	-- Need ON
+	pdcch-CandidateReductions-Format4B-r14		
+								PDCCH-CandidateReductionsLAA-UL-r14	OPTIONAL		-- Need ON
+}
+
+PDCCH-CandidateReductionValue-r13 ::= ENUMERATED {n0, n33, n66, n100}
+
+PDCCH-CandidateReductionValue-r14 ::= ENUMERATED {n0, n50, n100, n150}				
+
+PDCCH-CandidateReductions-r13 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		pdcch-candidateReductionAL1-r13		PDCCH-CandidateReductionValue-r13,
+		pdcch-candidateReductionAL2-r13		PDCCH-CandidateReductionValue-r13,
+		pdcch-candidateReductionAL3-r13		PDCCH-CandidateReductionValue-r13,
+		pdcch-candidateReductionAL4-r13		PDCCH-CandidateReductionValue-r13,
+		pdcch-candidateReductionAL5-r13		PDCCH-CandidateReductionValue-r13
+	}
+}
+
+PDCCH-CandidateReductionsLAA-UL-r14 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		pdcch-candidateReductionAL1-r14		PDCCH-CandidateReductionValue-r13,
+		pdcch-candidateReductionAL2-r14		PDCCH-CandidateReductionValue-r13,
+		pdcch-candidateReductionAL3-r14		PDCCH-CandidateReductionValue-r14,
+		pdcch-candidateReductionAL4-r14		PDCCH-CandidateReductionValue-r14,
+		pdcch-candidateReductionAL5-r14		PDCCH-CandidateReductionValue-r14
+	}
+}
+
+
+
+PDCP-Config ::=						SEQUENCE {
+	discardTimer						ENUMERATED {
+											ms50, ms100, ms150, ms300, ms500,
+											ms750, ms1500, infinity
+	}															OPTIONAL,			-- Cond Setup
+	rlc-AM								SEQUENCE {
+		statusReportRequired				BOOLEAN
+	}															OPTIONAL,			-- Cond Rlc-AM-UM
+	rlc-UM								SEQUENCE {
+		pdcp-SN-Size						ENUMERATED {len7bits, len12bits}
+	}															OPTIONAL,			-- Cond Rlc-UM
+	headerCompression					CHOICE {
+		notUsed								NULL,
+		rohc								SEQUENCE {
+			maxCID								INTEGER (1..16383)				DEFAULT 15,
+			profiles							SEQUENCE {
+				profile0x0001						BOOLEAN,
+				profile0x0002						BOOLEAN,
+				profile0x0003						BOOLEAN,
+				profile0x0004						BOOLEAN,
+				profile0x0006						BOOLEAN,
+				profile0x0101						BOOLEAN,
+				profile0x0102						BOOLEAN,
+				profile0x0103						BOOLEAN,
+				profile0x0104						BOOLEAN
+			},
+			...
+		}
+	},
+	...,
+	[[	rn-IntegrityProtection-r10		ENUMERATED {enabled}	OPTIONAL	-- Cond RN
+	]],
+	[[	pdcp-SN-Size-v1130				ENUMERATED {len15bits}	OPTIONAL	-- Cond Rlc-AM2
+	]],
+	[[	ul-DataSplitDRB-ViaSCG-r12		BOOLEAN		OPTIONAL,	-- Need ON
+		t-Reordering-r12				ENUMERATED {
+										ms0, ms20, ms40, ms60, ms80, ms100, ms120, ms140,
+										ms160, ms180, ms200, ms220, ms240, ms260, ms280, ms300,
+										ms500, ms750, spare14, spare13, spare12, spare11, spare10,
+										spare9, spare8, spare7, spare6, spare5, spare4, spare3,
+										spare2, spare1}					OPTIONAL	-- Cond SetupS
+	]],
+	[[	ul-DataSplitThreshold-r13		CHOICE {
+			release						NULL,
+			setup						ENUMERATED {
+										b0, b100, b200, b400, b800, b1600, b3200, b6400, b12800,
+										b25600, b51200, b102400, b204800, b409600, b819200,
+										spare1}
+		}																OPTIONAL,	-- Need ON
+		pdcp-SN-Size-v1310				ENUMERATED {len18bits}	OPTIONAL,	-- Cond Rlc-AM3
+		statusFeedback-r13				CHOICE {
+			release						NULL,
+			setup						SEQUENCE {
+				statusPDU-TypeForPolling-r13		ENUMERATED {type1, type2}		OPTIONAL,	-- Need ON
+				statusPDU-Periodicity-Type1-r13		ENUMERATED {
+										ms5, ms10, ms20, ms30, ms40, ms50, ms60, ms70, ms80, ms90,
+										ms100, ms150, ms200, ms300, ms500, ms1000, ms2000, ms5000,
+										ms10000, ms20000, ms50000}		OPTIONAL,	-- Need ON
+				statusPDU-Periodicity-Type2-r13		ENUMERATED {
+										ms5, ms10, ms20, ms30, ms40, ms50, ms60, ms70, ms80, ms90,
+										ms100, ms150, ms200, ms300, ms500, ms1000, ms2000, ms5000,
+										ms10000, ms20000, ms50000}		OPTIONAL,	-- Need ON
+				statusPDU-Periodicity-Offset-r13	ENUMERATED {
+										ms1, ms2, ms5, ms10, ms25, ms50, ms100, ms250, ms500,
+										ms2500, ms5000, ms25000}	OPTIONAL	-- Need ON
+			}
+		}																OPTIONAL	-- Need ON
+	]],
+	[[	ul-LWA-Config-r14			CHOICE {
+			release						NULL,
+			setup						SEQUENCE {
+				ul-LWA-DRB-ViaWLAN-r14		BOOLEAN,
+				ul-LWA-DataSplitThreshold-r14	ENUMERATED {
+										b0, b100, b200, b400, b800, b1600, b3200, b6400,
+										b12800, b25600, b51200, b102400, b204800, b409600,
+										b819200 }			OPTIONAL	-- Need OR
+			}
+		}														OPTIONAL,		-- Need ON
+		uplinkOnlyHeaderCompression-r14		CHOICE {
+			notUsed-r14							NULL,
+			rohc-r14								SEQUENCE {
+				maxCID-r14								INTEGER (1..16383)		DEFAULT 15,
+				profiles-r14							SEQUENCE {
+					profile0x0006-r14						BOOLEAN
+				},
+				...
+			}
+		}													OPTIONAL -- Need ON
+	]],
+	[[	uplinkDataCompression-r15	SEQUENCE {
+			bufferSize-r15				ENUMERATED {kbyte2, kbyte4, kbyte8, spare1},
+			dictionary-r15				ENUMERATED {sip-SDP, operator}	OPTIONAL, -- Need OR
+			...
+		}															OPTIONAL,-- Cond Rlc-AM4
+		pdcp-DuplicationConfig-r15	CHOICE {
+			release						NULL,
+			setup						SEQUENCE {
+				pdcp-Duplication-r15		ENUMERATED {configured, activated}
+			}
+		}													OPTIONAL -- Need ON
+	]],
+	[[
+	ethernetHeaderCompression-r16	SetupRelease {EthernetHeaderCompression-r16}	OPTIONAL -- Need ON
+	]]
+}
+
+EthernetHeaderCompression-r16	::=	SEQUENCE {
+	ehc-Common-r16		SEQUENCE {
+		ehc-CID-Length-r16		ENUMERATED {bits7, bits15}
+	},
+	ehc-Downlink-r16	SEQUENCE {
+		drb-ContinueEHC-DL-r16		ENUMERATED {true}		OPTIONAL -- Need OR
+	}	OPTIONAL,-- Need ON
+	ehc-Uplink-r16		SEQUENCE {
+		maxCID-EHC-UL-r16				INTEGER (1..32767),
+		drb-ContinueEHC-UL-r16		ENUMERATED {true}		OPTIONAL -- Need OR
+	}	OPTIONAL,   -- Need ON
+	...
+}
+
+
+
+PDSCH-ConfigCommon ::=		SEQUENCE {
+	referenceSignalPower				INTEGER (-60..50),
+	p-b									INTEGER (0..3)
+}
+
+PDSCH-ConfigCommon-v1310 ::=	SEQUENCE {
+	pdsch-maxNumRepetitionCEmodeA-r13	ENUMERATED {
+											r16, r32 }					OPTIONAL,	-- Need OR
+	pdsch-maxNumRepetitionCEmodeB-r13	ENUMERATED {
+											r192, r256, r384, r512, r768, r1024,
+											r1536, r2048}					OPTIONAL	-- Need OR
+}
+
+PDSCH-ConfigDedicated::=		SEQUENCE {
+	p-a									ENUMERATED {
+											dB-6, dB-4dot77, dB-3, dB-1dot77,
+											dB0, dB1, dB2, dB3}
+}
+
+PDSCH-ConfigDedicated-v1130 ::=		SEQUENCE {
+	dmrs-ConfigPDSCH-r11				DMRS-Config-r11					OPTIONAL,	-- Need ON
+	qcl-Operation						ENUMERATED {typeA, typeB}			OPTIONAL,	-- Need OR
+	re-MappingQCLConfigToReleaseList-r11	RE-MappingQCLConfigToReleaseList-r11	OPTIONAL,	-- Need ON
+	re-MappingQCLConfigToAddModList-r11		RE-MappingQCLConfigToAddModList-r11		OPTIONAL	-- Need ON
+}
+
+PDSCH-ConfigDedicated-v1280 ::=		SEQUENCE {
+	tbsIndexAlt-r12						ENUMERATED {a26, a33}				OPTIONAL	-- Need OR
+}
+
+PDSCH-ConfigDedicated-v1310 ::=		SEQUENCE {
+	dmrs-ConfigPDSCH-v1310				DMRS-Config-v1310					OPTIONAL	-- Need ON
+}
+
+PDSCH-ConfigDedicated-v1430 ::=		SEQUENCE {
+	ce-PDSCH-MaxBandwidth-r14			ENUMERATED {bw5, bw20}				OPTIONAL,	-- Need OP
+	ce-PDSCH-TenProcesses-r14			ENUMERATED {on}						OPTIONAL,	-- Need OR
+	ce-HARQ-AckBundling-r14				ENUMERATED {on}						OPTIONAL,	-- Need OR
+	ce-SchedulingEnhancement-r14		ENUMERATED {range1, range2}			OPTIONAL,	-- Need OR
+	tbsIndexAlt2-r14						ENUMERATED {b33}				OPTIONAL	-- Need OR
+}
+
+PDSCH-ConfigDedicated-v1530 ::=		SEQUENCE {
+	qcl-Operation-v1530						ENUMERATED {typeC}				OPTIONAL,	-- Need OR
+	tbs-IndexAlt3-r15							ENUMERATED {a37}			OPTIONAL,	-- Need OR
+	-- eNote (ToDo): Clarify that eMTC fields (i.e. fields starting with ce-) do not apply
+	-- for SCell (merging issue)
+	ce-CQI-AlternativeTableConfig-r15			ENUMERATED {on}				OPTIONAL,	-- Need OR
+	ce-PDSCH-64QAM-Config-r15					ENUMERATED {on}				OPTIONAL,	-- Need OR
+	ce-PDSCH-FlexibleStartPRB-AllocConfig-r15	ENUMERATED {on}				OPTIONAL,	-- Need OR
+	altMCS-TableScalingConfig-r15		ENUMERATED {oDot5, oDot625, oDot75, oDot875}	OPTIONAL	-- Need OR
+}
+
+PDSCH-ConfigDedicated-v1610 ::=		SEQUENCE {
+	ce-PDSCH-MultiTB-Config-r16		SetupRelease {CE-PDSCH-MultiTB-Config-r16}
+}
+
+PDSCH-ConfigDedicatedSCell-v1430 ::=		SEQUENCE {
+	tbsIndexAlt2-r14						ENUMERATED {b33}				OPTIONAL	-- Need OR
+}
+
+CE-PDSCH-MultiTB-Config-r16 ::= SEQUENCE {
+	interleaving-r16						ENUMERATED {on}		OPTIONAL,		-- Need OR
+	harq-AckBundling-r16					ENUMERATED {on}		OPTIONAL		-- Need OR
+}
+
+RE-MappingQCLConfigToAddModList-r11 ::=		SEQUENCE (SIZE (1..maxRE-MapQCL-r11)) OF PDSCH-RE-MappingQCL-Config-r11
+
+RE-MappingQCLConfigToReleaseList-r11 ::=	SEQUENCE (SIZE (1..maxRE-MapQCL-r11)) OF PDSCH-RE-MappingQCL-ConfigId-r11
+
+PDSCH-RE-MappingQCL-Config-r11 ::=		SEQUENCE {
+	pdsch-RE-MappingQCL-ConfigId-r11	PDSCH-RE-MappingQCL-ConfigId-r11,
+	optionalSetOfFields-r11				SEQUENCE {
+		crs-PortsCount-r11					ENUMERATED {n1, n2, n4, spare1},
+		crs-FreqShift-r11					INTEGER (0..5),
+		mbsfn-SubframeConfigList-r11		CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				subframeConfigList					MBSFN-SubframeConfigList
+			}
+		}																	OPTIONAL,	-- Need ON
+		pdsch-Start-r11						ENUMERATED {reserved, n1, n2, n3, n4, assigned}
+	}																		OPTIONAL,	-- Need OP
+	csi-RS-ConfigZPId-r11				CSI-RS-ConfigZPId-r11,
+	qcl-CSI-RS-ConfigNZPId-r11			CSI-RS-ConfigNZPId-r11				OPTIONAL,	-- Need OR
+	...,
+	[[	mbsfn-SubframeConfigList-v1430	CHOICE {
+			release						NULL,
+			setup						SEQUENCE {
+				subframeConfigList-v1430	MBSFN-SubframeConfigList-v1430
+			}
+		}																	OPTIONAL	-- Need OP
+	]],
+	[[	codewordOneConfig-v1530				CHOICE {
+			release						NULL,
+			setup						SEQUENCE {
+				crs-PortsCount-v1530					ENUMERATED {n1, n2, n4, spare1},
+				crs-FreqShift-v1530						INTEGER (0..5),
+				mbsfn-SubframeConfigList-v1530			MBSFN-SubframeConfigList	OPTIONAL,
+				mbsfn-SubframeConfigListExt-v1530		MBSFN-SubframeConfigList-v1430 OPTIONAL,
+				pdsch-Start-v1530						ENUMERATED {reserved, n1, n2, n3, n4, assigned},
+				csi-RS-ConfigZPId-v1530					CSI-RS-ConfigZPId-r11,
+				qcl-CSI-RS-ConfigNZPId-v1530			CSI-RS-ConfigNZPId-r11	OPTIONAL
+			}
+		}																OPTIONAL	-- Cond TypeC
+	]]
+}
+
+
+
+PDSCH-RE-MappingQCL-ConfigId-r11 ::=		INTEGER (1..maxRE-MapQCL-r11)
+
+
+PerCC-GapIndicationList-r14 ::=	SEQUENCE (SIZE (1..maxServCell-r13)) OF PerCC-GapIndication-r14
+
+PerCC-GapIndication-r14 ::=			SEQUENCE {
+	servCellId-r14								ServCellIndex-r13,		
+	gapIndication-r14							ENUMERATED {gap, ncsg, nogap-noNcsg}
+}
+
+
+
+PHICH-Config ::=					SEQUENCE {
+	phich-Duration						ENUMERATED {normal, extended},
+	phich-Resource						ENUMERATED {oneSixth, half, one, two}
+}
+
+
+
+PhysicalConfigDedicated ::=		SEQUENCE {
+	pdsch-ConfigDedicated				PDSCH-ConfigDedicated			OPTIONAL,		-- Need ON
+	pucch-ConfigDedicated				PUCCH-ConfigDedicated			OPTIONAL,		-- Need ON
+	pusch-ConfigDedicated				PUSCH-ConfigDedicated			OPTIONAL,		-- Need ON
+	uplinkPowerControlDedicated			UplinkPowerControlDedicated		OPTIONAL,		-- Need ON
+	tpc-PDCCH-ConfigPUCCH				TPC-PDCCH-Config				OPTIONAL,		-- Need ON
+	tpc-PDCCH-ConfigPUSCH				TPC-PDCCH-Config				OPTIONAL,		-- Need ON
+	cqi-ReportConfig					CQI-ReportConfig				OPTIONAL,		-- Cond CQI-r8
+	soundingRS-UL-ConfigDedicated		SoundingRS-UL-ConfigDedicated	OPTIONAL,		-- Need ON
+	antennaInfo							CHOICE {
+		explicitValue						AntennaInfoDedicated,
+		defaultValue						NULL
+	}																	OPTIONAL,	-- Cond AI-r8
+	schedulingRequestConfig				SchedulingRequestConfig			OPTIONAL,		-- Need ON
+	...,
+	[[	cqi-ReportConfig-v920				CQI-ReportConfig-v920		OPTIONAL,		-- Cond CQI-r8
+		antennaInfo-v920					AntennaInfoDedicated-v920	OPTIONAL		-- Cond AI-r8
+	]],
+	[[	antennaInfo-r10					CHOICE {
+			explicitValue-r10				AntennaInfoDedicated-r10,
+			defaultValue					NULL
+		}																OPTIONAL,	-- Cond AI-r10
+		antennaInfoUL-r10				AntennaInfoUL-r10				OPTIONAL,		-- Need ON
+		cif-Presence-r10				BOOLEAN							OPTIONAL,		-- Need ON
+		cqi-ReportConfig-r10			CQI-ReportConfig-r10			OPTIONAL,	-- Cond CQI-r10
+		csi-RS-Config-r10				CSI-RS-Config-r10				OPTIONAL,		-- Need ON
+		pucch-ConfigDedicated-v1020		PUCCH-ConfigDedicated-v1020		OPTIONAL,		-- Need ON
+		pusch-ConfigDedicated-v1020		PUSCH-ConfigDedicated-v1020		OPTIONAL,		-- Need ON
+		schedulingRequestConfig-v1020	SchedulingRequestConfig-v1020	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicated-v1020
+								SoundingRS-UL-ConfigDedicated-v1020		OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedAperiodic-r10
+							SoundingRS-UL-ConfigDedicatedAperiodic-r10	OPTIONAL,		-- Need ON
+		uplinkPowerControlDedicated-v1020	
+									UplinkPowerControlDedicated-v1020	OPTIONAL		-- Need ON
+	]],
+	[[	additionalSpectrumEmissionCA-r10			CHOICE {
+			release									NULL,
+			setup									SEQUENCE {
+				additionalSpectrumEmissionPCell-r10		AdditionalSpectrumEmission
+			}
+		}			OPTIONAL	-- Need ON
+	]],
+	[[	-- DL configuration as well as configuration applicable for DL and UL
+		csi-RS-ConfigNZPToReleaseList-r11
+									CSI-RS-ConfigNZPToReleaseList-r11	OPTIONAL,		-- Need ON
+		csi-RS-ConfigNZPToAddModList-r11
+									CSI-RS-ConfigNZPToAddModList-r11	OPTIONAL,		-- Need ON
+		csi-RS-ConfigZPToReleaseList-r11	
+									CSI-RS-ConfigZPToReleaseList-r11	OPTIONAL,		-- Need ON
+		csi-RS-ConfigZPToAddModList-r11	CSI-RS-ConfigZPToAddModList-r11	OPTIONAL,		-- Need ON
+		epdcch-Config-r11				EPDCCH-Config-r11				OPTIONAL,		-- Need ON
+		pdsch-ConfigDedicated-v1130		PDSCH-ConfigDedicated-v1130		OPTIONAL,		-- Need ON
+	-- UL configuration
+		cqi-ReportConfig-v1130			CQI-ReportConfig-v1130			OPTIONAL,		-- Need ON
+		pucch-ConfigDedicated-v1130		PUCCH-ConfigDedicated-v1130		OPTIONAL,		-- Need ON
+		pusch-ConfigDedicated-v1130		PUSCH-ConfigDedicated-v1130		OPTIONAL,		-- Need ON
+		uplinkPowerControlDedicated-v1130
+									UplinkPowerControlDedicated-v1130	OPTIONAL		-- Need ON
+	]],
+	[[	antennaInfo-v1250				AntennaInfoDedicated-v1250		OPTIONAL,	-- Cond AI-r10
+		eimta-MainConfig-r12			EIMTA-MainConfig-r12			OPTIONAL,		-- Need ON
+		eimta-MainConfigPCell-r12		EIMTA-MainConfigServCell-r12	OPTIONAL,		-- Need ON
+		pucch-ConfigDedicated-v1250		PUCCH-ConfigDedicated-v1250		OPTIONAL,		-- Need ON
+		cqi-ReportConfigPCell-v1250		CQI-ReportConfig-v1250			OPTIONAL,		-- Need ON
+		uplinkPowerControlDedicated-v1250
+									UplinkPowerControlDedicated-v1250	OPTIONAL,		-- Need ON
+		pusch-ConfigDedicated-v1250		PUSCH-ConfigDedicated-v1250		OPTIONAL,		-- Need ON
+		csi-RS-Config-v1250					CSI-RS-Config-v1250			OPTIONAL		-- Need ON
+	]],
+	[[	pdsch-ConfigDedicated-v1280			PDSCH-ConfigDedicated-v1280	OPTIONAL		-- Need ON
+	]],
+	[[	pdsch-ConfigDedicated-v1310			PDSCH-ConfigDedicated-v1310	OPTIONAL,		-- Need ON
+		pucch-ConfigDedicated-r13			PUCCH-ConfigDedicated-r13	OPTIONAL,		-- Need ON
+		pusch-ConfigDedicated-r13			PUSCH-ConfigDedicated-r13	OPTIONAL,		-- Need ON
+		pdcch-CandidateReductions-r13
+										PDCCH-CandidateReductions-r13	OPTIONAL,		-- Need ON
+		cqi-ReportConfig-v1310					CQI-ReportConfig-v1310	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicated-v1310
+								SoundingRS-UL-ConfigDedicated-v1310		OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedUpPTsExt-r13
+						SoundingRS-UL-ConfigDedicatedUpPTsExt-r13		OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedAperiodic-v1310
+						SoundingRS-UL-ConfigDedicatedAperiodic-v1310	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r13
+				SoundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r13		OPTIONAL,		-- Need ON
+		csi-RS-Config-v1310				CSI-RS-Config-v1310				OPTIONAL,		-- Need ON
+		ce-Mode-r13					CHOICE {
+			release						NULL,
+			setup						ENUMERATED {ce-ModeA,ce-ModeB}
+		}																OPTIONAL,		-- Need ON
+		csi-RS-ConfigNZPToAddModListExt-r13	CSI-RS-ConfigNZPToAddModListExt-r13	OPTIONAL,	-- Need ON
+		csi-RS-ConfigNZPToReleaseListExt-r13	CSI-RS-ConfigNZPToReleaseListExt-r13	OPTIONAL	-- Need ON
+	]],
+	[[	cqi-ReportConfig-v1320					CQI-ReportConfig-v1320	OPTIONAL		-- Need ON
+	]],
+	[[	typeA-SRS-TPC-PDCCH-Group-r14	CHOICE {
+			release							NULL,
+			setup							SEQUENCE (SIZE (1..32)) OF SRS-TPC-PDCCH-Config-r14
+		}																OPTIONAL,		-- Need ON
+		must-Config-r14						CHOICE{
+			release								NULL,
+			setup								SEQUENCE {
+				k-max-r14						ENUMERATED {l1, l3},
+				p-a-must-r14					ENUMERATED {
+													dB-6, dB-4dot77, dB-3, dB-1dot77,
+													dB0, dB1, dB2, dB3}	OPTIONAL		-- Need ON
+			}
+		}															OPTIONAL,		-- Need ON
+		pusch-EnhancementsConfig-r14		PUSCH-EnhancementsConfig-r14		OPTIONAL,	-- Need ON
+		ce-pdsch-pusch-EnhancementConfig-r14		ENUMERATED {on}	OPTIONAL,	-- Need OR
+		antennaInfo-v1430				AntennaInfoDedicated-v1430		OPTIONAL,	-- Need ON
+		pucch-ConfigDedicated-v1430		PUCCH-ConfigDedicated-v1430		OPTIONAL,	-- Need ON
+		pdsch-ConfigDedicated-v1430		PDSCH-ConfigDedicated-v1430		OPTIONAL,		-- Need ON
+		pusch-ConfigDedicated-v1430		PUSCH-ConfigDedicated-v1430	OPTIONAL,		-- Need ON
+		soundingRS-UL-PeriodicConfigDedicatedList-r14			SEQUENCE (SIZE (1..2)) OF SoundingRS-UL-ConfigDedicated	OPTIONAL,		-- Cond PeriodicSRSPCell
+		soundingRS-UL-PeriodicConfigDedicatedUpPTsExtList-r14	SEQUENCE (SIZE (1..4)) OF SoundingRS-UL-ConfigDedicatedUpPTsExt-r13	OPTIONAL,		-- Cond PeriodicSRSExt		
+		soundingRS-UL-AperiodicConfigDedicatedList-r14			SEQUENCE (SIZE (1..2)) OF SoundingRS-UL-ConfigDedicatedAperiodic-r10	OPTIONAL,		-- Cond AperiodicSRS
+		soundingRS-UL-ConfigDedicatedApUpPTsExtList-r14	SEQUENCE (SIZE (1..4)) OF SoundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r13	OPTIONAL,		-- Cond AperiodicSRSExt
+		csi-RS-Config-v1430				CSI-RS-Config-v1430				OPTIONAL,		-- Need ON
+		csi-RS-ConfigZP-ApList-r14				CSI-RS-ConfigZP-ApList-r14	OPTIONAL,	-- Need ON
+		cqi-ReportConfig-v1430					CQI-ReportConfig-v1430	OPTIONAL,	-- Need ON
+		semiOpenLoop-r14						BOOLEAN					OPTIONAL	-- Need ON
+	]],
+	[[	csi-RS-Config-v1480					CSI-RS-Config-v1480			OPTIONAL		-- Need ON
+	]],
+	[[	physicalConfigDedicatedSTTI-r15		PhysicalConfigDedicatedSTTI-r15	OPTIONAL,-- Need ON
+		pdsch-ConfigDedicated-v1530			PDSCH-ConfigDedicated-v1530		OPTIONAL,-- Need ON
+		pusch-ConfigDedicated-v1530			PUSCH-ConfigDedicated-v1530		OPTIONAL,-- Need ON
+		cqi-ReportConfig-v1530				CQI-ReportConfig-v1530			OPTIONAL,-- Need ON
+		antennaInfo-v1530					AntennaInfoDedicated-v1530		OPTIONAL,-- Need ON
+		csi-RS-Config-v1530					CSI-RS-Config-v1530				OPTIONAL,-- Need ON
+		uplinkPowerControlDedicated-v1530
+									UplinkPowerControlDedicated-v1530	OPTIONAL,		-- Need ON
+		semiStaticCFI-Config-r15		CHOICE{
+			release							NULL,
+			setup							CHOICE{
+				cfi-Config-r15					CFI-Config-r15,
+				cfi-PatternConfig-r15			CFI-PatternConfig-r15
+			}
+		}														OPTIONAL,	 -- Need ON
+		blindPDSCH-Repetition-Config-r15	CHOICE{
+			release							NULL,
+			setup							SEQUENCE {
+				blindSubframePDSCH-Repetitions-r15		BOOLEAN,
+				blindSlotSubslotPDSCH-Repetitions-r15	BOOLEAN,
+				maxNumber-SubframePDSCH-Repetitions-r15	ENUMERATED {n4,n6}	OPTIONAL,	-- Need ON
+				maxNumber-SlotSubslotPDSCH-Repetitions-r15	ENUMERATED {n4,n6}		OPTIONAL, -- Need ON
+				rv-SubframePDSCH-Repetitions-r15	ENUMERATED {dlrvseq1, dlrvseq2}	OPTIONAL, -- Need ON
+				rv-SlotsublotPDSCH-Repetitions-r15	ENUMERATED {dlrvseq1, dlrvseq2}	OPTIONAL, -- Need ON
+				numberOfProcesses-SubframePDSCH-Repetitions-r15	INTEGER(1..16)	OPTIONAL, -- Need ON
+				numberOfProcesses-SlotSubslotPDSCH-Repetitions-r15	INTEGER(1..16)	OPTIONAL, -- Need ON
+				mcs-restrictionSubframePDSCH-Repetitions-r15	ENUMERATED {n0, n1}	OPTIONAL, -- Need ON
+				mcs-restrictionSlotSubslotPDSCH-Repetitions-r15	ENUMERATED {n0, n1}	OPTIONAL -- Need ON
+			}
+		}														OPTIONAL	 -- Need ON
+	]],
+	[[	spucch-Config-v1550				SPUCCH-Config-v1550			OPTIONAL -- Need ON
+	]],
+	[[	pdsch-ConfigDedicated-v1610		PDSCH-ConfigDedicated-v1610		OPTIONAL, -- Need ON
+		pusch-ConfigDedicated-v1610		PUSCH-ConfigDedicated-v1610		OPTIONAL, -- Need ON
+		ce-CSI-RS-Feedback-r16			ENUMERATED {enabled}			OPTIONAL,  -- Need OR
+		resourceReservationConfigDedicatedDL-r16	SetupRelease {ResourceReservationConfigDedicatedDL-r16}		OPTIONAL,  -- Need ON
+		resourceReservationConfigDedicatedUL-r16	SetupRelease {ResourceReservationConfigDedicatedUL-r16}		OPTIONAL,  -- Need ON
+		soundingRS-UL-ConfigDedicatedAdd-r16		SetupRelease {SoundingRS-UL-ConfigDedicatedAdd-r16}
+																		OPTIONAL, --  Need ON
+		uplinkPowerControlAddSRS-r16	SetupRelease {UplinkPowerControlAddSRS-r16}	OPTIONAL,  -- Need ON
+		soundingRS-VirtualCellID-r16		SetupRelease {SoundingRS-VirtualCellID-r16}	OPTIONAL,  -- Need ON
+		widebandPRG-r16					SetupRelease {WidebandPRG-r16}				OPTIONAL   -- Need ON
+	]]
+}
+
+PhysicalConfigDedicated-v1370 ::=	SEQUENCE {
+	pucch-ConfigDedicated-v1370			PUCCH-ConfigDedicated-v1370		OPTIONAL		-- Cond PUCCH-Format4or5
+}
+
+PhysicalConfigDedicated-v13c0 ::=	SEQUENCE {
+	pucch-ConfigDedicated-v13c0			PUCCH-ConfigDedicated-v13c0	
+}
+
+PhysicalConfigDedicatedSCell-r10 ::=		SEQUENCE {
+	-- DL configuration as well as configuration applicable for DL and UL
+	nonUL-Configuration-r10					SEQUENCE {
+		antennaInfo-r10
+											AntennaInfoDedicated-r10	OPTIONAL,		-- Need ON
+		crossCarrierSchedulingConfig-r10
+									CrossCarrierSchedulingConfig-r10	OPTIONAL,		-- Need ON
+		csi-RS-Config-r10						CSI-RS-Config-r10		OPTIONAL,		-- Need ON
+		pdsch-ConfigDedicated-r10				PDSCH-ConfigDedicated	OPTIONAL		-- Need ON
+	}																	OPTIONAL,	-- Cond SCellAdd
+	-- UL configuration
+	ul-Configuration-r10					SEQUENCE {
+		antennaInfoUL-r10						AntennaInfoUL-r10		OPTIONAL,		-- Need ON
+		pusch-ConfigDedicatedSCell-r10
+								PUSCH-ConfigDedicatedSCell-r10		OPTIONAL,	-- Cond PUSCH-SCell1
+		uplinkPowerControlDedicatedSCell-r10
+								UplinkPowerControlDedicatedSCell-r10	OPTIONAL,		-- Need ON
+		cqi-ReportConfigSCell-r10			CQI-ReportConfigSCell-r10	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicated-r10
+										SoundingRS-UL-ConfigDedicated	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicated-v1020
+									SoundingRS-UL-ConfigDedicated-v1020	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedAperiodic-r10
+							SoundingRS-UL-ConfigDedicatedAperiodic-r10	OPTIONAL	-- Need ON
+	}																	OPTIONAL,	-- Cond CommonUL
+	...,
+	[[	-- DL configuration as well as configuration applicable for DL and UL
+		csi-RS-ConfigNZPToReleaseList-r11
+									CSI-RS-ConfigNZPToReleaseList-r11	OPTIONAL,		-- Need ON
+		csi-RS-ConfigNZPToAddModList-r11	
+									CSI-RS-ConfigNZPToAddModList-r11	OPTIONAL,		-- Need ON
+		csi-RS-ConfigZPToReleaseList-r11
+									CSI-RS-ConfigZPToReleaseList-r11	OPTIONAL,		-- Need ON
+		csi-RS-ConfigZPToAddModList-r11
+										CSI-RS-ConfigZPToAddModList-r11	OPTIONAL,		-- Need ON
+		epdcch-Config-r11					EPDCCH-Config-r11			OPTIONAL,		-- Need ON
+		pdsch-ConfigDedicated-v1130			PDSCH-ConfigDedicated-v1130	OPTIONAL,		-- Need ON
+	-- UL configuration
+		cqi-ReportConfig-v1130				CQI-ReportConfig-v1130		OPTIONAL,		-- Need ON
+		pusch-ConfigDedicated-v1130
+									PUSCH-ConfigDedicated-v1130		OPTIONAL,	-- Cond PUSCH-SCell1
+		uplinkPowerControlDedicatedSCell-v1130
+									UplinkPowerControlDedicated-v1130	OPTIONAL		-- Need ON
+	]],
+	[[	antennaInfo-v1250					AntennaInfoDedicated-v1250	OPTIONAL,		-- Need ON
+		eimta-MainConfigSCell-r12
+										EIMTA-MainConfigServCell-r12	OPTIONAL,		-- Need ON
+		cqi-ReportConfigSCell-v1250			CQI-ReportConfig-v1250		OPTIONAL,		-- Need ON
+		uplinkPowerControlDedicatedSCell-v1250
+									UplinkPowerControlDedicated-v1250	OPTIONAL,		-- Need ON
+		csi-RS-Config-v1250					CSI-RS-Config-v1250			OPTIONAL		-- Need ON
+	]],
+	[[	pdsch-ConfigDedicated-v1280			PDSCH-ConfigDedicated-v1280	OPTIONAL		-- Need ON
+	]],
+	[[	pucch-Cell-r13						ENUMERATED {true}		OPTIONAL,	-- Cond PUCCH-SCell1
+		pucch-SCell							CHOICE{
+			release								NULL,
+			setup								SEQUENCE {
+				pucch-ConfigDedicated-r13
+											PUCCH-ConfigDedicated-r13	OPTIONAL,		-- Need ON
+				schedulingRequestConfig-r13			
+									SchedulingRequestConfigSCell-r13	OPTIONAL,		-- Need ON
+				tpc-PDCCH-ConfigPUCCH-SCell-r13		
+											TPC-PDCCH-ConfigSCell-r13	OPTIONAL,		-- Need ON
+				pusch-ConfigDedicated-r13		
+										PUSCH-ConfigDedicated-r13	OPTIONAL,	-- Cond PUSCH-SCell
+				uplinkPowerControlDedicated-r13		
+								UplinkPowerControlDedicatedSCell-v1310	OPTIONAL	-- Need ON
+			}
+		}																OPTIONAL,	-- Need ON
+		crossCarrierSchedulingConfig-r13
+						CrossCarrierSchedulingConfig-r13	OPTIONAL,	-- Cond Cross-Carrier-Config
+		pdcch-ConfigSCell-r13				PDCCH-ConfigSCell-r13		OPTIONAL,		-- Need ON
+		cqi-ReportConfig-v1310				CQI-ReportConfig-v1310		OPTIONAL,		-- Need ON
+		pdsch-ConfigDedicated-v1310			PDSCH-ConfigDedicated-v1310	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicated-v1310
+								SoundingRS-UL-ConfigDedicated-v1310		OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedUpPTsExt-r13
+							SoundingRS-UL-ConfigDedicatedUpPTsExt-r13	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedAperiodic-v1310
+						SoundingRS-UL-ConfigDedicatedAperiodic-v1310	OPTIONAL,		-- Need ON
+		soundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r13
+					SoundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r13	OPTIONAL,		-- Need ON
+		csi-RS-Config-v1310					CSI-RS-Config-v1310			OPTIONAL,		-- Need ON
+		laa-SCellConfiguration-r13			LAA-SCellConfiguration-r13	OPTIONAL,		-- Need ON
+		csi-RS-ConfigNZPToAddModListExt-r13	CSI-RS-ConfigNZPToAddModListExt-r13	OPTIONAL,	-- Need ON
+		csi-RS-ConfigNZPToReleaseListExt-r13	CSI-RS-ConfigNZPToReleaseListExt-r13	OPTIONAL	-- Need ON
+	]],
+	[[	cqi-ReportConfig-v1320				CQI-ReportConfig-v1320	OPTIONAL		-- Need ON
+	]],
+	[[	laa-SCellConfiguration-v1430		LAA-SCellConfiguration-v1430
+																		OPTIONAL,	-- Need ON
+		typeB-SRS-TPC-PDCCH-Config-r14		SRS-TPC-PDCCH-Config-r14	OPTIONAL,	-- Need ON
+
+		uplinkPUSCH-LessPowerControlDedicated-v1430		UplinkPUSCH-LessPowerControlDedicated-v1430 OPTIONAL,		-- Need ON
+		soundingRS-UL-PeriodicConfigDedicatedList-r14					SEQUENCE (SIZE (1..2)) OF SoundingRS-UL-ConfigDedicated						OPTIONAL,		-- Cond PeriodicSRS
+		soundingRS-UL-PeriodicConfigDedicatedUpPTsExtList-r14					SEQUENCE (SIZE (1..4)) OF SoundingRS-UL-ConfigDedicatedUpPTsExt-r13						OPTIONAL,		-- Cond PeriodicSRSExt		
+		soundingRS-UL-AperiodicConfigDedicatedList-r14					SEQUENCE (SIZE (1..2)) OF SoundingRS-AperiodicSet-r14						OPTIONAL,		-- Cond AperiodicSRS
+		soundingRS-UL-ConfigDedicatedApUpPTsExtList-r14					SEQUENCE (SIZE (1..4)) OF SoundingRS-AperiodicSetUpPTsExt-r14			OPTIONAL,		-- Cond AperiodicSRSExt
+		must-Config-r14						CHOICE{
+			release								NULL,
+			setup								SEQUENCE {
+				k-max-r14						ENUMERATED {l1, l3},
+				p-a-must-r14					ENUMERATED {
+													dB-6, dB-4dot77, dB-3, dB-1dot77,
+													dB0, dB1, dB2, dB3}	OPTIONAL		-- Need ON
+			}
+		}															OPTIONAL,		-- Need ON
+		pusch-ConfigDedicated-v1430			PUSCH-ConfigDedicatedSCell-v1430	OPTIONAL,	-- Need ON
+		csi-RS-Config-v1430						CSI-RS-Config-v1430			OPTIONAL,	-- Need ON
+		csi-RS-ConfigZP-ApList-r14				CSI-RS-ConfigZP-ApList-r14		OPTIONAL,	-- Need ON
+		cqi-ReportConfig-v1430					CQI-ReportConfig-v1430	OPTIONAL,	-- Need ON
+		semiOpenLoop-r14						BOOLEAN						OPTIONAL,	-- Need ON
+		pdsch-ConfigDedicatedSCell-v1430		PDSCH-ConfigDedicatedSCell-v1430		OPTIONAL		-- Need ON
+	]],
+	[[	csi-RS-Config-v1480					CSI-RS-Config-v1480				OPTIONAL	-- Need ON
+	]],
+	[[	physicalConfigDedicatedSTTI-r15		PhysicalConfigDedicatedSTTI-r15	OPTIONAL,	-- Need ON
+		pdsch-ConfigDedicated-v1530			PDSCH-ConfigDedicated-v1530		OPTIONAL,	-- Need ON
+		dummy								CQI-ReportConfig-v1530			OPTIONAL,	-- Need ON
+		cqi-ReportConfigSCell-r15			CQI-ReportConfigSCell-r15		OPTIONAL,	-- Need ON
+		cqi-ShortConfigSCell-r15			CQI-ShortConfigSCell-r15		OPTIONAL,	-- Need ON
+		csi-RS-Config-v1530					CSI-RS-Config-v1530				OPTIONAL,	-- Need ON
+	uplinkPowerControlDedicatedSCell-v1530
+									UplinkPowerControlDedicated-v1530	OPTIONAL,		-- Need ON
+		laa-SCellConfiguration-v1530		LAA-SCellConfiguration-v1530	OPTIONAL,	-- Need ON
+		pusch-ConfigDedicated-v1530			PUSCH-ConfigDedicatedScell-v1530	OPTIONAL,	-- Cond AUL
+		semiStaticCFI-Config-r15		CHOICE{
+			release							NULL,
+			setup							CHOICE{
+				cfi-Config-r15					CFI-Config-r15,
+				cfi-PatternConfig-r15			CFI-PatternConfig-r15
+			}
+		}														OPTIONAL,	 -- Need ON
+		blindPDSCH-Repetition-Config-r15	CHOICE{
+			release							NULL,
+			setup							SEQUENCE {
+				blindSubframePDSCH-Repetitions-r15		BOOLEAN,
+				blindSlotSubslotPDSCH-Repetitions-r15	BOOLEAN,
+				maxNumber-SubframePDSCH-Repetitions-r15	ENUMERATED {n4,n6}	OPTIONAL,	-- Need ON
+				maxNumber-SlotSubslotPDSCH-Repetitions-r15	ENUMERATED {n4,n6}		OPTIONAL, -- Need ON
+				rv-SubframePDSCH-Repetitions-r15	ENUMERATED {dlrvseq1, dlrvseq2}	OPTIONAL, -- Need ON
+				rv-SlotsublotPDSCH-Repetitions-r15	ENUMERATED {dlrvseq1, dlrvseq2}	OPTIONAL, -- Need ON
+				numberOfProcesses-SubframePDSCH-Repetitions-r15	INTEGER(1..16)	OPTIONAL, -- Need ON
+				numberOfProcesses-SlotSubslotPDSCH-Repetitions-r15	INTEGER(1..16)	OPTIONAL, -- Need ON
+				mcs-restrictionSubframePDSCH-Repetitions-r15	ENUMERATED {n0, n1}	OPTIONAL, -- Need ON
+				mcs-restrictionSlotSubslotPDSCH-Repetitions-r15	ENUMERATED {n0, n1}	OPTIONAL -- Need ON
+			}
+		}														OPTIONAL	 -- Need ON
+	]],
+	[[	spucch-Config-v1550				SPUCCH-Config-v1550			OPTIONAL -- Need ON
+	]],
+	[[	soundingRS-UL-ConfigDedicatedAdd-r16		SetupRelease {SoundingRS-UL-ConfigDedicatedAdd-r16}
+																OPTIONAL, -- Need ON
+		uplinkPowerControlAddSRS-r16				SetupRelease {UplinkPowerControlAddSRS-r16}
+																OPTIONAL, -- Need ON
+		soundingRS-VirtualCellID-r16				SetupRelease {SoundingRS-VirtualCellID-r16}
+																OPTIONAL,  -- Need ON
+		widebandPRG-r16							SetupRelease {WidebandPRG-r16}		OPTIONAL -- Need ON
+	]]
+}
+
+PhysicalConfigDedicatedSCell-v1370 ::=	SEQUENCE {
+	pucch-SCell-v1370				CHOICE{
+		release							NULL,
+		setup							SEQUENCE {
+			pucch-ConfigDedicated-v1370		PUCCH-ConfigDedicated-v1370		OPTIONAL	-- Cond PUCCH-Format4or5
+		}
+	}
+}
+
+PhysicalConfigDedicatedSCell-v13c0 ::=	SEQUENCE {
+	pucch-SCell-v13c0				CHOICE{
+		release							NULL,
+		setup							SEQUENCE {
+			pucch-ConfigDedicated-v13c0		PUCCH-ConfigDedicated-v13c0
+		}
+	}
+}
+
+CFI-Config-r15	::= SEQUENCE {
+	cfi-SubframeNonMBSFN-r15		INTEGER (1..4)						OPTIONAL,	 -- Need ON
+	cfi-SlotSubslotNonMBSFN-r15		INTEGER (1..3)					OPTIONAL,	 -- Need ON
+	cfi-SubframeMBSFN-r15			INTEGER (1..2)						OPTIONAL,	 -- Need ON
+	cfi-SlotSubslotMBSFN-r15		INTEGER (1..2)						OPTIONAL	 -- Need ON
+}
+
+CFI-PatternConfig-r15	::= SEQUENCE {
+	cfi-PatternSubframe-r15		SEQUENCE (SIZE(10)) OF INTEGER (1..4)	OPTIONAL,	 -- Need ON
+	cfi-PatternSlotSubslot-r15	SEQUENCE (SIZE(10)) OF INTEGER (1..3)	OPTIONAL	 -- Need ON
+}
+
+LAA-SCellConfiguration-r13 ::=			SEQUENCE {
+	subframeStartPosition-r13				ENUMERATED {s0, s07},
+	laa-SCellSubframeConfig-r13				BIT STRING (SIZE(8))
+}
+
+LAA-SCellConfiguration-v1430 ::=		SEQUENCE {
+	crossCarrierSchedulingConfig-UL-r14	CHOICE {
+		release									NULL,
+		setup									SEQUENCE {
+			crossCarrierSchedulingConfigLAA-UL-r14		CrossCarrierSchedulingConfigLAA-UL-r14
+		}
+	}													OPTIONAL,	-- Cond Cross-Carrier-ConfigUL
+	lbt-Config-r14								LBT-Config-r14			OPTIONAL,		-- Need ON
+	pdcch-ConfigLAA-r14							PDCCH-ConfigLAA-r14	OPTIONAL,		-- Need ON
+	absenceOfAnyOtherTechnology-r14			ENUMERATED {true}		OPTIONAL,		-- Need OR
+	soundingRS-UL-ConfigDedicatedAperiodic-v1430
+						SoundingRS-UL-ConfigDedicatedAperiodic-v1430	OPTIONAL		-- Need ON
+}
+
+LAA-SCellConfiguration-v1530 ::=		SEQUENCE {
+	aul-Config-r15							AUL-Config-r15		OPTIONAL,		-- Need ON
+	pusch-ModeConfigLAA-r15					PUSCH-ModeConfigLAA-r15	OPTIONAL	-- Need OR
+}
+
+PUSCH-ModeConfigLAA-r15 ::=			SEQUENCE {
+		laa-PUSCH-Mode1	BOOLEAN,
+		laa-PUSCH-Mode2	BOOLEAN,
+		laa-PUSCH-Mode3	BOOLEAN
+}
+
+LBT-Config-r14 ::=		CHOICE{
+	maxEnergyDetectionThreshold-r14				INTEGER(-85..-52),
+	energyDetectionThresholdOffset-r14			INTEGER(-13..20)
+}
+
+
+CSI-RS-ConfigNZPToAddModList-r11 ::=	SEQUENCE (SIZE (1..maxCSI-RS-NZP-r11)) OF CSI-RS-ConfigNZP-r11
+
+CSI-RS-ConfigNZPToAddModListExt-r13 ::=	SEQUENCE (SIZE (1..maxCSI-RS-NZP-v1310)) OF CSI-RS-ConfigNZP-r11
+
+CSI-RS-ConfigNZPToAddModList-r15 ::=	SEQUENCE (SIZE (1..maxCSI-RS-NZP-r13)) OF CSI-RS-ConfigNZP-r11
+
+CSI-RS-ConfigNZPToReleaseList-r11 ::=	SEQUENCE (SIZE (1..maxCSI-RS-NZP-r11)) OF CSI-RS-ConfigNZPId-r11
+
+CSI-RS-ConfigNZPToReleaseListExt-r13 ::=	SEQUENCE (SIZE (1..maxCSI-RS-NZP-v1310)) OF CSI-RS-ConfigNZPId-v1310
+
+CSI-RS-ConfigNZPToReleaseList-r15 ::=	SEQUENCE (SIZE (1..maxCSI-RS-NZP-r13)) OF CSI-RS-ConfigNZPId-r13
+
+CSI-RS-ConfigZPToAddModList-r11 ::=	SEQUENCE (SIZE (1..maxCSI-RS-ZP-r11)) OF CSI-RS-ConfigZP-r11
+
+CSI-RS-ConfigZPToReleaseList-r11 ::=	SEQUENCE (SIZE (1..maxCSI-RS-ZP-r11)) OF CSI-RS-ConfigZPId-r11
+
+PhysicalConfigDedicatedSTTI-r15 ::=	CHOICE {
+	release					NULL,
+	setup					SEQUENCE {
+		antennaInfoDedicatedSTTI-r15		AntennaInfoDedicatedSTTI-r15		OPTIONAL, -- Need ON
+		antennaInfoUL-STTI-r15				AntennaInfoUL-STTI-r15				OPTIONAL, -- Need ON
+		pucch-ConfigDedicated-v1530			PUCCH-ConfigDedicated-v1530			OPTIONAL, -- Need ON
+		schedulingRequestConfig-v1530		SchedulingRequestConfig-v1530		OPTIONAL, -- Need ON
+		uplinkPowerControlDedicatedSTTI-r15	UplinkPowerControlDedicatedSTTI-r15	OPTIONAL,	--Need ON
+		cqi-ReportConfig-r15				CQI-ReportConfig-r15				OPTIONAL, -- Need ON
+		csi-RS-Config-r15					CSI-RS-Config-r15					OPTIONAL, -- Need ON
+		csi-RS-ConfigNZPToReleaseList-r15	CSI-RS-ConfigNZPToReleaseList-r15	OPTIONAL, -- Need ON
+		csi-RS-ConfigNZPToAddModList-r15	CSI-RS-ConfigNZPToAddModList-r15	OPTIONAL, -- Need ON
+		csi-RS-ConfigZPToReleaseList-r15	CSI-RS-ConfigZPToReleaseList-r11	OPTIONAL, -- Need ON
+		csi-RS-ConfigZPToAddModList-r11		CSI-RS-ConfigZPToAddModList-r11		OPTIONAL, -- Need ON
+		csi-RS-ConfigZP-ApList-r15			CSI-RS-ConfigZP-ApList-r14			OPTIONAL, -- Need ON
+		eimta-MainConfig-r12				EIMTA-MainConfig-r12				OPTIONAL, -- Need ON
+		eimta-MainConfigServCell-r15		EIMTA-MainConfigServCell-r12		OPTIONAL, -- Need ON
+		semiOpenLoopSTTI-r15				BOOLEAN,
+		slotOrSubslotPDSCH-Config-r15		SlotOrSubslotPDSCH-Config-r15		OPTIONAL, -- Need ON
+		slotOrSubslotPUSCH-Config-r15		SlotOrSubslotPUSCH-Config-r15		OPTIONAL, -- Need ON
+		spdcch-Config-r15					SPDCCH-Config-r15					OPTIONAL, -- Need ON
+		spucch-Config-r15					SPUCCH-Config-r15					OPTIONAL, -- Need ON
+		srs-DCI7-TriggeringConfig-r15		BOOLEAN,
+		shortProcessingTime-r15				BOOLEAN,
+		shortTTI-r15						ShortTTI-r15						OPTIONAL -- Need ON
+	}
+}
+
+SoundingRS-AperiodicSet-r14 ::= SEQUENCE{
+	srs-CC-SetIndexList-r14					
+								SEQUENCE (SIZE (1..4)) OF SRS-CC-SetIndex-r14
+															OPTIONAL,	-- Cond SRS-Trigger-TypeA
+	soundingRS-UL-ConfigDedicatedAperiodic-r14
+												SoundingRS-UL-ConfigDedicatedAperiodic-r10
+}
+
+SoundingRS-AperiodicSetUpPTsExt-r14 ::= SEQUENCE{
+	srs-CC-SetIndexList-r14
+								SEQUENCE (SIZE (1..4)) OF SRS-CC-SetIndex-r14
+															OPTIONAL,	-- Cond SRS-Trigger-TypeA
+	soundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r14
+											SoundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r13
+}
+
+ShortTTI-r15 ::=					SEQUENCE {
+	dl-STTI-Length-r15					ShortTTI-Length-r15			OPTIONAL,	-- Need OR
+	ul-STTI-Length-r15					ShortTTI-Length-r15			OPTIONAL	-- Need OR
+}
+
+ShortTTI-Length-r15 ::=					ENUMERATED {slot, subslot}
+
+SoundingRS-VirtualCellID-r16 ::=			SEQUENCE {
+	srs-VirtualCellID-r16						INTEGER (0..503),
+	srs-VirtualCellID-AllSRS-r16				BOOLEAN
+}
+
+
+WidebandPRG-r16 ::= SEQUENCE {
+	widebandPRG-Subframe-r16				BOOLEAN,
+	widebandPRG-SlotSubslot-r16			BOOLEAN
+}
+
+ResourceReservationConfigDedicatedDL-r16 ::= SEQUENCE {
+	resourceReservationDedicatedDL-r16			ResourceReservationConfigDL-r16	OPTIONAL -- Need OP
+}
+
+ResourceReservationConfigDedicatedUL-r16 ::= SEQUENCE {
+	resourceReservationDedicatedUL-r16			ResourceReservationConfigUL-r16	OPTIONAL -- Need OP
+}
+
+
+
+P-Max ::=				INTEGER (-30..33)
+
+
+
+PRACH-ConfigSIB ::=				SEQUENCE {
+	rootSequenceIndex					INTEGER (0..837),
+	prach-ConfigInfo					PRACH-ConfigInfo
+}
+
+PRACH-ConfigSIB-v1310 ::=			SEQUENCE {
+	rsrp-ThresholdsPrachInfoList-r13		RSRP-ThresholdsPrachInfoList-r13,
+	mpdcch-startSF-CSS-RA-r13			CHOICE {
+		fdd-r13								ENUMERATED {v1, v1dot5, v2, v2dot5, v4, v5, v8,
+												v10},
+		tdd-r13								ENUMERATED {v1, v2, v4, v5, v8, v10, v20, spare}
+	}																		OPTIONAL,	-- Cond MP
+	prach-HoppingOffset-r13				INTEGER (0..94)						OPTIONAL,	-- Need OR
+	prach-ParametersListCE-r13			PRACH-ParametersListCE-r13
+}
+
+PRACH-ConfigSIB-v1530 ::=			SEQUENCE {
+	edt-PRACH-ParametersListCE-r15		SEQUENCE (SIZE(1..maxCE-Level-r13)) OF EDT-PRACH-ParametersCE-r15
+}
+
+PRACH-Config ::=					SEQUENCE {
+	rootSequenceIndex					INTEGER (0..837),
+	prach-ConfigInfo					PRACH-ConfigInfo					OPTIONAL	-- Need ON
+}
+
+PRACH-Config-v1310 ::=				SEQUENCE {
+	rsrp-ThresholdsPrachInfoList-r13		RSRP-ThresholdsPrachInfoList-r13		OPTIONAL,	-- Cond MP
+	mpdcch-startSF-CSS-RA-r13			CHOICE {
+		fdd-r13								ENUMERATED {v1, v1dot5, v2, v2dot5, v4, v5, v8,
+												v10},
+		tdd-r13								ENUMERATED {v1, v2, v4, v5, v8, v10, v20, spare}
+	}																		OPTIONAL,	-- Cond MP
+	prach-HoppingOffset-r13				INTEGER (0..94)						OPTIONAL,	-- Need OR
+	prach-ParametersListCE-r13			PRACH-ParametersListCE-r13			OPTIONAL,	-- Cond MP
+	initial-CE-level-r13					INTEGER (0..3)		OPTIONAL	-- Need OR
+}
+
+PRACH-Config-v1430 ::=				SEQUENCE {
+	rootSequenceIndexHighSpeed-r14				INTEGER (0..837),
+	zeroCorrelationZoneConfigHighSpeed-r14		INTEGER (0..12),
+	prach-ConfigIndexHighSpeed-r14				INTEGER (0..63),
+	prach-FreqOffsetHighSpeed-r14				INTEGER (0..94)
+}
+
+PRACH-ConfigSCell-r10 ::=				SEQUENCE {
+	prach-ConfigIndex-r10					INTEGER (0..63)
+}
+
+PRACH-ConfigInfo ::=				SEQUENCE {
+	prach-ConfigIndex					INTEGER (0..63),
+	highSpeedFlag						BOOLEAN,
+	zeroCorrelationZoneConfig			INTEGER (0..15),
+	prach-FreqOffset					INTEGER (0..94)
+}
+
+PRACH-ParametersListCE-r13 ::=	SEQUENCE (SIZE(1..maxCE-Level-r13)) OF PRACH-ParametersCE-r13
+
+PRACH-ParametersCE-r13 ::=			SEQUENCE {
+	prach-ConfigIndex-r13					INTEGER (0..63),
+	prach-FreqOffset-r13						INTEGER (0..94),
+	prach-StartingSubframe-r13				ENUMERATED {sf2, sf4, sf8, sf16, sf32, sf64, sf128,
+														sf256}				OPTIONAL,	-- Need OP
+	maxNumPreambleAttemptCE-r13
+								ENUMERATED {n3, n4, n5, n6, n7, n8, n10}	OPTIONAL,	-- Need OP
+	numRepetitionPerPreambleAttempt-r13		ENUMERATED {n1,n2,n4,n8,n16,n32,n64,n128},
+	mpdcch-NarrowbandsToMonitor-r13			SEQUENCE (SIZE(1..2)) OF
+													INTEGER (1..maxAvailNarrowBands-r13),
+	mpdcch-NumRepetition-RA-r13				ENUMERATED {r1, r2, r4, r8, r16,
+														r32, r64, r128, r256},
+	prach-HoppingConfig-r13					ENUMERATED {on,off}
+}
+
+EDT-PRACH-ParametersCE-r15 ::=		SEQUENCE {
+	edt-PRACH-ParametersCE-r15		SEQUENCE {
+		prach-ConfigIndex-r15				INTEGER (0..63),
+		prach-FreqOffset-r15					INTEGER (0..94),
+		prach-StartingSubframe-r15			ENUMERATED {sf2, sf4, sf8, sf16, sf32, sf64, sf128, sf256}			OPTIONAL,	-- Need OP
+		mpdcch-NarrowbandsToMonitor-r15		SEQUENCE (SIZE(1..2)) OF INTEGER (1..maxAvailNarrowBands-r13)
+	}	OPTIONAL -- Need OR
+}
+
+RSRP-ThresholdsPrachInfoList-r13 ::= SEQUENCE (SIZE(1..3)) OF RSRP-Range
+
+
+
+PresenceAntennaPort1 ::=				BOOLEAN
+
+
+
+PUCCH-ConfigCommon ::=				SEQUENCE {
+	deltaPUCCH-Shift					ENUMERATED {ds1, ds2, ds3},
+	nRB-CQI								INTEGER (0..98),
+	nCS-AN								INTEGER (0..7),
+	n1PUCCH-AN							INTEGER (0..2047)
+}
+
+PUCCH-ConfigCommon-v1310 ::=		SEQUENCE {
+	n1PUCCH-AN-InfoList-r13					N1PUCCH-AN-InfoList-r13		OPTIONAL,	-- Need OR
+	pucch-NumRepetitionCE-Msg4-Level0-r13	ENUMERATED {n1, n2, n4, n8}		OPTIONAL,	-- Need OR
+	pucch-NumRepetitionCE-Msg4-Level1-r13	ENUMERATED {n1, n2, n4, n8}		OPTIONAL,	-- Need OR
+	pucch-NumRepetitionCE-Msg4-Level2-r13	ENUMERATED {n4, n8, n16, n32}	OPTIONAL,	-- Need OR
+	pucch-NumRepetitionCE-Msg4-Level3-r13	ENUMERATED {n4, n8, n16, n32}	OPTIONAL	-- Need OR
+}
+
+PUCCH-ConfigCommon-v1430 ::=		SEQUENCE {
+	pucch-NumRepetitionCE-Msg4-Level3-r14	ENUMERATED {n64, n128}	OPTIONAL	-- Need OR
+}
+
+PUCCH-ConfigDedicated ::=			SEQUENCE {
+	ackNackRepetition					CHOICE{
+		release								NULL,
+		setup								SEQUENCE {
+			repetitionFactor					ENUMERATED {n2, n4, n6, spare1},
+			n1PUCCH-AN-Rep						INTEGER (0..2047)
+		}
+	},
+	tdd-AckNackFeedbackMode				ENUMERATED {bundling, multiplexing}	OPTIONAL	-- Cond TDD
+}
+
+PUCCH-ConfigDedicated-v1020 ::=		SEQUENCE {
+	pucch-Format-r10					CHOICE {
+		format3-r10						PUCCH-Format3-Conf-r13,
+		channelSelection-r10				SEQUENCE {
+			n1PUCCH-AN-CS-r10					CHOICE {
+				release								NULL,
+				setup								SEQUENCE {
+					n1PUCCH-AN-CS-List-r10				SEQUENCE (SIZE (1..2)) OF N1PUCCH-AN-CS-r10
+				}
+			}																OPTIONAL	-- Need ON
+		}
+	}																		OPTIONAL,	-- Need OR
+	twoAntennaPortActivatedPUCCH-Format1a1b-r10		ENUMERATED {true}		OPTIONAL,	-- Need OR
+	simultaneousPUCCH-PUSCH-r10						ENUMERATED {true}		OPTIONAL,	-- Need OR
+	n1PUCCH-AN-RepP1-r10							INTEGER (0..2047)		OPTIONAL	-- Need OR
+}
+
+PUCCH-ConfigDedicated-v1130 ::=		SEQUENCE {
+	n1PUCCH-AN-CS-v1130					CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			n1PUCCH-AN-CS-ListP1-r11			SEQUENCE (SIZE (2..4)) OF INTEGER (0..2047)
+		}
+	}																		OPTIONAL,	-- Need ON
+	nPUCCH-Param-r11					CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			nPUCCH-Identity-r11					INTEGER (0..503),
+			n1PUCCH-AN-r11						INTEGER (0..2047)
+		}
+	}																		OPTIONAL	-- Need ON
+}
+
+PUCCH-ConfigDedicated-v1250 ::=		SEQUENCE {
+	nkaPUCCH-Param-r12					CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			nkaPUCCH-AN-r12						INTEGER (0..2047)
+		}
+	}
+}
+
+PUCCH-ConfigDedicated-r13 ::=		SEQUENCE {
+--Release 8
+	ackNackRepetition-r13				CHOICE{
+		release								NULL,
+		setup								SEQUENCE {
+			repetitionFactor-r13				ENUMERATED {n2, n4, n6, spare1},
+			n1PUCCH-AN-Rep-r13				INTEGER (0..2047)
+		}
+	},
+	tdd-AckNackFeedbackMode-r13			ENUMERATED {bundling, multiplexing}	OPTIONAL,	-- Cond TDD
+--Release 10
+	pucch-Format-r13					CHOICE {
+		format3-r13								SEQUENCE {
+			n3PUCCH-AN-List-r13	SEQUENCE (SIZE (1..4)) OF INTEGER (0..549)	OPTIONAL,	-- Need ON
+			twoAntennaPortActivatedPUCCH-Format3-r13		CHOICE {	
+				release											NULL,
+				setup											SEQUENCE {
+					n3PUCCH-AN-ListP1-r13	SEQUENCE (SIZE (1..4)) OF INTEGER (0..549)
+				}
+			}																OPTIONAL	-- Need ON
+		},
+		channelSelection-r13				SEQUENCE {
+			n1PUCCH-AN-CS-r13					CHOICE {
+				release								NULL,
+				setup								SEQUENCE {
+					n1PUCCH-AN-CS-List-r13				SEQUENCE (SIZE (1..2)) OF N1PUCCH-AN-CS-r10,
+					dummy1			SEQUENCE (SIZE (2..4)) OF INTEGER (0..2047)
+				}
+			}																OPTIONAL	-- Need ON
+		},
+		format4-r13							SEQUENCE {
+			format4-resourceConfiguration-r13			SEQUENCE (SIZE (4)) OF Format4-resource-r13,
+			format4-MultiCSI-resourceConfiguration-r13	SEQUENCE (SIZE (1..2)) OF Format4-resource-r13 OPTIONAL	-- Need OR
+		},
+		format5-r13				SEQUENCE {
+			format5-resourceConfiguration-r13			SEQUENCE (SIZE (4)) OF Format5-resource-r13,
+			format5-MultiCSI-resourceConfiguration-r13	Format5-resource-r13 OPTIONAL	-- Need OR
+		}
+	}																		OPTIONAL,	-- Need OR
+	twoAntennaPortActivatedPUCCH-Format1a1b-r13		ENUMERATED {true}		OPTIONAL,	-- Need OR
+	simultaneousPUCCH-PUSCH-r13						ENUMERATED {true}		OPTIONAL,	-- Need OR
+	n1PUCCH-AN-RepP1-r13							INTEGER (0..2047)		OPTIONAL,	-- Need OR
+--Release 11
+	nPUCCH-Param-r13					CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			nPUCCH-Identity-r13					INTEGER (0..503),
+			n1PUCCH-AN-r13						INTEGER (0..2047)
+		}
+	}																		OPTIONAL,	-- Need ON
+--Release 12
+	nkaPUCCH-Param-r13					CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			nkaPUCCH-AN-r13						INTEGER (0..2047)
+		}
+	}																		OPTIONAL,	-- Need ON
+--Release 13
+	spatialBundlingPUCCH-r13			BOOLEAN,
+	spatialBundlingPUSCH-r13			BOOLEAN,
+	harq-TimingTDD-r13					BOOLEAN,
+	codebooksizeDetermination-r13		ENUMERATED {dai,cc}					OPTIONAL,	-- Need OR
+	maximumPayloadCoderate-r13			INTEGER (0..7)						OPTIONAL,	-- Need OR
+	pucch-NumRepetitionCE-r13			CHOICE {
+		release						NULL,
+		setup						CHOICE {
+			modeA						SEQUENCE {
+				pucch-NumRepetitionCE-format1-r13					ENUMERATED {r1, r2, r4, r8},
+				pucch-NumRepetitionCE-format2-r13					ENUMERATED {r1, r2, r4, r8}
+			},
+			modeB						SEQUENCE {
+				pucch-NumRepetitionCE-format1-r13					ENUMERATED {r4, r8, r16, r32},
+				pucch-NumRepetitionCE-format2-r13					ENUMERATED {r4, r8, r16, r32}
+			}
+		}
+	}																		OPTIONAL	--Need ON
+}
+
+PUCCH-ConfigDedicated-v1370 ::=		SEQUENCE {
+	pucch-Format-v1370					CHOICE {
+		release	NULL,
+		setup	PUCCH-Format3-Conf-r13
+	}
+}
+
+PUCCH-ConfigDedicated-v13c0 ::=		SEQUENCE {
+	channelSelection-v13c0				SEQUENCE {
+		n1PUCCH-AN-CS-v13c0					CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+					n1PUCCH-AN-CS-ListP1-v13c0			SEQUENCE (SIZE (2..4)) OF INTEGER (0..2047)
+			}
+		}
+	}
+}
+
+PUCCH-Format3-Conf-r13 ::=	SEQUENCE {
+	n3PUCCH-AN-List-r13	SEQUENCE (SIZE (1..4)) OF INTEGER (0..549)	OPTIONAL,	-- Need ON
+	twoAntennaPortActivatedPUCCH-Format3-r13		CHOICE {	
+		release											NULL,
+		setup											SEQUENCE {
+			n3PUCCH-AN-ListP1-r13	SEQUENCE (SIZE (1..4)) OF INTEGER (0..549)
+		}
+	}																OPTIONAL	-- Need ON
+}
+
+PUCCH-ConfigDedicated-v1430 ::=		SEQUENCE {
+	pucch-NumRepetitionCE-format1-r14		ENUMERATED {r64,r128}		OPTIONAL	-- Need OR
+}
+
+PUCCH-ConfigDedicated-v1530 ::=		SEQUENCE {
+	n1PUCCH-AN-SPT-r15					INTEGER (0..2047)			OPTIONAL,	-- Need OR
+	codebooksizeDeterminationSTTI-r15	ENUMERATED {dai,cc}			OPTIONAL	-- Need OR
+}
+
+Format4-resource-r13	::=				SEQUENCE {
+	startingPRB-format4-r13						INTEGER (0..109),
+	numberOfPRB-format4-r13					INTEGER (0..7)
+}
+
+Format5-resource-r13	::=				SEQUENCE {
+	startingPRB-format5-r13						INTEGER (0..109),
+	cdm-index-format5-r13						INTEGER (0..1)
+}
+
+
+
+N1PUCCH-AN-CS-r10	::= SEQUENCE (SIZE (1..4)) OF INTEGER (0..2047)
+
+N1PUCCH-AN-InfoList-r13 ::= SEQUENCE (SIZE(1..maxCE-Level-r13)) OF INTEGER (0..2047)
+
+
+
+PUR-Config-r16 ::=		SEQUENCE {	
+	pur-ConfigID-r16				PUR-ConfigID-r16			OPTIONAL,	-- Need OR
+	pur-ImplicitReleaseAfter-r16	ENUMERATED {n2, n4, n8, spare}	OPTIONAL,	-- Need OR
+	pur-StartTimeParameters-r16		SEQUENCE {
+		periodicityAndOffset-r16		PUR-PeriodicityAndOffset-r16,
+		startSFN-r16					INTEGER (0..1023),
+		startSubFrame-r16				INTEGER (0..9),
+		hsfn-LSB-Info-r16				BIT STRING (SIZE(1))
+	}		OPTIONAL,	--Need ON
+	pur-NumOccasions-r16			ENUMERATED {one, infinite},
+	pur-RNTI-r16					C-RNTI						OPTIONAL,	-- Need ON
+	pur-TimeAlignmentTimer-r16		INTEGER (1..8)				OPTIONAL,	-- Need OR
+	pur-RSRP-ChangeThreshold-r16	SetupRelease {PUR-RSRP-ChangeThreshold-r16} OPTIONAL,	-- Need ON
+	pur-ResponseWindowTimer-r16		ENUMERATED {sf240, sf480, sf960, sf1920, sf3840, sf5760, sf7680, sf10240}		OPTIONAL,	-- Need ON
+	pur-MPDCCH-Config-r16			PUR-MPDCCH-Config-r16		OPTIONAL,	-- Need ON
+	pur-PDSCH-FreqHopping-r16		BOOLEAN,
+	pur-PUCCH-Config-r16			PUR-PUCCH-Config-r16		OPTIONAL,	-- Need ON
+	pur-PUSCH-Config-r16			PUR-PUSCH-Config-r16		OPTIONAL,	-- Need ON
+	...
+}
+
+PUR-MPDCCH-Config-r16 ::=		SEQUENCE {
+	mpdcch-FreqHopping-r16			BOOLEAN,
+	mpdcch-Narrowband-r16			INTEGER (1..maxAvailNarrowBands-r13),
+	mpdcch-PRB-PairsConfig-r16		SEQUENCE{
+		numberPRB-Pairs-r16				ENUMERATED {n2, n4, n6, spare1},
+		resourceBlockAssignment-r16		BIT STRING (SIZE(4))
+	},
+	mpdcch-NumRepetition-r16		ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128, r256},
+	mpdcch-StartSF-UESS-r16			CHOICE {
+		fdd								ENUMERATED {v1, v1dot5, v2, v2dot5, v4, v5, v8, v10},
+		tdd							ENUMERATED {v1, v2, v4, v5, v8, v10, v20, spare1}
+	},
+	mpdcch-Offset-PUR-SS-r16	ENUMERATED {zero, oneEighth, oneQuarter,
+											threeEighth, oneHalf, fiveEighth,
+											threeQuarter, sevenEighth}
+}
+
+PUR-PUCCH-Config-r16 ::=			SEQUENCE {
+	n1PUCCH-AN-r16						INTEGER (0..2047)			OPTIONAL,	-- Need ON
+	pucch-NumRepetitionCE-Format1-r16	ENUMERATED {n1, n2, n4, n8}	OPTIONAL	-- Need ON
+}
+
+PUR-PUSCH-Config-r16 ::=		SEQUENCE {
+	pur-GrantInfo-r16				CHOICE {
+		ce-ModeA						SEQUENCE {
+			numRUs-r16						BIT STRING (SIZE(2)),
+			prb-AllocationInfo-r16			BIT STRING (SIZE(10)),
+			mcs-r16							BIT STRING (SIZE(4)),
+			numRepetitions-r16				BIT STRING (SIZE(3))
+		},
+		ce-ModeB						SEQUENCE {
+			subPRB-Allocation-r16			BOOLEAN,
+			numRUs-r16						BOOLEAN,
+			prb-AllocationInfo-r16			BIT STRING (SIZE(8)),
+			mcs-r16							BIT STRING (SIZE(4)),
+			numRepetitions-r16				BIT STRING (SIZE(3))
+		}
+	}	OPTIONAL,	-- Need ON
+	pur-PUSCH-FreqHopping-r16		BOOLEAN,
+	p0-UE-PUSCH-r16					INTEGER (-8..7),
+	alpha-r16						Alpha-r12,
+	pusch-CyclicShift-r16			ENUMERATED {n0, n6},
+	pusch-NB-MaxTBS-r16				BOOLEAN,
+	locationCE-ModeB-r16			INTEGER (0..5)	OPTIONAL -- Cond SubPRB
+}
+
+PUR-RSRP-ChangeThreshold-r16 ::= SEQUENCE {
+	increaseThresh-r16				RSRP-ChangeThresh-r16,
+	decreaseThresh-r16				RSRP-ChangeThresh-r16	OPTIONAL		--Need OP
+}
+
+RSRP-ChangeThresh-r16 ::= ENUMERATED {dB4, dB6, dB8, dB10, dB14, dB18, dB22, dB26, dB30, dB34, spare6, spare5, spare4, spare3, spare2, spare1}
+
+
+
+PUR-ConfigID-r16 ::= BIT STRING (SIZE(20))
+
+
+
+PUR-PeriodicityAndOffset-r16 ::= CHOICE {
+	periodicity8		INTEGER (1..7),
+	periodicity16		INTEGER (1..15),
+	periodicity32		INTEGER (1..31),
+	periodicity64		INTEGER (1..63),
+	periodicity128		INTEGER (1..127),
+	periodicity256		INTEGER (1..255),
+	periodicity512		INTEGER (1..511),
+	periodicity1024		INTEGER (1..1023),
+	periodicity2048		INTEGER (1..2047),
+	periodicity4096		INTEGER (1..4095),
+	periodicity8192		INTEGER (1..8191)
+}
+
+
+
+PUSCH-ConfigCommon ::=				SEQUENCE {
+	pusch-ConfigBasic					SEQUENCE {
+		n-SB								INTEGER (1..4),
+		hoppingMode							ENUMERATED {interSubFrame, intraAndInterSubFrame},
+		pusch-HoppingOffset					INTEGER (0..98),
+		enable64QAM							BOOLEAN
+	},
+	ul-ReferenceSignalsPUSCH			UL-ReferenceSignalsPUSCH
+}
+
+PUSCH-ConfigCommon-v1270 ::=		SEQUENCE {
+	enable64QAM-v1270						ENUMERATED {true}
+}
+
+PUSCH-ConfigCommon-v1310 ::=	SEQUENCE {
+	pusch-maxNumRepetitionCEmodeA-r13	ENUMERATED {
+											r8, r16, r32 }					OPTIONAL,	-- Need OR
+	pusch-maxNumRepetitionCEmodeB-r13	ENUMERATED {
+											r192, r256, r384, r512, r768, r1024,
+											r1536, r2048}					OPTIONAL,	-- Need OR
+	pusch-HoppingOffset-v1310
+									INTEGER (1..maxAvailNarrowBands-r13)	OPTIONAL	-- Need OR
+}
+
+PUSCH-ConfigDedicated ::=			SEQUENCE {
+	betaOffset-ACK-Index				INTEGER (0..15),
+	betaOffset-RI-Index					INTEGER (0..15),
+	betaOffset-CQI-Index				INTEGER (0..15)
+}
+
+PUSCH-ConfigDedicated-v1020 ::=		SEQUENCE {
+	betaOffsetMC-r10					SEQUENCE {	
+		betaOffset-ACK-Index-MC-r10			INTEGER (0..15),
+		betaOffset-RI-Index-MC-r10			INTEGER (0..15),
+		betaOffset-CQI-Index-MC-r10			INTEGER (0..15)
+	}																		OPTIONAL,	-- Need OR
+	groupHoppingDisabled-r10			ENUMERATED {true}					OPTIONAL,	-- Need OR
+	dmrs-WithOCC-Activated-r10			ENUMERATED {true}					OPTIONAL	-- Need OR
+}
+
+PUSCH-ConfigDedicated-v1130 ::=		SEQUENCE {
+	pusch-DMRS-r11						CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			nPUSCH-Identity-r11					INTEGER (0..509),
+			nDMRS-CSH-Identity-r11				INTEGER (0..509)
+		}
+	}
+}
+
+PUSCH-ConfigDedicated-v1250::=		SEQUENCE {
+	uciOnPUSCH							CHOICE {
+		release								NULL,
+		setup									SEQUENCE {
+			betaOffset-ACK-Index-SubframeSet2-r12			INTEGER (0..15),
+			betaOffset-RI-Index-SubframeSet2-r12			INTEGER (0..15),
+			betaOffset-CQI-Index-SubframeSet2-r12			INTEGER (0..15),
+			betaOffsetMC-r12						SEQUENCE {	
+				betaOffset-ACK-Index-MC-SubframeSet2-r12	INTEGER (0..15),
+				betaOffset-RI-Index-MC-SubframeSet2-r12		INTEGER (0..15),
+				betaOffset-CQI-Index-MC-SubframeSet2-r12	INTEGER (0..15)
+			}																OPTIONAL	-- Need OR
+		}
+	}
+}
+PUSCH-ConfigDedicated-r13 ::=			SEQUENCE {
+	betaOffset-ACK-Index-r13				INTEGER (0..15),
+	betaOffset2-ACK-Index-r13				INTEGER (0..15)					OPTIONAL,	-- Need OR
+	betaOffset-RI-Index-r13					INTEGER (0..15),
+	betaOffset-CQI-Index-r13				INTEGER (0..15),
+	betaOffsetMC-r13						SEQUENCE {	
+		betaOffset-ACK-Index-MC-r13				INTEGER (0..15),
+		betaOffset2-ACK-Index-MC-r13			INTEGER (0..15)				OPTIONAL,	-- Need OR
+		betaOffset-RI-Index-MC-r13				INTEGER (0..15),
+		betaOffset-CQI-Index-MC-r13				INTEGER (0..15)
+	}																		OPTIONAL,	-- Need OR
+	groupHoppingDisabled-r13				ENUMERATED {true}				OPTIONAL,	-- Need OR
+	dmrs-WithOCC-Activated-r13				ENUMERATED {true}				OPTIONAL,	-- Need OR
+	pusch-DMRS-r11							CHOICE {
+		release									NULL,
+		setup									SEQUENCE {
+			nPUSCH-Identity-r13						INTEGER (0..509),
+			nDMRS-CSH-Identity-r13					INTEGER (0..509)
+		}
+	}																		OPTIONAL,	-- Need ON
+	uciOnPUSCH								CHOICE {
+		release									NULL,
+		setup									SEQUENCE {
+			betaOffset-ACK-Index-SubframeSet2-r13			INTEGER (0..15),
+			betaOffset2-ACK-Index-SubframeSet2-r13			INTEGER (0..15)	OPTIONAL,	-- Need OR
+			betaOffset-RI-Index-SubframeSet2-r13			INTEGER (0..15),
+			betaOffset-CQI-Index-SubframeSet2-r13			INTEGER (0..15),
+			betaOffsetMC-r12						SEQUENCE {	
+				betaOffset-ACK-Index-MC-SubframeSet2-r13	INTEGER (0..15),
+				betaOffset2-ACK-Index-MC-SubframeSet2-r13	INTEGER (0..15)	OPTIONAL,	-- Need OR
+				betaOffset-RI-Index-MC-SubframeSet2-r13		INTEGER (0..15),
+				betaOffset-CQI-Index-MC-SubframeSet2-r13	INTEGER (0..15)
+			}																OPTIONAL	-- Need OR
+		}
+	}																		OPTIONAL,	-- Need ON
+	pusch-HoppingConfig-r13					ENUMERATED {on}					OPTIONAL	-- Need OR
+}
+
+PUSCH-ConfigDedicated-v1430 ::=			SEQUENCE {
+	ce-PUSCH-NB-MaxTBS-r14					ENUMERATED {on}					OPTIONAL,	-- Need OR
+	ce-PUSCH-MaxBandwidth-r14				ENUMERATED {bw5}				OPTIONAL,	-- Need OR
+	tdd-PUSCH-UpPTS-r14						TDD-PUSCH-UpPTS-r14				OPTIONAL,	-- Need ON
+	ul-DMRS-IFDMA-r14						BOOLEAN,
+	enable256QAM-r14						Enable256QAM-r14				OPTIONAL	-- Need ON
+}
+
+PUSCH-ConfigDedicated-v1530 ::=			SEQUENCE {
+	ce-PUSCH-FlexibleStartPRB-AllocConfig-r15	CHOICE {
+		release				NULL,
+		setup				SEQUENCE {
+			offsetCE-ModeB-r15			INTEGER (-1..3)	OPTIONAL		-- Cond CE-ModeB
+		}
+	},
+	ce-PUSCH-SubPRB-Config-r15	CHOICE {
+		release				NULL,
+		setup				SEQUENCE {
+			locationCE-ModeB-r15			INTEGER (0..5)		OPTIONAL,	-- Cond CE-ModeB
+			sixToneCyclicShift-r15		INTEGER (0..3),
+			threeToneCyclicShift-r15		INTEGER (0..2)
+		}
+	}		OPTIONAL -- Need ON
+}
+
+PUSCH-ConfigDedicated-v1610 ::=		SEQUENCE {
+	ce-PUSCH-MultiTB-Config-r16		SetupRelease {CE-PUSCH-MultiTB-Config-r16}
+}
+
+PUSCH-ConfigDedicatedSCell-r10 ::=		SEQUENCE {
+	groupHoppingDisabled-r10				ENUMERATED {true}				OPTIONAL,	-- Need OR
+	dmrs-WithOCC-Activated-r10				ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+PUSCH-ConfigDedicatedSCell-v1430 ::=			SEQUENCE {
+	enable256QAM-r14						Enable256QAM-r14				OPTIONAL	-- Need OR
+}
+
+PUSCH-ConfigDedicatedScell-v1530 ::=			SEQUENCE {
+	uci-OnPUSCH-r15						CHOICE {
+		release									NULL,
+		setup									SEQUENCE {
+			betaOffsetAUL-r15								INTEGER (0..15)
+		}
+	}
+}
+
+TDD-PUSCH-UpPTS-r14 ::=					CHOICE {
+	release									NULL,
+	setup									SEQUENCE {
+		symPUSCH-UpPTS-r14						ENUMERATED {sym1, sym2, sym3, sym4, sym5, sym6}																					OPTIONAL,	-- Need ON
+		dmrs-LessUpPTS-Config-r14				ENUMERATED {true}			OPTIONAL	-- Need OR
+	}
+}
+
+CE-PUSCH-MultiTB-Config-r16	 ::=	SEQUENCE {
+	interleaving-r16						ENUMERATED {on}			OPTIONAL	-- Need OR
+}
+
+Enable256QAM-r14 ::=					CHOICE {
+		release								NULL,
+		setup								CHOICE {
+			tpc-SubframeSet-Configured-r14		SEQUENCE {
+					subframeSet1-DCI-Format0-r14										BOOLEAN,
+					subframeSet1-DCI-Format4-r14										BOOLEAN,
+					subframeSet2-DCI-Format0-r14										BOOLEAN,
+					subframeSet2-DCI-Format4-r14										BOOLEAN
+			},
+			tpc-SubframeSet-NotConfigured-r14	SEQUENCE {
+					dci-Format0-r14		BOOLEAN,
+					dci-Format4-r14		BOOLEAN
+			}
+		}
+}
+
+PUSCH-EnhancementsConfig-r14 ::=		CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		pusch-HoppingOffsetPUSCH-Enh-r14			INTEGER (1..100)		OPTIONAL,	-- Need ON
+		interval-ULHoppingPUSCH-Enh-r14			CHOICE {
+			interval-FDD-PUSCH-Enh-r14				ENUMERATED {int1, int2, int4, int8},
+			interval-TDD-PUSCH-Enh-r14				ENUMERATED {int1, int5, int10, int20}
+		}																	OPTIONAL	-- Need ON
+	}
+}
+
+UL-ReferenceSignalsPUSCH ::=		SEQUENCE {
+	groupHoppingEnabled					BOOLEAN,
+	groupAssignmentPUSCH				INTEGER (0..29),
+	sequenceHoppingEnabled				BOOLEAN,
+	cyclicShift							INTEGER (0..7)
+}
+
+
+
+RACH-ConfigCommon ::=		SEQUENCE {
+	preambleInfo						SEQUENCE {
+		numberOfRA-Preambles				ENUMERATED {
+												n4, n8, n12, n16, n20, n24, n28,
+												n32, n36, n40, n44, n48, n52, n56,
+												n60, n64},
+		preamblesGroupAConfig				SEQUENCE {
+			sizeOfRA-PreamblesGroupA			ENUMERATED {
+													n4, n8, n12, n16, n20, n24, n28,
+													n32, n36, n40, n44, n48, n52, n56,
+													n60},
+			messageSizeGroupA						ENUMERATED {b56, b144, b208, b256},
+			messagePowerOffsetGroupB			ENUMERATED {
+													minusinfinity, dB0, dB5, dB8, dB10, dB12,
+													dB15, dB18},
+			...
+		}			OPTIONAL													-- Need OP
+	},
+	powerRampingParameters				PowerRampingParameters,
+	ra-SupervisionInfo					SEQUENCE {
+		preambleTransMax					PreambleTransMax,
+		ra-ResponseWindowSize				ENUMERATED {
+												sf2, sf3, sf4, sf5, sf6, sf7,
+												sf8, sf10},
+		mac-ContentionResolutionTimer		ENUMERATED {
+												sf8, sf16, sf24, sf32, sf40, sf48,
+												sf56, sf64}
+	},
+	maxHARQ-Msg3Tx						INTEGER (1..8),
+	...,
+	[[	preambleTransMax-CE-r13			PreambleTransMax					OPTIONAL,	-- Need OR
+		rach-CE-LevelInfoList-r13		RACH-CE-LevelInfoList-r13			OPTIONAL	-- Need OR
+	]],
+	[[	edt-SmallTBS-Subset-r15			ENUMERATED {true}					OPTIONAL		-- Cond EDT-OR
+	]]
+}
+
+RACH-ConfigCommon-v1250 ::=		SEQUENCE {
+	txFailParams-r12				SEQUENCE {
+		connEstFailCount-r12					ENUMERATED {n1, n2, n3, n4},
+		connEstFailOffsetValidity-r12			ENUMERATED {s30, s60, s120, s240,
+														s300, s420, s600, s900},
+		connEstFailOffset-r12					INTEGER (0..15)		OPTIONAL	-- Need OP
+	}
+}
+
+RACH-ConfigCommonSCell-r11 ::=		SEQUENCE {
+	powerRampingParameters-r11				PowerRampingParameters,
+	ra-SupervisionInfo-r11					SEQUENCE {
+		preambleTransMax-r11					PreambleTransMax
+	},
+	...
+}
+
+RACH-CE-LevelInfoList-r13 ::=	SEQUENCE (SIZE (1..maxCE-Level-r13)) OF RACH-CE-LevelInfo-r13
+
+RACH-CE-LevelInfo-r13 ::=		SEQUENCE {
+	preambleMappingInfo-r13				SEQUENCE {
+		firstPreamble-r13					INTEGER(0..63),
+		lastPreamble-r13					INTEGER(0..63)
+	},
+	ra-ResponseWindowSize-r13			ENUMERATED {sf20, sf50, sf80, sf120, sf180,
+													sf240, sf320, sf400},
+
+	mac-ContentionResolutionTimer-r13	ENUMERATED {sf80, sf100, sf120,
+													sf160, sf200, sf240, sf480, sf960},
+	rar-HoppingConfig-r13				ENUMERATED {on,off},
+	...,
+	[[	edt-Parameters-r15			SEQUENCE {
+			edt-LastPreamble-r15		INTEGER(0..63),
+			edt-SmallTBS-Enabled-r15	BOOLEAN,
+			edt-TBS-r15				ENUMERATED {b328, b408, b504, b600, b712,
+												b808, b936, b1000or456},
+			mac-ContentionResolutionTimer-r15	ENUMERATED {sf240, sf480, sf960,
+													sf1920, sf3840, sf5760, sf7680, sf10240}		OPTIONAL -- Need OP
+			}	OPTIONAL		-- Cond EDT
+	]]
+}
+
+PowerRampingParameters ::=			SEQUENCE {
+	powerRampingStep					ENUMERATED {dB0, dB2,dB4, dB6},
+	preambleInitialReceivedTargetPower	ENUMERATED {
+											dBm-120, dBm-118, dBm-116, dBm-114, dBm-112,
+											dBm-110, dBm-108, dBm-106, dBm-104, dBm-102,
+											dBm-100, dBm-98, dBm-96, dBm-94,
+											dBm-92, dBm-90}
+}
+
+PreambleTransMax ::=				ENUMERATED {
+											n3, n4, n5, n6, n7,	n8, n10, n20, n50,
+											n100, n200}
+
+
+
+RACH-ConfigDedicated ::=		SEQUENCE {
+	ra-PreambleIndex					INTEGER (0..63),
+	ra-PRACH-MaskIndex					INTEGER (0..15)
+}
+
+
+
+RadioResourceConfigCommonSIB ::=	SEQUENCE {
+	rach-ConfigCommon					RACH-ConfigCommon,
+	bcch-Config						BCCH-Config,
+	pcch-Config						PCCH-Config,
+	prach-Config						PRACH-ConfigSIB,
+	pdsch-ConfigCommon					PDSCH-ConfigCommon,
+	pusch-ConfigCommon					PUSCH-ConfigCommon,
+	pucch-ConfigCommon					PUCCH-ConfigCommon,
+	soundingRS-UL-ConfigCommon			SoundingRS-UL-ConfigCommon,
+	uplinkPowerControlCommon			UplinkPowerControlCommon,
+	ul-CyclicPrefixLength				UL-CyclicPrefixLength,
+	...,
+	[[	uplinkPowerControlCommon-v1020	UplinkPowerControlCommon-v1020		OPTIONAL	-- Need OR
+	]],
+	[[	rach-ConfigCommon-v1250			RACH-ConfigCommon-v1250				OPTIONAL	-- Need OR
+	]],
+	[[	pusch-ConfigCommon-v1270		PUSCH-ConfigCommon-v1270			OPTIONAL	-- Need OR
+	]],
+	[[	bcch-Config-v1310				BCCH-Config-v1310					OPTIONAL,	-- Need OR
+		pcch-Config-v1310				PCCH-Config-v1310					OPTIONAL,	-- Need OR
+		freqHoppingParameters-r13		FreqHoppingParameters-r13			OPTIONAL,	-- Need OR
+		pdsch-ConfigCommon-v1310		PDSCH-ConfigCommon-v1310			OPTIONAL,	-- Need OR
+		pusch-ConfigCommon-v1310		PUSCH-ConfigCommon-v1310			OPTIONAL,	-- Need OR
+		prach-ConfigCommon-v1310		PRACH-ConfigSIB-v1310				OPTIONAL,	-- Need OR
+		pucch-ConfigCommon-v1310		PUCCH-ConfigCommon-v1310			OPTIONAL	-- Need OR
+	]],
+	[[	highSpeedConfig-r14				HighSpeedConfig-r14					OPTIONAL,	-- Need OR
+		prach-Config-v1430				PRACH-Config-v1430					OPTIONAL,	-- Need OR
+		pucch-ConfigCommon-v1430		PUCCH-ConfigCommon-v1430			OPTIONAL	-- Need OR
+	]],
+	[[	prach-Config-v1530				PRACH-ConfigSIB-v1530				OPTIONAL,	-- Cond EDT
+		ce-RSS-Config-r15				RSS-Config-r15						OPTIONAL,	-- Need OR
+		wus-Config-r15					WUS-Config-r15						OPTIONAL,	-- Need OR
+		highSpeedConfig-v1530			HighSpeedConfig-v1530				OPTIONAL	-- Need OR
+	]],
+	[[	uplinkPowerControlCommon-v1540	UplinkPowerControlCommon-v1530		OPTIONAL	-- Need OR
+	]],
+	[[	wus-Config-v1560				WUS-Config-v1560					OPTIONAL	-- Need OR
+	]],
+	[[
+		wus-Config-v1610				WUS-Config-v1610					OPTIONAL,	-- Need OR
+		highSpeedConfig-v1610		HighSpeedConfig-v1610			OPTIONAL,	-- Need OR
+		crs-ChEstMPDCCH-ConfigCommon-r16	CRS-ChEstMPDCCH-ConfigCommon-r16	OPTIONAL, -- Need OR
+		gwus-Config-r16					GWUS-Config-r16						OPTIONAL,	-- Need OR
+		uplinkPowerControlCommon-v1610	UplinkPowerControlCommon-v1610		OPTIONAL,	-- Need OR
+		rss-MeasConfig-r16				ENUMERATED {enabled}				OPTIONAL,	-- Need OR
+		rss-MeasNonNCL-r16				ENUMERATED {enabled}				OPTIONAL,	-- Need OR
+		puncturedSubcarriersDL-r16		BIT STRING (SIZE (2))				OPTIONAL,	-- Need OR
+		highSpeedInterRAT-NR-r16		BOOLEAN								OPTIONAL	-- Need OR
+	]]
+}
+
+RadioResourceConfigCommon ::=		SEQUENCE {
+	rach-ConfigCommon					RACH-ConfigCommon					OPTIONAL,	-- Need ON
+	prach-Config						PRACH-Config,
+	pdsch-ConfigCommon					PDSCH-ConfigCommon					OPTIONAL,	-- Need ON
+	pusch-ConfigCommon					PUSCH-ConfigCommon,
+	phich-Config						PHICH-Config						OPTIONAL,	-- Need ON
+	pucch-ConfigCommon					PUCCH-ConfigCommon					OPTIONAL,	-- Need ON
+	soundingRS-UL-ConfigCommon			SoundingRS-UL-ConfigCommon			OPTIONAL,	-- Need ON
+	uplinkPowerControlCommon			UplinkPowerControlCommon			OPTIONAL,	-- Need ON
+	antennaInfoCommon					AntennaInfoCommon					OPTIONAL,	-- Need ON
+	p-Max								P-Max								OPTIONAL,	-- Need OP
+	tdd-Config							TDD-Config							OPTIONAL,	-- Cond TDD
+	ul-CyclicPrefixLength				UL-CyclicPrefixLength,
+	...,
+	[[	uplinkPowerControlCommon-v1020	UplinkPowerControlCommon-v1020		OPTIONAL	-- Need ON
+	]],
+	[[	tdd-Config-v1130				TDD-Config-v1130					OPTIONAL	-- Cond TDD3
+	]],
+	[[	pusch-ConfigCommon-v1270		PUSCH-ConfigCommon-v1270			OPTIONAL	-- Need OR
+	]],
+	[[	
+		prach-Config-v1310				PRACH-Config-v1310					OPTIONAL,	-- Need ON
+		freqHoppingParameters-r13		FreqHoppingParameters-r13			OPTIONAL,	-- Need ON
+		pdsch-ConfigCommon-v1310		PDSCH-ConfigCommon-v1310			OPTIONAL,	-- Need ON
+		pucch-ConfigCommon-v1310		PUCCH-ConfigCommon-v1310			OPTIONAL,	-- Need ON
+		pusch-ConfigCommon-v1310		PUSCH-ConfigCommon-v1310			OPTIONAL,	-- Need ON
+		uplinkPowerControlCommon-v1310	UplinkPowerControlCommon-v1310		OPTIONAL	-- Need ON
+	]],
+	[[	highSpeedConfig-r14				HighSpeedConfig-r14					OPTIONAL,	-- Need OR
+		prach-Config-v1430				PRACH-Config-v1430					OPTIONAL,	-- Need OR
+		pucch-ConfigCommon-v1430		PUCCH-ConfigCommon-v1430			OPTIONAL,	-- Need OR
+		tdd-Config-v1430				TDD-Config-v1430					OPTIONAL	-- Cond TDD3
+	]],
+	[[
+		tdd-Config-v1450				TDD-Config-v1450					OPTIONAL	-- Cond TDD3
+	]],
+	[[	uplinkPowerControlCommon-v1530	UplinkPowerControlCommon-v1530		OPTIONAL,	-- Need ON
+		highSpeedConfig-v1530			HighSpeedConfig-v1530				OPTIONAL	-- Need OR
+	]],
+	[[
+		highSpeedConfig-v1610		HighSpeedConfig-v1610			OPTIONAL,	-- Need OR
+		uplinkPowerControlCommon-v1610	UplinkPowerControlCommon-v1610		OPTIONAL,	-- Need OR
+		highSpeedInterRAT-NR-r16		BOOLEAN								OPTIONAL	-- Need ON
+	]]
+}
+
+RadioResourceConfigCommonPSCell-r12 ::=	SEQUENCE {
+	basicFields-r12						RadioResourceConfigCommonSCell-r10,
+	pucch-ConfigCommon-r12				PUCCH-ConfigCommon,
+	rach-ConfigCommon-r12				RACH-ConfigCommon,
+	uplinkPowerControlCommonPSCell-r12	UplinkPowerControlCommonPSCell-r12,
+	...,
+	[[	uplinkPowerControlCommonPSCell-v1310
+									UplinkPowerControlCommon-v1310		OPTIONAL	-- Need ON
+	]],
+	[[	uplinkPowerControlCommonPSCell-v1530	
+									UplinkPowerControlCommon-v1530		OPTIONAL	-- Need ON
+	]]
+}
+
+RadioResourceConfigCommonPSCell-v12f0 ::=	SEQUENCE {
+	basicFields-v12f0					RadioResourceConfigCommonSCell-v10l0
+}
+
+RadioResourceConfigCommonPSCell-v1440 ::=	SEQUENCE {
+	basicFields-v1440					RadioResourceConfigCommonSCell-v1440
+}
+
+RadioResourceConfigCommonSCell-r10 ::=	SEQUENCE {
+	-- DL configuration as well as configuration applicable for DL and UL
+	nonUL-Configuration-r10					SEQUENCE {
+		-- 1: Cell characteristics
+		dl-Bandwidth-r10						ENUMERATED {n6, n15, n25, n50, n75, n100},
+		-- 2: Physical configuration, general
+		antennaInfoCommon-r10					AntennaInfoCommon,
+		mbsfn-SubframeConfigList-r10			MBSFN-SubframeConfigList	OPTIONAL,	-- Need OR
+		-- 3: Physical configuration, control
+		phich-Config-r10						PHICH-Config,
+		-- 4: Physical configuration, physical channels
+		pdsch-ConfigCommon-r10					PDSCH-ConfigCommon,
+		tdd-Config-r10							TDD-Config					OPTIONAL	-- Cond TDDSCell
+	},
+	-- UL configuration
+	ul-Configuration-r10				SEQUENCE {
+		ul-FreqInfo-r10						SEQUENCE {
+			ul-CarrierFreq-r10					ARFCN-ValueEUTRA			OPTIONAL,	-- Need OP
+			ul-Bandwidth-r10					ENUMERATED {n6, n15,
+													n25, n50, n75, n100}	OPTIONAL,	-- Need OP
+			additionalSpectrumEmissionSCell-r10		AdditionalSpectrumEmission
+		},
+		p-Max-r10							P-Max							OPTIONAL,	-- Need OP
+		uplinkPowerControlCommonSCell-r10		UplinkPowerControlCommonSCell-r10,
+		-- A special version of IE UplinkPowerControlCommon may be introduced
+		-- 3: Physical configuration, control
+		soundingRS-UL-ConfigCommon-r10		SoundingRS-UL-ConfigCommon,
+		ul-CyclicPrefixLength-r10			UL-CyclicPrefixLength,
+		-- 4: Physical configuration, physical channels
+		prach-ConfigSCell-r10					PRACH-ConfigSCell-r10		OPTIONAL,	-- Cond TDD-OR-NoR11
+		pusch-ConfigCommon-r10				PUSCH-ConfigCommon
+	}																		OPTIONAL,	-- Need OR
+	...,
+	[[	ul-CarrierFreq-v1090				ARFCN-ValueEUTRA-v9e0			OPTIONAL	-- Need OP
+	]],
+	[[	rach-ConfigCommonSCell-r11			RACH-ConfigCommonSCell-r11		OPTIONAL,	-- Cond ULSCell
+		prach-ConfigSCell-r11				PRACH-Config					OPTIONAL,	-- Cond UL
+		tdd-Config-v1130					TDD-Config-v1130				OPTIONAL,	-- Cond TDD2
+		uplinkPowerControlCommonSCell-v1130
+								UplinkPowerControlCommonSCell-v1130			OPTIONAL	-- Cond UL
+	]],
+	[[	pusch-ConfigCommon-v1270		PUSCH-ConfigCommon-v1270			OPTIONAL	-- Need OR
+	]],
+	[[	pucch-ConfigCommon-r13				PUCCH-ConfigCommon		OPTIONAL,	-- Cond UL
+		uplinkPowerControlCommonSCell-v1310
+								UplinkPowerControlCommonSCell-v1310	OPTIONAL	-- Cond UL
+	]],
+	[[	highSpeedConfigSCell-r14		HighSpeedConfigSCell-r14			OPTIONAL,	-- Need OR
+		prach-Config-v1430				PRACH-Config-v1430					OPTIONAL,	-- Cond UL
+	ul-Configuration-r14				SEQUENCE {
+		ul-FreqInfo-r14						SEQUENCE {
+			ul-CarrierFreq-r14					ARFCN-ValueEUTRA-r9			OPTIONAL,	-- Need OP
+			ul-Bandwidth-r14					ENUMERATED {n6, n15,
+													n25, n50, n75, n100}	OPTIONAL,	-- Need OP
+			additionalSpectrumEmissionSCell-r14		AdditionalSpectrumEmission
+		},
+		p-Max-r14							P-Max							OPTIONAL,	-- Need OP
+		soundingRS-UL-ConfigCommon-r14		SoundingRS-UL-ConfigCommon,
+		ul-CyclicPrefixLength-r14			UL-CyclicPrefixLength,
+		prach-ConfigSCell-r14					PRACH-ConfigSCell-r10		OPTIONAL,	-- Cond TDD-OR-NoR11		
+		uplinkPowerControlCommonPUSCH-LessCell-v1430
+					UplinkPowerControlCommonPUSCH-LessCell-v1430	OPTIONAL	-- Need OR
+}																	OPTIONAL,	-- Cond ULSRS
+	harq-ReferenceConfig-r14					ENUMERATED {sa2,sa4,sa5}	OPTIONAL,		-- Need OR
+	soundingRS-FlexibleTiming-r14			ENUMERATED {true}			OPTIONAL		-- Need OR
+	]],
+	[[	mbsfn-SubframeConfigList-v1430		MBSFN-SubframeConfigList-v1430		OPTIONAL -- Need ON
+	]],
+	[[	uplinkPowerControlCommonSCell-v1530	UplinkPowerControlCommon-v1530		OPTIONAL -- Need ON
+	]],
+	[[	highSpeedEnhMeasFlagSCell-r16			BOOLEAN						OPTIONAL -- Need ON
+    ]]
+}
+
+RadioResourceConfigCommonSCell-v10l0 ::=	SEQUENCE {
+	-- UL configuration
+	ul-Configuration-v10l0				SEQUENCE {
+		additionalSpectrumEmissionSCell-v10l0		AdditionalSpectrumEmission-v10l0
+	}
+}
+
+RadioResourceConfigCommonSCell-v1440 ::=	SEQUENCE {
+	ul-Configuration-v1440				SEQUENCE {
+		ul-FreqInfo-v1440						SEQUENCE {
+			additionalSpectrumEmissionSCell-v1440		AdditionalSpectrumEmission-v10l0
+		}
+	}
+}
+
+BCCH-Config ::=						SEQUENCE {
+	modificationPeriodCoeff				ENUMERATED {n2, n4, n8, n16}
+}
+
+BCCH-Config-v1310 ::=				SEQUENCE {
+	modificationPeriodCoeff-v1310		ENUMERATED {n64}
+}
+
+FreqHoppingParameters-r13 ::=		SEQUENCE {
+	dummy			ENUMERATED {nb2, nb4}				OPTIONAL,
+	dummy2			CHOICE {
+		interval-FDD-r13						ENUMERATED {int1, int2, int4, int8},
+		interval-TDD-r13						ENUMERATED {int1, int5, int10, int20}
+	}																		OPTIONAL,
+	dummy3			CHOICE {
+		interval-FDD-r13						ENUMERATED {int2, int4, int8, int16},
+		interval-TDD-r13						ENUMERATED { int5, int10, int20, int40}
+	}																								OPTIONAL,
+	interval-ULHoppingConfigCommonModeA-r13	CHOICE {
+		interval-FDD-r13						ENUMERATED {int1, int2, int4, int8},
+		interval-TDD-r13						ENUMERATED {int1, int5, int10, int20}
+	}																		OPTIONAL,	-- Cond MP-A
+	interval-ULHoppingConfigCommonModeB-r13	CHOICE {
+		interval-FDD-r13						ENUMERATED {int2, int4, int8, int16},
+		interval-TDD-r13						ENUMERATED { int5, int10, int20, int40}
+	}																		OPTIONAL,	-- Cond MP-B
+	dummy4				INTEGER (1..maxAvailNarrowBands-r13)			OPTIONAL
+}
+
+PCCH-Config ::=						SEQUENCE {
+	defaultPagingCycle					ENUMERATED {
+											rf32, rf64, rf128, rf256},
+	nB									ENUMERATED {
+											fourT, twoT, oneT, halfT, quarterT, oneEighthT,
+											oneSixteenthT, oneThirtySecondT}
+}
+
+PCCH-Config-v1310 ::=				SEQUENCE {
+	paging-narrowBands-r13				INTEGER (1..maxAvailNarrowBands-r13),
+	mpdcch-NumRepetition-Paging-r13		ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128, r256},
+	nB-v1310							ENUMERATED {one64thT, one128thT, one256thT}
+																			OPTIONAL	-- Need OR
+}
+
+UL-CyclicPrefixLength ::=			ENUMERATED {len1, len2}
+
+HighSpeedConfig-r14 ::=			SEQUENCE {
+	highSpeedEnhancedMeasFlag-r14			ENUMERATED {true}				OPTIONAL,	-- Need OR
+	highSpeedEnhancedDemodulationFlag-r14	ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+HighSpeedConfig-v1530 ::=		SEQUENCE {
+	highSpeedMeasGapCE-ModeA-r15			ENUMERATED {true}
+}
+
+HighSpeedConfigSCell-r14 ::=		SEQUENCE {
+	highSpeedEnhancedDemodulationFlag-r14	ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+HighSpeedConfig-v1610 ::=		SEQUENCE {
+	highSpeedEnhMeasFlag2-r16			ENUMERATED {true}			OPTIONAL,	-- Need OR
+	highSpeedEnhDemodFlag2-r16			ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+
+
+RadioResourceConfigDedicated ::=		SEQUENCE {
+	srb-ToAddModList					SRB-ToAddModList			OPTIONAL,		-- Cond HO-Conn
+	drb-ToAddModList					DRB-ToAddModList			OPTIONAL,		-- Cond HO-toEUTRA
+	drb-ToReleaseList					DRB-ToReleaseList			OPTIONAL,		-- Need ON
+	mac-MainConfig						CHOICE {
+			explicitValue					MAC-MainConfig,
+			defaultValue					NULL
+	}		OPTIONAL,																-- Cond HO-toEUTRA2
+	sps-Config							SPS-Config					OPTIONAL,		-- Need ON
+	physicalConfigDedicated				PhysicalConfigDedicated		OPTIONAL,		-- Need ON
+	...,
+	[[	rlf-TimersAndConstants-r9		RLF-TimersAndConstants-r9			OPTIONAL	-- Need ON
+	]],
+	[[	measSubframePatternPCell-r10	MeasSubframePatternPCell-r10		OPTIONAL	-- Need ON
+	]],
+	[[	neighCellsCRS-Info-r11			NeighCellsCRS-Info-r11				OPTIONAL	-- Need ON
+	]],
+	[[	naics-Info-r12				NAICS-AssistanceInfo-r12			OPTIONAL	-- Need ON
+	]],
+	[[	neighCellsCRS-Info-r13			NeighCellsCRS-Info-r13				OPTIONAL,	-- Cond CRSIM
+		rlf-TimersAndConstants-r13		RLF-TimersAndConstants-r13			OPTIONAL	-- Need ON
+	]],
+	[[	sps-Config-v1430				SPS-Config-v1430					OPTIONAL	-- Cond SPS
+	]],
+	[[	srb-ToAddModListExt-r15			SRB-ToAddModListExt-r15				OPTIONAL,	-- Need ON
+		srb-ToReleaseListExt-r15		INTEGER (4)							OPTIONAL,	-- Need ON
+
+		sps-Config-v1530				SPS-Config-v1530					OPTIONAL,	-- Need ON
+
+		crs-IntfMitigConfig-r15	CHOICE {
+			release					NULL,
+			setup					CHOICE {
+				crs-IntfMitigEnabled			NULL,
+				crs-IntfMitigNumPRBs	ENUMERATED {n6, n24}
+			}
+		}											OPTIONAL,		-- Need ON
+		neighCellsCRS-Info-r15			NeighCellsCRS-Info-r15		OPTIONAL,	-- Need ON
+		drb-ToAddModList-r15			DRB-ToAddModList-r15		OPTIONAL,		-- Need ON
+		drb-ToReleaseList-r15			DRB-ToReleaseList-r15		OPTIONAL,		-- Need ON
+		dummy							SEQUENCE (SIZE (1..2)) OF INTEGER (1..2)	OPTIONAL	-- Need ON
+	]],
+	[[	sps-Config-v1540				SPS-Config-v1540					OPTIONAL	-- Need ON
+	]],
+	[[
+		rlf-TimersAndConstantsMCG-Failure-r16	RLF-TimersAndConstantsMCG-Failure-r16
+														OPTIONAL,	-- Cond Split-SRB1-SRB3
+		crs-ChEstMPDCCH-ConfigDedicated-r16	SetupRelease{CRS-ChEstMPDCCH-ConfigDedicated-r16}	OPTIONAL,	-- Need ON
+		newUE-Identity-r16				C-RNTI						OPTIONAL		-- Need OP
+	]]
+}
+
+RadioResourceConfigDedicated-v1370 ::=		SEQUENCE {
+	physicalConfigDedicated-v1370		PhysicalConfigDedicated-v1370		OPTIONAL	-- Need ON
+}
+
+RadioResourceConfigDedicated-v13c0 ::=		SEQUENCE {
+	physicalConfigDedicated-v13c0		PhysicalConfigDedicated-v13c0
+}
+
+RadioResourceConfigDedicatedPSCell-r12 ::=		SEQUENCE {
+	-- UE specific configuration extensions applicable for an PSCell
+	physicalConfigDedicatedPSCell-r12		PhysicalConfigDedicated		OPTIONAL,	-- Need ON
+	sps-Config-r12							SPS-Config					OPTIONAL,	-- Need ON
+	naics-Info-r12							NAICS-AssistanceInfo-r12	OPTIONAL,	-- Need ON
+	...,
+	[[	neighCellsCRS-InfoPSCell-r13		NeighCellsCRS-Info-r13		OPTIONAL	-- Need ON
+	]],
+	[[	sps-Config-v1430				SPS-Config-v1430				OPTIONAL	-- Cond SPS2
+	]],
+	[[	sps-Config-v1530				SPS-Config-v1530				OPTIONAL,	-- Need ON
+		crs-IntfMitigEnabled-r15			BOOLEAN						OPTIONAL,	-- Need ON
+		neighCellsCRS-Info-r15				NeighCellsCRS-Info-r15		OPTIONAL	-- Need ON
+	]],
+	[[	sps-Config-v1540				SPS-Config-v1540				OPTIONAL	-- Need ON
+	]]
+}
+
+RadioResourceConfigDedicatedPSCell-v1370 ::=		SEQUENCE {
+	physicalConfigDedicatedPSCell-v1370		PhysicalConfigDedicated-v1370	OPTIONAL	-- Need ON
+}
+
+RadioResourceConfigDedicatedPSCell-v13c0 ::=		SEQUENCE {
+	physicalConfigDedicatedPSCell-v13c0		PhysicalConfigDedicated-v13c0
+}
+
+RadioResourceConfigDedicatedSCG-r12 ::=		SEQUENCE {
+	drb-ToAddModListSCG-r12				DRB-ToAddModListSCG-r12			OPTIONAL,	-- Need ON
+	mac-MainConfigSCG-r12				MAC-MainConfig					OPTIONAL,	-- Need ON
+	rlf-TimersAndConstantsSCG-r12		RLF-TimersAndConstantsSCG-r12	OPTIONAL,	-- Need ON
+	...,
+	[[	drb-ToAddModListSCG-r15			DRB-ToAddModListSCG-r15			OPTIONAL	-- Need ON
+	]],
+	[[	srb-ToAddModListSCG-r15			SRB-ToAddModList					OPTIONAL,	-- Need ON
+		srb-ToReleaseListSCG-r15			SRB-ToReleaseList-r15				OPTIONAL	-- Need ON
+	]],
+	[[	-- NE-DC additions for release of RLC bearer config for DRBs
+		drb-ToReleaseListSCG-r15		DRB-ToReleaseList-r15		OPTIONAL		-- Need ON
+	]]
+}
+
+RadioResourceConfigDedicatedSCell-r10 ::=	SEQUENCE {
+	-- UE specific configuration extensions applicable for an SCell
+	physicalConfigDedicatedSCell-r10		PhysicalConfigDedicatedSCell-r10	OPTIONAL,	-- Need ON
+	...,
+	[[	mac-MainConfigSCell-r11			MAC-MainConfigSCell-r11			OPTIONAL	-- Cond SCellAdd
+	]],
+	[[	naics-Info-r12				NAICS-AssistanceInfo-r12		OPTIONAL	-- Need ON
+	]],
+	[[	neighCellsCRS-InfoSCell-r13			NeighCellsCRS-Info-r13		OPTIONAL	-- Need ON
+	]],
+	[[	physicalConfigDedicatedSCell-v1370	PhysicalConfigDedicatedSCell-v1370	OPTIONAL	-- Need ON
+	]],
+	[[	crs-IntfMitigEnabled-r15			BOOLEAN						OPTIONAL,	-- Need ON
+		neighCellsCRS-Info-r15				NeighCellsCRS-Info-r15		OPTIONAL,	-- Need ON
+		sps-Config-v1530					SPS-Config-v1530			OPTIONAL	-- Need ON
+	]]
+}
+
+RadioResourceConfigDedicatedSCell-v13c0 ::=	SEQUENCE {
+	physicalConfigDedicatedSCell-v13c0	PhysicalConfigDedicatedSCell-v13c0
+}
+
+SRB-ToAddModList ::=				SEQUENCE (SIZE (1..2)) OF SRB-ToAddMod
+
+SRB-ToAddModListExt-r15 ::=				SEQUENCE (SIZE (1)) OF SRB-ToAddMod
+
+SRB-ToAddMod ::=	SEQUENCE {
+	srb-Identity						INTEGER (1..2),
+	rlc-Config							CHOICE {
+		explicitValue						RLC-Config,
+		defaultValue						NULL
+	}		OPTIONAL,																-- Cond Setup
+	logicalChannelConfig				CHOICE {
+		explicitValue						LogicalChannelConfig,
+		defaultValue						NULL
+	}		OPTIONAL,																-- Cond Setup
+	...,
+	[[	pdcp-verChange-r15				ENUMERATED {true}		OPTIONAL,			-- Cond NR-PDCP
+		rlc-Config-v1530				RLC-Config-v1530		OPTIONAL,			-- Need ON
+		rlc-BearerConfigSecondary-r15	RLC-BearerConfig-r15	OPTIONAL,			-- Need ON
+		srb-Identity-v1530				INTEGER (4)				OPTIONAL			-- Need ON
+	]],
+	[[	rlc-Config-v1560					RLC-Config-v1510		OPTIONAL		-- Need ON
+	]]
+}
+
+DRB-ToAddModList ::=				SEQUENCE (SIZE (1..maxDRB)) OF DRB-ToAddMod
+DRB-ToAddModList-r15 ::=			SEQUENCE (SIZE (1..maxDRB-r15)) OF DRB-ToAddMod
+
+DRB-ToAddModListSCG-r12 ::=		SEQUENCE (SIZE (1..maxDRB)) OF DRB-ToAddModSCG-r12
+DRB-ToAddModListSCG-r15 ::=		SEQUENCE (SIZE (1..maxDRB-r15)) OF DRB-ToAddModSCG-r12
+
+DRB-ToAddMod ::=	SEQUENCE {
+	eps-BearerIdentity					INTEGER (0..15)			OPTIONAL,		-- Cond DRB-Setup
+	drb-Identity						DRB-Identity,
+	pdcp-Config							PDCP-Config				OPTIONAL,		-- Cond PDCP
+	rlc-Config							RLC-Config				OPTIONAL,		-- Cond SetupM
+	logicalChannelIdentity				INTEGER (3..10)			OPTIONAL,		-- Cond DRB-SetupM
+	logicalChannelConfig				LogicalChannelConfig	OPTIONAL,		-- Cond SetupM
+	...,
+	[[	drb-TypeChange-r12					ENUMERATED {toMCG}		OPTIONAL,		-- Need OP
+		rlc-Config-v1250					RLC-Config-v1250		OPTIONAL		-- Need ON
+	]],
+	[[	rlc-Config-v1310					RLC-Config-v1310		OPTIONAL,		-- Need ON
+		drb-TypeLWA-r13						BOOLEAN					OPTIONAL,		-- Need ON
+		drb-TypeLWIP-r13					ENUMERATED {lwip, lwip-DL-only,
+											lwip-UL-only, eutran}		OPTIONAL		-- Need ON
+	]],
+	[[	rlc-Config-v1430					RLC-Config-v1430		OPTIONAL,		-- Need ON
+		lwip-UL-Aggregation-r14				BOOLEAN					OPTIONAL,		-- Cond LWIP
+		lwip-DL-Aggregation-r14				BOOLEAN					OPTIONAL,		-- Cond LWIP
+		lwa-WLAN-AC-r14			ENUMERATED {ac-bk, ac-be, ac-vi, ac-vo}	OPTIONAL	-- Cond UL-LWA
+	]],
+	[[	rlc-Config-v1510					RLC-Config-v1510		OPTIONAL		-- Need ON
+	]],
+	[[	rlc-Config-v1530					RLC-Config-v1530		OPTIONAL,		-- Need ON
+		rlc-BearerConfigSecondary-r15		RLC-BearerConfig-r15	OPTIONAL,		-- Need ON
+		logicalChannelIdentity-r15			INTEGER (32..38)		OPTIONAL		-- Need ON
+	]],
+	[[	daps-HO-r16							ENUMERATED {true}		OPTIONAL		-- Cond DAPS
+	]]
+}
+
+DRB-ToAddModSCG-r12 ::=	SEQUENCE {
+	drb-Identity-r12					DRB-Identity,
+	drb-Type-r12						CHOICE {
+		split-r12							NULL,
+		scg-r12								SEQUENCE {
+			eps-BearerIdentity-r12				INTEGER (0..15)	OPTIONAL,	-- Cond DRB-Setup
+			pdcp-Config-r12						PDCP-Config		OPTIONAL	-- Cond PDCP-S
+		}
+	}															OPTIONAL,	-- Cond SetupS2
+	rlc-ConfigSCG-r12					RLC-Config				OPTIONAL,	-- Cond SetupS
+	rlc-Config-v1250						RLC-Config-v1250			OPTIONAL,	-- Need ON
+	logicalChannelIdentitySCG-r12		INTEGER (3..10)			OPTIONAL,	-- Cond DRB-SetupS
+	logicalChannelConfigSCG-r12			LogicalChannelConfig	OPTIONAL,	-- Cond SetupS
+	...,
+	[[	rlc-Config-v1430					RLC-Config-v1430		OPTIONAL		-- Need ON
+	]],
+	[[	logicalChannelIdentitySCG-r15		INTEGER (32..38)	OPTIONAL,			-- Need ON
+		rlc-Config-v1530					RLC-Config-v1530		OPTIONAL,		-- Need ON
+		rlc-BearerConfigSecondary-r15		RLC-BearerConfig-r15	OPTIONAL		-- Need ON
+	]],
+	[[	rlc-Config-v1560					RLC-Config-v1510		OPTIONAL		-- Need ON
+	]]
+}
+
+DRB-ToReleaseList ::=				SEQUENCE (SIZE (1..maxDRB)) OF DRB-Identity
+DRB-ToReleaseList-r15 ::=			SEQUENCE (SIZE (1..maxDRB-r15)) OF DRB-Identity
+
+SRB-ToReleaseList-r15 ::=			SEQUENCE (SIZE (1..2)) OF INTEGER (1..2)
+
+MeasSubframePatternPCell-r10 ::=		CHOICE {
+	release								NULL,
+	setup							MeasSubframePattern-r10
+}
+
+NeighCellsCRS-Info-r11 ::=		CHOICE {
+	release							NULL,
+	setup							CRS-AssistanceInfoList-r11
+}
+
+CRS-AssistanceInfoList-r11 ::=	SEQUENCE (SIZE (1..maxCellReport)) OF CRS-AssistanceInfo-r11
+
+CRS-AssistanceInfo-r11 ::= SEQUENCE {
+	physCellId-r11						PhysCellId,
+	antennaPortsCount-r11				ENUMERATED {an1, an2, an4, spare1},
+	mbsfn-SubframeConfigList-r11		MBSFN-SubframeConfigList,
+	...,
+	[[	mbsfn-SubframeConfigList-v1430	MBSFN-SubframeConfigList-v1430		OPTIONAL	-- Need ON
+	]]
+}
+
+NeighCellsCRS-Info-r13 ::=		CHOICE {
+	release							NULL,
+	setup							CRS-AssistanceInfoList-r13
+}
+
+CRS-AssistanceInfoList-r13 ::=	SEQUENCE (SIZE (1..maxCellReport)) OF CRS-AssistanceInfo-r13
+
+CRS-AssistanceInfo-r13 ::= SEQUENCE {
+	physCellId-r13						PhysCellId,
+	antennaPortsCount-r13				ENUMERATED {an1, an2, an4, spare1},
+	mbsfn-SubframeConfigList-r13		MBSFN-SubframeConfigList			OPTIONAL,	-- Need ON
+	...,
+	[[	mbsfn-SubframeConfigList-v1430	MBSFN-SubframeConfigList-v1430		OPTIONAL	-- Need ON
+	]]
+}
+
+NeighCellsCRS-Info-r15 ::= CHOICE {
+	release								NULL,
+	setup								CRS-AssistanceInfoList-r15
+}
+
+CRS-AssistanceInfoList-r15 ::= SEQUENCE (SIZE (1..maxCellReport)) OF CRS-AssistanceInfo-r15
+
+CRS-AssistanceInfo-r15 ::= SEQUENCE {
+	physCellId-r15						PhysCellId,
+	crs-IntfMitigEnabled-r15			ENUMERATED {enabled}				OPTIONAL	-- Need ON
+}
+
+NAICS-AssistanceInfo-r12 ::=		CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		neighCellsToReleaseList-r12		NeighCellsToReleaseList-r12			OPTIONAL	,	-- Need ON
+		neighCellsToAddModList-r12		NeighCellsToAddModList-r12			OPTIONAL,	-- Need ON
+		servCellp-a-r12					P-a								OPTIONAL	-- Need ON
+	}
+}
+
+NeighCellsToReleaseList-r12 ::=	SEQUENCE (SIZE (1..maxNeighCell-r12)) OF PhysCellId
+
+NeighCellsToAddModList-r12 ::=	SEQUENCE (SIZE (1..maxNeighCell-r12)) OF NeighCellsInfo-r12
+
+NeighCellsInfo-r12	::=		SEQUENCE {
+	physCellId-r12					PhysCellId,
+	p-b-r12						INTEGER (0..3),
+	crs-PortsCount-r12				ENUMERATED {n1, n2, n4, spare},
+	mbsfn-SubframeConfig-r12		MBSFN-SubframeConfigList				OPTIONAL,	-- Need ON
+	p-aList-r12					SEQUENCE (SIZE (1..maxP-a-PerNeighCell-r12)) OF P-a,
+	transmissionModeList-r12		BIT STRING (SIZE(8)),
+	resAllocGranularity-r12			INTEGER (1..4),
+	...
+}
+P-a ::= ENUMERATED {	dB-6, dB-4dot77, dB-3, dB-1dot77,
+									dB0, dB1, dB2, dB3}
+
+RLC-BearerConfig-r15 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		rlc-Config-r15						RLC-Config-r15				OPTIONAL,	-- Need ON
+		logicalChannelIdentityConfig-r15	CHOICE {
+			logicalChannelIdentity-r15			INTEGER (1..10),
+			logicalChannelIdentityExt-r15		INTEGER (32..38)
+		},
+		logicalChannelConfig-r15			LogicalChannelConfig		OPTIONAL	-- Need ON
+	}
+}
+
+
+
+RCLWI-Configuration-r13 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		rclwi-Config-r13					RCLWI-Config-r13
+	}
+}
+
+RCLWI-Config-r13 ::=				SEQUENCE {
+	command								CHOICE {
+		steerToWLAN-r13						SEQUENCE {
+			mobilityConfig-r13					WLAN-Id-List-r12
+		},
+		steerToLTE-r13						NULL
+	},
+	...
+}
+
+
+
+ResourceReservationConfigDL-r16 ::= SEQUENCE {
+	periodicityStartPos-r16		PeriodicityStartPos-r16,
+	resourceReservationFreq-r16	CHOICE {
+		rbg-Bitmap1dot4				BIT STRING (SIZE (6)),
+		rbg-Bitmap3					BIT STRING (SIZE (8)),
+		rbg-Bitmap5					BIT STRING (SIZE (13)),
+		rbg-Bitmap10				BIT STRING (SIZE (17)),
+		rbg-Bitmap15				BIT STRING (SIZE (19)),
+		rbg-Bitmap20				BIT STRING (SIZE (25))
+	}	OPTIONAL, -- Need OP
+	slotBitmap-r16				CHOICE {
+		slotPattern10ms				BIT STRING (SIZE (20)),
+		slotPattern40ms				BIT STRING (SIZE (80))
+	},
+	symbolBitmap1-r16			BIT STRING (SIZE (7))	OPTIONAL,	-- Cond Bitmap1
+	symbolBitmap2-r16			BIT STRING (SIZE (7))	OPTIONAL,	-- Cond Bitmap2
+	...
+}
+
+ResourceReservationConfigUL-r16 ::= SEQUENCE {
+	periodicityStartPos-r16		PeriodicityStartPos-r16,
+	slotBitmap-r16				CHOICE {
+		slotPattern10ms				BIT STRING (SIZE (20)),
+		slotPattern40ms				BIT STRING (SIZE (80))
+	} OPTIONAL,	-- Cond FDDandTDDnoDL
+	symbolBitmap1-r16			BIT STRING (SIZE (7))	OPTIONAL,	-- Cond Bitmap1
+	symbolBitmap2-r16			BIT STRING (SIZE (7))	OPTIONAL,	-- Cond Bitmap2
+	...
+}
+
+PeriodicityStartPos-r16 ::=		CHOICE {
+	periodicity10ms					NULL,
+	periodicity20ms					INTEGER(0..1),
+	periodicity40ms					INTEGER(0..3),
+	periodicity80ms					INTEGER(0..7),
+	periodicity160ms				INTEGER(0..15),
+	spare3 NULL, spare2 NULL, spare1 NULL
+}
+
+
+
+RLC-Config ::=				CHOICE {
+	am									SEQUENCE {
+		ul-AM-RLC							UL-AM-RLC,
+		dl-AM-RLC							DL-AM-RLC
+	},
+	um-Bi-Directional					SEQUENCE {
+		ul-UM-RLC							UL-UM-RLC,
+		dl-UM-RLC							DL-UM-RLC
+	},
+	um-Uni-Directional-UL				SEQUENCE {
+		ul-UM-RLC							UL-UM-RLC
+	},
+	um-Uni-Directional-DL				SEQUENCE {
+		dl-UM-RLC							DL-UM-RLC
+	},
+	...
+}
+
+RLC-Config-v1250 ::=				SEQUENCE {
+	ul-extended-RLC-LI-Field-r12			BOOLEAN,
+	dl-extended-RLC-LI-Field-r12			BOOLEAN
+}
+
+RLC-Config-v1310 ::=				SEQUENCE {
+	ul-extended-RLC-AM-SN-r13					BOOLEAN,
+	dl-extended-RLC-AM-SN-r13					BOOLEAN,
+	pollPDU-v1310								PollPDU-v1310		OPTIONAL	-- Need OR
+}
+
+RLC-Config-v1430 ::=				CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		pollByte-r14						PollByte-r14
+	}
+}
+
+RLC-Config-v1510 ::=				SEQUENCE {
+	reestablishRLC-r15				ENUMERATED {true}
+}
+
+RLC-Config-v1530 ::=				CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		rlc-OutOfOrderDelivery-r15			ENUMERATED {true}
+	}
+}
+
+RLC-Config-r15 ::=				SEQUENCE {
+	mode-r15								CHOICE {
+		am-r15								SEQUENCE {
+			ul-AM-RLC-r15						UL-AM-RLC-r15,
+			dl-AM-RLC-r15						DL-AM-RLC-r15
+		},
+		um-Bi-Directional-r15				SEQUENCE {
+			ul-UM-RLC-r15						UL-UM-RLC,
+			dl-UM-RLC-r15						DL-UM-RLC-r15
+		},
+		um-Uni-Directional-UL-r15			SEQUENCE {
+			ul-UM-RLC-r15						UL-UM-RLC
+		},
+		um-Uni-Directional-DL-r15			SEQUENCE {
+			dl-UM-RLC-r15						DL-UM-RLC-r15
+		}
+	},
+	reestablishRLC-r15					ENUMERATED {true}				OPTIONAL,	-- Need ON
+	rlc-OutOfOrderDelivery-r15			ENUMERATED {true}				OPTIONAL,	-- Need ON
+	...
+}
+
+UL-AM-RLC ::=						SEQUENCE {
+	t-PollRetransmit					T-PollRetransmit,
+	pollPDU								PollPDU,
+	pollByte							PollByte,
+	maxRetxThreshold					ENUMERATED {
+											t1, t2, t3, t4, t6, t8, t16, t32}
+}
+
+UL-AM-RLC-r15 ::=					SEQUENCE {
+	t-PollRetransmit-r15				T-PollRetransmit,
+	pollPDU-r15							PollPDU-r15,
+	pollByte-r15						PollByte-r14,
+	maxRetxThreshold-r15				ENUMERATED {
+											t1, t2, t3, t4, t6, t8, t16, t32},
+	extended-RLC-LI-Field-r15			BOOLEAN
+}
+
+DL-AM-RLC ::=						SEQUENCE {
+	t-Reordering						T-Reordering,
+	t-StatusProhibit					T-StatusProhibit
+}
+
+DL-AM-RLC-r15 ::=					SEQUENCE {
+	t-Reordering-r15					T-Reordering,
+	t-StatusProhibit-r15				T-StatusProhibit,
+	extended-RLC-LI-Field-r15			BOOLEAN
+}
+
+UL-UM-RLC ::=						SEQUENCE {
+	sn-FieldLength						SN-FieldLength
+}
+
+DL-UM-RLC ::=						SEQUENCE {
+	sn-FieldLength						SN-FieldLength,
+	t-Reordering						T-Reordering
+}
+
+DL-UM-RLC-r15 ::=					SEQUENCE {
+	sn-FieldLength-r15					SN-FieldLength-r15,
+	t-Reordering-r15					T-Reordering
+}
+
+SN-FieldLength ::=					ENUMERATED {size5, size10}
+
+SN-FieldLength-r15 ::=				ENUMERATED {size5, size10, size16-r15}
+
+T-PollRetransmit ::=				ENUMERATED {
+										ms5, ms10, ms15, ms20, ms25, ms30, ms35,
+										ms40, ms45, ms50, ms55, ms60, ms65, ms70,
+										ms75, ms80, ms85, ms90, ms95, ms100, ms105,
+										ms110, ms115, ms120, ms125, ms130, ms135,
+										ms140, ms145, ms150, ms155, ms160, ms165,
+										ms170, ms175, ms180, ms185, ms190, ms195,
+										ms200, ms205, ms210, ms215, ms220, ms225,
+										ms230, ms235, ms240, ms245, ms250, ms300,
+										ms350, ms400, ms450, ms500, ms800-v1310,
+										ms1000-v1310, ms2000-v1310, ms4000-v1310,
+										spare5, spare4, spare3, spare2, spare1}
+
+PollPDU ::=							ENUMERATED {
+										p4, p8, p16, p32, p64, p128, p256, pInfinity}
+
+PollPDU-v1310 ::=					ENUMERATED {
+										p512, p1024, p2048, p4096, p6144, p8192, p12288, p16384}
+
+PollPDU-r15 ::=						ENUMERATED {
+										p4, p8, p16, p32, p64, p128, p256, p512, p1024,
+										p2048-r15, p4096-r15, p6144-r15, p8192-r15,
+										p12288-r15, p16384-r15, pInfinity}
+
+PollByte ::=						ENUMERATED {
+										kB25, kB50, kB75, kB100, kB125, kB250, kB375,
+										kB500, kB750, kB1000, kB1250, kB1500, kB2000,
+										kB3000, kBinfinity, spare1}
+
+PollByte-r14 ::=					ENUMERATED {
+										kB1, kB2, kB5, kB8, kB10, kB15, kB3500,
+										kB4000, kB4500, kB5000, kB5500, kB6000, kB6500,
+										kB7000, kB7500, kB8000, kB9000, kB10000, kB11000, kB12000,
+										kB13000, kB14000, kB15000, kB16000, kB17000, kB18000,
+										kB19000, kB20000, kB25000, kB30000, kB35000, kB40000}
+
+T-Reordering ::=					ENUMERATED {
+										ms0, ms5, ms10, ms15, ms20, ms25, ms30, ms35,
+										ms40, ms45, ms50, ms55, ms60, ms65, ms70,
+										ms75, ms80, ms85, ms90, ms95, ms100, ms110,
+										ms120, ms130, ms140, ms150, ms160, ms170,
+										ms180, ms190, ms200, ms1600-v1310}
+
+T-StatusProhibit ::=				ENUMERATED {
+										ms0, ms5, ms10, ms15, ms20, ms25, ms30, ms35,
+										ms40, ms45, ms50, ms55, ms60, ms65, ms70,
+										ms75, ms80, ms85, ms90, ms95, ms100, ms105,
+										ms110, ms115, ms120, ms125, ms130, ms135,
+										ms140, ms145, ms150, ms155, ms160, ms165,
+										ms170, ms175, ms180, ms185, ms190, ms195,
+										ms200, ms205, ms210, ms215, ms220, ms225,
+										ms230, ms235, ms240, ms245, ms250, ms300,
+										ms350, ms400, ms450, ms500, ms800-v1310,
+										ms1000-v1310, ms1200-v1310, ms1600-v1310, ms2000-v1310, ms2400-v1310, spare2,
+										spare1}
+
+
+
+RLF-TimersAndConstants-r9 ::=			CHOICE {
+	release									NULL,
+	setup									SEQUENCE {
+		t301-r9								ENUMERATED {
+												ms100, ms200, ms300, ms400, ms600, ms1000, ms1500,
+												ms2000},
+		t310-r9								ENUMERATED {
+												ms0, ms50, ms100, ms200, ms500, ms1000, ms2000},
+		n310-r9								ENUMERATED {
+												n1, n2, n3, n4, n6, n8, n10, n20},
+		t311-r9								ENUMERATED {
+												ms1000, ms3000, ms5000, ms10000, ms15000,
+												ms20000, ms30000},
+		n311-r9								ENUMERATED {
+												n1, n2, n3, n4, n5, n6, n8, n10},
+		...
+	}
+}
+
+RLF-TimersAndConstants-r13 ::=			CHOICE {
+	release									NULL,
+	setup									SEQUENCE {
+		t301-v1310								ENUMERATED {
+													ms2500, ms3000, ms3500, ms4000, ms5000,
+													ms6000, ms8000, ms10000},
+		...,
+		[[	t310-v1330							ENUMERATED {ms4000, ms6000}	OPTIONAL	-- Need ON
+		]]
+	}
+}
+
+RLF-TimersAndConstantsSCG-r12 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		t313-r12							ENUMERATED {
+												ms0, ms50, ms100, ms200, ms500, ms1000, ms2000},
+		n313-r12							ENUMERATED {
+												n1, n2, n3, n4, n6, n8, n10, n20},
+		n314-r12							ENUMERATED {
+												n1, n2, n3, n4, n5, n6, n8, n10},
+		...
+	}
+}
+
+RLF-TimersAndConstantsMCG-Failure-r16 ::=	CHOICE {
+	release									NULL,
+	setup									SEQUENCE {
+		t316-r16								ENUMERATED {ms50, ms100, ms200, ms300, ms400,
+													ms500, ms600, ms1000, ms1500, ms2000},
+		...
+	}
+}
+
+
+
+RN-SubframeConfig-r10 ::=		SEQUENCE {
+	subframeConfigPattern-r10			CHOICE {
+		subframeConfigPatternFDD-r10	BIT STRING (SIZE(8)),
+		subframeConfigPatternTDD-r10	INTEGER (0..31)
+	}																	OPTIONAL,	-- Need ON
+	rpdcch-Config-r10				SEQUENCE {
+		resourceAllocationType-r10		ENUMERATED {type0, type1, type2Localized, type2Distributed,
+													spare4, spare3, spare2, spare1},
+		resourceBlockAssignment-r10			CHOICE {
+			type01-r10							CHOICE {
+				nrb6-r10							BIT STRING (SIZE(6)),
+				nrb15-r10							BIT STRING (SIZE(8)),
+				nrb25-r10							BIT STRING (SIZE(13)),
+				nrb50-r10							BIT STRING (SIZE(17)),
+				nrb75-r10							BIT STRING (SIZE(19)),
+				nrb100-r10							BIT STRING (SIZE(25))
+			},
+			type2-r10							CHOICE {
+				nrb6-r10							BIT STRING (SIZE(5)),
+				nrb15-r10							BIT STRING (SIZE(7)),
+				nrb25-r10							BIT STRING (SIZE(9)),
+				nrb50-r10							BIT STRING (SIZE(11)),
+				nrb75-r10							BIT STRING (SIZE(12)),
+				nrb100-r10							BIT STRING (SIZE(13))
+			},
+			...
+		},
+		demodulationRS-r10				CHOICE {
+			interleaving-r10				ENUMERATED {crs},
+			noInterleaving-r10				ENUMERATED {crs, dmrs}
+		},
+		pdsch-Start-r10					INTEGER (1..3),
+		pucch-Config-r10				CHOICE {
+			tdd								CHOICE {
+				channelSelectionMultiplexingBundling	SEQUENCE {
+					n1PUCCH-AN-List-r10			SEQUENCE (SIZE (1..4)) OF INTEGER (0..2047)
+				},
+				fallbackForFormat3				SEQUENCE {
+					n1PUCCH-AN-P0-r10				INTEGER (0..2047),
+					n1PUCCH-AN-P1-r10				INTEGER (0..2047)		OPTIONAL	-- Need OR
+				}
+			},
+			fdd								SEQUENCE {
+				n1PUCCH-AN-P0-r10				INTEGER (0..2047),
+				n1PUCCH-AN-P1-r10				INTEGER (0..2047)			OPTIONAL	-- Need OR
+			}
+		},
+		...
+	}																	OPTIONAL,	-- Need ON
+	...
+}
+
+
+
+RSS-Config-r15 ::=				SEQUENCE {
+	duration-r15					ENUMERATED {sf8, sf16, sf32, sf40},
+	freqLocation-r15					INTEGER (0..98),
+	periodicity-r15					ENUMERATED {ms160, ms320, ms640, ms1280},
+	powerBoost-r15					ENUMERATED {dB0, dB3, dB4dot8, dB6},
+	timeOffset-r15					INTEGER (0..31)
+}
+
+
+
+SchedulingRequestConfig ::=		CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		sr-PUCCH-ResourceIndex				INTEGER (0..2047),
+		sr-ConfigIndex						INTEGER (0..157),
+		dsr-TransMax						ENUMERATED {
+												n4, n8, n16, n32, n64, spare3, spare2, spare1}
+	}
+}
+
+SchedulingRequestConfig-v1020 ::=	SEQUENCE {
+	sr-PUCCH-ResourceIndexP1-r10		INTEGER (0..2047)			OPTIONAL		-- Need OR
+}
+
+SchedulingRequestConfigSCell-r13 ::=		CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		sr-PUCCH-ResourceIndex-r13			INTEGER (0..2047),
+		sr-PUCCH-ResourceIndexP1-r13		INTEGER (0..2047)			OPTIONAL,		-- Need OR
+		sr-ConfigIndex-r13					INTEGER (0..157),
+		dsr-TransMax-r13					ENUMERATED {
+												n4, n8, n16, n32, n64, spare3, spare2, spare1}
+	}
+	
+}
+
+SchedulingRequestConfig-v1530 ::=	CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		sr-SlotSPUCCH-IndexFH-r15			INTEGER (0..1319)		OPTIONAL, -- Need OR
+		sr-SlotSPUCCH-IndexNoFH-r15		INTEGER (0..3959)		OPTIONAL, -- Need OR
+		sr-SubslotSPUCCH-ResourceList-r15	SR-SubslotSPUCCH-ResourceList-r15 OPTIONAL, -- Need OR
+		sr-ConfigIndexSlot-r15				INTEGER (0..36)			OPTIONAL,		-- Need OR
+		sr-ConfigIndexSubslot-r15			INTEGER (0..122)		OPTIONAL,		-- Need OR
+		dssr-TransMax-r15					ENUMERATED {
+												n4, n8, n16, n32, n64, spare3, spare2, spare1}
+	}
+}
+
+SR-SubslotSPUCCH-ResourceList-r15 ::=	SEQUENCE (SIZE(1..4)) OF INTEGER (0..1319)
+
+
+
+SlotOrSubslotPDSCH-Config-r15 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		altCQI-TableSTTI-r15			ENUMERATED {
+											allSubframes, csi-SubframeSet1,
+											csi-SubframeSet2, spare1}			OPTIONAL, -- Need OR
+		altCQI-Table1024QAM-STTI-r15	ENUMERATED {
+											allSubframes, csi-SubframeSet1,
+											csi-SubframeSet2, spare1}			OPTIONAL, -- Need OR
+		resourceAllocation-r15			ENUMERATED {
+							resourceAllocationType0,resourceAllocationType2}	OPTIONAL, -- Need OR
+		tbsIndexAlt-STTI-r15			ENUMERATED {a33}			OPTIONAL, -- Need OR
+		tbsIndexAlt2-STTI-r15			ENUMERATED {b33}			OPTIONAL, -- Need OR
+		tbsIndexAlt3-STTI-r15			ENUMERATED {a37}			OPTIONAL, -- Need OR
+			...
+	}
+}
+
+
+
+SlotOrSubslotPUSCH-Config-r15 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		betaOffsetSlot-ACK-Index-r15		INTEGER(0..15)		OPTIONAL, -- Need OR
+		betaOffset2Slot-ACK-Index-r15		INTEGER(0..15)		OPTIONAL, -- Need OR
+		betaOffsetSubslot-ACK-Index-r15		SEQUENCE (SIZE(1..2)) OF INTEGER(0..15)	OPTIONAL, -- Need OR
+		betaOffset2Subslot-ACK-Index-r15	SEQUENCE (SIZE(1..2)) OF INTEGER(0..15) OPTIONAL, -- Need OR
+		betaOffsetSlot-RI-Index-r15			INTEGER(0..15)		OPTIONAL, -- Need OR
+		betaOffsetSubslot-RI-Index-r15		SEQUENCE (SIZE(1..2)) OF INTEGER(0..15)	OPTIONAL, -- Need OR
+		betaOffsetSlot-CQI-Index-r15		INTEGER(0..15)		OPTIONAL, -- Need OR
+		betaOffsetSubslot-CQI-Index-r15		INTEGER(0..15)		OPTIONAL, -- Need OR
+		enable256QAM-SlotOrSubslot-r15		Enable256QAM-r14	OPTIONAL, -- Need ON
+		resourceAllocationOffset-r15		INTEGER (1..2)		OPTIONAL, -- Need OR
+		ul-DMRS-IFDMA-SlotOrSubslot-r15		BOOLEAN,
+		...
+	}
+}
+
+
+
+SoundingRS-UL-ConfigCommon ::=		CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		srs-BandwidthConfig					ENUMERATED {bw0, bw1, bw2, bw3, bw4, bw5, bw6, bw7},
+		srs-SubframeConfig					ENUMERATED {
+												sc0, sc1, sc2, sc3, sc4, sc5, sc6, sc7,
+												sc8, sc9, sc10, sc11, sc12, sc13, sc14, sc15},
+		ackNackSRS-SimultaneousTransmission	BOOLEAN,
+		srs-MaxUpPts						ENUMERATED {true}			OPTIONAL	-- Cond TDD
+	}
+}
+
+SoundingRS-UL-ConfigDedicated ::=	CHOICE{
+	release								NULL,
+	setup								SEQUENCE {
+		srs-Bandwidth						ENUMERATED {bw0, bw1, bw2, bw3},
+		srs-HoppingBandwidth				ENUMERATED {hbw0, hbw1, hbw2, hbw3},
+		freqDomainPosition					INTEGER (0..23),
+		duration							BOOLEAN,
+		srs-ConfigIndex						INTEGER (0..1023),
+		transmissionComb					INTEGER (0..1),
+		cyclicShift							ENUMERATED {cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7}
+	}
+}
+
+SoundingRS-UL-ConfigDedicated-v1020 ::=	SEQUENCE {
+	srs-AntennaPort-r10					SRS-AntennaPort
+}
+
+SoundingRS-UL-ConfigDedicated-v1310 ::=	CHOICE{
+	release								NULL,
+	setup								SEQUENCE {
+		transmissionComb-v1310				INTEGER (2..3)				OPTIONAL,	-- Need OR
+		cyclicShift-v1310					ENUMERATED {cs8, cs9, cs10, cs11}	OPTIONAL,	-- Need OR
+		transmissionCombNum-r13				ENUMERATED {n2, n4}		OPTIONAL	-- Need OR
+	}
+}
+
+SoundingRS-UL-ConfigDedicatedUpPTsExt-r13 ::=	CHOICE{
+	release								NULL,
+	setup								SEQUENCE {
+		srs-UpPtsAdd-r13						ENUMERATED {sym2, sym4},
+		srs-Bandwidth-r13					ENUMERATED {bw0, bw1, bw2, bw3},
+		srs-HoppingBandwidth-r13			ENUMERATED {hbw0, hbw1, hbw2, hbw3},
+		freqDomainPosition-r13				INTEGER (0..23),
+		duration-r13						BOOLEAN,
+		srs-ConfigIndex-r13					INTEGER (0..1023),
+		transmissionComb-r13				INTEGER (0..3),
+		cyclicShift-r13						ENUMERATED {cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+														cs8, cs9, cs10, cs11},
+		srs-AntennaPort-r13					SRS-AntennaPort,
+		transmissionCombNum-r13				ENUMERATED {n2, n4}
+	}
+}
+
+SoundingRS-UL-ConfigDedicatedAperiodic-r10 ::=	CHOICE{
+	release								NULL,
+	setup								SEQUENCE {
+		srs-ConfigIndexAp-r10				INTEGER (0..31),
+		srs-ConfigApDCI-Format4-r10			SEQUENCE (SIZE (1..3)) OF SRS-ConfigAp-r10	OPTIONAL,--Need ON
+		srs-ActivateAp-r10					CHOICE {
+				release							NULL,
+				setup							SEQUENCE {
+					srs-ConfigApDCI-Format0-r10			SRS-ConfigAp-r10,
+					srs-ConfigApDCI-Format1a2b2c-r10		SRS-ConfigAp-r10,
+					...
+				}
+		}																	OPTIONAL	-- Need ON
+	}
+}
+
+SoundingRS-UL-ConfigDedicatedAperiodic-v1310 ::=	CHOICE{
+	release								NULL,
+	setup								SEQUENCE {
+		srs-ConfigApDCI-Format4-v1310		SEQUENCE (SIZE (1..3)) OF SRS-ConfigAp-v1310	OPTIONAL,--Need ON
+		srs-ActivateAp-v1310				CHOICE {
+				release							NULL,
+				setup							SEQUENCE {
+					srs-ConfigApDCI-Format0-v1310		SRS-ConfigAp-v1310	OPTIONAL,	-- Need ON
+					srs-ConfigApDCI-Format1a2b2c-v1310	SRS-ConfigAp-v1310	OPTIONAL	-- Need ON
+				}
+		}																	OPTIONAL	-- Need ON
+	}
+}
+
+SoundingRS-UL-ConfigDedicatedAperiodicUpPTsExt-r13 ::=	CHOICE{
+	release								NULL,
+	setup								SEQUENCE {
+		srs-UpPtsAdd-r13					ENUMERATED {sym2, sym4},
+		srs-ConfigIndexAp-r13				INTEGER (0..31),
+		srs-ConfigApDCI-Format4-r13			SEQUENCE (SIZE (1..3)) OF SRS-ConfigAp-r13	OPTIONAL,--Need ON
+		srs-ActivateAp-r13					CHOICE {
+				release							NULL,
+				setup							SEQUENCE {
+					srs-ConfigApDCI-Format0-r13			SRS-ConfigAp-r13,
+					srs-ConfigApDCI-Format1a2b2c-r13		SRS-ConfigAp-r13
+				}
+		}																	OPTIONAL	-- Need ON
+	}
+}
+
+SoundingRS-UL-ConfigDedicatedAperiodic-v1430 ::=	CHOICE{
+	release								NULL,
+	setup								SEQUENCE {		
+		srs-SubframeIndication-r14			INTEGER (1..4)	OPTIONAL		-- Need ON
+	}
+}
+
+SoundingRS-UL-ConfigDedicatedAdd-r16 ::= SEQUENCE {
+		srs-ConfigIndexAp-r16				INTEGER (0..31),
+		srs-ConfigApDCI-Format4-r16			SEQUENCE (SIZE (1..3)) OF SRS-ConfigAdd-r16
+																	OPTIONAL,	--Need ON
+		srs-ActivateAp-r13					CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+			srs-ConfigApDCI-Format0-r16			SRS-ConfigAdd-r16,
+			srs-ConfigApDCI-Format1a2b2c-r16	SRS-ConfigAdd-r16
+		}
+	}																OPTIONAL	--Need ON
+}
+
+SRS-ConfigAp-r10 ::= SEQUENCE {
+	srs-AntennaPortAp-r10				SRS-AntennaPort,
+	srs-BandwidthAp-r10					ENUMERATED {bw0, bw1, bw2, bw3},
+	freqDomainPositionAp-r10			INTEGER (0..23),
+	transmissionCombAp-r10				INTEGER (0..1),
+	cyclicShiftAp-r10					ENUMERATED {cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7}
+}
+
+SRS-ConfigAp-v1310 ::= SEQUENCE {
+	transmissionCombAp-v1310			INTEGER (2..3)						OPTIONAL,	-- Need OR
+	cyclicShiftAp-v1310					ENUMERATED {cs8, cs9, cs10, cs11}	OPTIONAL,	-- Need OR
+	transmissionCombNum-r13				ENUMERATED {n2, n4}			OPTIONAL	-- Need OR
+}
+
+SRS-ConfigAp-r13 ::= SEQUENCE {
+	srs-AntennaPortAp-r13				SRS-AntennaPort,
+	srs-BandwidthAp-r13					ENUMERATED {bw0, bw1, bw2, bw3},
+	freqDomainPositionAp-r13			INTEGER (0..23),
+	transmissionCombAp-r13				INTEGER (0..3),
+	cyclicShiftAp-r13					ENUMERATED {cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+											cs8, cs9, cs10, cs11},
+	transmissionCombNum-r13				ENUMERATED {n2, n4}
+}
+
+SRS-AntennaPort ::=					ENUMERATED {an1, an2, an4, spare1}
+
+SRS-ConfigAdd-r16 ::=		SEQUENCE {
+	srs-RepNumAdd-r16				ENUMERATED {n1, n2, n3, n4, n6, n7, n8, n9, n12, n13},
+	srs-BandwidthAdd-r16			ENUMERATED {bw0, bw1, bw2, bw3},
+	srs-HoppingBandwidthAdd-r16		ENUMERATED {hbw0, hbw1, hbw2, hbw3},
+	srs-FreqDomainPosAdd-r16		INTEGER (0..23),
+	srs-AntennaPortAdd-r16			SRS-AntennaPort,
+	srs-CyclicShiftAdd-r16			ENUMERATED {cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7,
+												cs8, cs9, cs10, cs11},
+	srs-TransmissionCombNumAdd-r16	ENUMERATED {n2, n4},
+	srs-TransmissionCombAdd-r16		INTEGER (0..3),
+	srs-StartPosAdd-r16				INTEGER (1..13),
+	srs-DurationAdd-r16				INTEGER (1..13),
+	srs-GuardSymbolAS-Add-r16		ENUMERATED {enabled}			OPTIONAL,	-- Need ON
+	srs-GuardSymbolFH-Add-r16		ENUMERATED {enabled}			OPTIONAL	-- Need ON
+}
+
+
+
+SPDCCH-Config-r15 ::=		CHOICE {
+	release						NULL,
+	setup						SEQUENCE {
+		spdcch-L1-ReuseIndication-r15		ENUMERATED {n0,n1,n2}	OPTIONAL, -- Need OR
+		spdcch-SetConfig-r15				SPDCCH-Set-r15			OPTIONAL -- Need OR
+	}
+}
+
+SPDCCH-Set-r15 ::= SEQUENCE (SIZE (1..4)) OF SPDCCH-Elements-r15
+
+SPDCCH-Elements-r15 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		spdcch-SetConfigId-r15				INTEGER (0..3)			OPTIONAL, -- Need OR
+		spdcch-SetReferenceSig-r15			ENUMERATED {crs, dmrs}	OPTIONAL, -- Need OR
+		transmissionType-r15				ENUMERATED {localised, distributed} OPTIONAL, -- Need OR
+		spdcch-NoOfSymbols-r15				INTEGER (1..2)			OPTIONAL, -- Need OR
+		dmrs-ScramblingSequenceInt-r15		INTEGER (0..503)		OPTIONAL, -- Need OR
+		dci7-CandidatesPerAL-PDCCH-r15		SEQUENCE (SIZE(1..4)) OF
+												DCI7-Candidates-r15 OPTIONAL, -- Need OR
+		dci7-CandidateSetsPerAL-SPDCCH-r15	SEQUENCE (SIZE(1..2)) OF
+												DCI7-CandidatesPerAL-SPDCCH-r15 OPTIONAL, -- Need OR
+		resourceBlockAssignment-r15			SEQUENCE{
+			numberRB-InFreq-domain-r15			INTEGER (2..100),
+			resourceBlockAssignment-r15			BIT STRING (SIZE(98))
+		}															OPTIONAL, -- Need OR
+		subslotApplicability-r15			BIT STRING (SIZE(5))	OPTIONAL, -- Need OR
+		al-StartingPointSPDCCH-r15			SEQUENCE (SIZE(1..4)) OF
+												INTEGER(0..49)		OPTIONAL, -- Need OR
+		subframeType-r15					ENUMERATED {mbsfn, nonmbsfn, all}	OPTIONAL, -- Need OR
+		rateMatchingMode-r15				ENUMERATED {m1, m2, m3, m4}		OPTIONAL, -- Need OR
+		...
+	}
+}
+
+DCI7-Candidates-r15 ::=						INTEGER (0..6)
+DCI7-CandidatesPerAL-SPDCCH-r15 ::=				SEQUENCE (SIZE(1..4)) OF DCI7-Candidates-r15
+
+
+
+SPS-Config ::=	SEQUENCE {
+	semiPersistSchedC-RNTI			C-RNTI					OPTIONAL,			-- Need OR
+	sps-ConfigDL					SPS-ConfigDL			OPTIONAL,			-- Need ON
+	sps-ConfigUL					SPS-ConfigUL			OPTIONAL			-- Need ON
+}
+
+SPS-Config-v1430 ::=	SEQUENCE {
+	ul-SPS-V-RNTI-r14					C-RNTI					OPTIONAL,			-- Need OR
+	sl-SPS-V-RNTI-r14					C-RNTI					OPTIONAL,			-- Need OR
+	sps-ConfigUL-ToAddModList-r14		SPS-ConfigUL-ToAddModList-r14	OPTIONAL,	-- Need ON
+	sps-ConfigUL-ToReleaseList-r14		SPS-ConfigUL-ToReleaseList-r14	OPTIONAL,	-- Need ON
+	sps-ConfigSL-ToAddModList-r14		SPS-ConfigSL-ToAddModList-r14	OPTIONAL,	-- Need ON
+	sps-ConfigSL-ToReleaseList-r14		SPS-ConfigSL-ToReleaseList-r14	OPTIONAL	-- Need ON
+}
+
+SPS-ConfigUL-ToAddModList-r14 ::= SEQUENCE (SIZE (1..maxConfigSPS-r14)) OF SPS-ConfigUL
+
+SPS-ConfigUL-ToReleaseList-r14 ::= SEQUENCE (SIZE (1..maxConfigSPS-r14)) OF SPS-ConfigIndex-r14
+
+SPS-ConfigSL-ToAddModList-r14 ::= SEQUENCE (SIZE (1..maxConfigSPS-r14)) OF SPS-ConfigSL-r14
+
+SPS-ConfigSL-ToReleaseList-r14 ::= SEQUENCE (SIZE (1..maxConfigSPS-r14)) OF SPS-ConfigIndex-r14
+
+SPS-Config-v1530 ::=	SEQUENCE {
+	semiPersistSchedC-RNTI-r15		C-RNTI						OPTIONAL,			-- Need OR
+	sps-ConfigDL-r15					SPS-ConfigDL				OPTIONAL,			-- Need ON
+	sps-ConfigUL-STTI-ToAddModList-r15	SPS-ConfigUL-STTI-ToAddModList-r15	OPTIONAL,	-- Need ON
+	sps-ConfigUL-STTI-ToReleaseList-r15	SPS-ConfigUL-STTI-ToReleaseList-r15	OPTIONAL,	-- Need ON
+	sps-ConfigUL-ToAddModList-r15		SPS-ConfigUL-ToAddModList-r15		OPTIONAL,	-- Need ON
+	sps-ConfigUL-ToReleaseList-r15		SPS-ConfigUL-ToReleaseList-r15		OPTIONAL	-- Need ON
+}
+
+SPS-Config-v1540 ::=	SEQUENCE {
+	sps-ConfigDL-STTI-r15				SPS-ConfigDL-STTI-r15				OPTIONAL	-- Need OR
+}
+
+SPS-ConfigUL-STTI-ToAddModList-r15 ::= SEQUENCE (SIZE (1..maxConfigSPS-r15)) OF SPS-ConfigUL-STTI-r15
+
+SPS-ConfigUL-STTI-ToReleaseList-r15 ::= SEQUENCE (SIZE (1..maxConfigSPS-r15)) OF SPS-ConfigIndex-r15
+
+SPS-ConfigUL-ToAddModList-r15 ::= SEQUENCE (SIZE (1..maxConfigSPS-r15)) OF SPS-ConfigUL
+
+SPS-ConfigUL-ToReleaseList-r15 ::= SEQUENCE (SIZE (1..maxConfigSPS-r15)) OF SPS-ConfigIndex-r15
+
+SPS-ConfigDL ::=	CHOICE{
+	release							NULL,
+	setup							SEQUENCE {
+		semiPersistSchedIntervalDL			ENUMERATED {
+												sf10, sf20, sf32, sf40, sf64, sf80,
+												sf128, sf160, sf320, sf640, spare6,
+												spare5, spare4, spare3, spare2,
+												spare1},
+		numberOfConfSPS-Processes			INTEGER (1..8),
+		n1PUCCH-AN-PersistentList			N1PUCCH-AN-PersistentList,
+		...,
+		[[	twoAntennaPortActivated-r10		CHOICE {
+				release							NULL,
+				setup							SEQUENCE {
+					n1PUCCH-AN-PersistentListP1-r10	N1PUCCH-AN-PersistentList
+				}
+			}																OPTIONAL	-- Need ON
+		]]
+	}
+}
+
+SPS-ConfigUL ::=	CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		semiPersistSchedIntervalUL			ENUMERATED {
+												sf10, sf20, sf32, sf40, sf64, sf80,
+												sf128, sf160, sf320, sf640, sf1-v1430,
+												sf2-v1430, sf3-v1430, sf4-v1430, sf5-v1430,
+												spare1},
+		implicitReleaseAfter				ENUMERATED {e2, e3, e4, e8},
+		p0-Persistent						SEQUENCE {
+			p0-NominalPUSCH-Persistent			INTEGER (-126..24),
+			p0-UE-PUSCH-Persistent				INTEGER (-8..7)
+		}		OPTIONAL,												-- Need OP
+		twoIntervalsConfig					ENUMERATED {true}			OPTIONAL,	-- Cond TDD
+		...,
+		[[	p0-PersistentSubframeSet2-r12		CHOICE {
+				release								NULL,
+				setup								SEQUENCE {
+					p0-NominalPUSCH-PersistentSubframeSet2-r12			INTEGER (-126..24),
+					p0-UE-PUSCH-PersistentSubframeSet2-r12				INTEGER (-8..7)
+				}
+			}															OPTIONAL	-- Need ON
+		]],
+		[[	numberOfConfUlSPS-Processes-r13			INTEGER (1..8)		OPTIONAL	-- Need OR
+		]],
+		[[	fixedRV-NonAdaptive-r14					ENUMERATED {true}		OPTIONAL,	-- Need OR
+			sps-ConfigIndex-r14						SPS-ConfigIndex-r14		OPTIONAL,	-- Need OR
+			semiPersistSchedIntervalUL-v1430		ENUMERATED {
+											sf50, sf100, sf200, sf300, sf400, sf500,
+											sf600, sf700, sf800, sf900, sf1000, spare5,
+											spare4, spare3, spare2, spare1}	OPTIONAL	-- Need OR
+
+		]],
+		[[ cyclicShiftSPS-r15				ENUMERATED {cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7}
+												OPTIONAL,	-- Need ON
+	-- eNote (TBC) that no separate STTI field is required (alike in merged CR)
+			harq-ProcID-Offset-r15				INTEGER (0..7)			OPTIONAL,	-- Need ON
+			rv-SPS-UL-Repetitions-r15			ENUMERATED {ulrvseq1, ulrvseq2, ulrvseq3} OPTIONAL, -- Need ON
+			tpc-PDCCH-ConfigPUSCH-SPS-r15		TPC-PDCCH-Config		OPTIONAL,	-- Need ON
+			totalNumberPUSCH-SPS-UL-Repetitions-r15	ENUMERATED {n2,n3,n4,n6}	OPTIONAL, -- Need ON
+			sps-ConfigIndex-r15					SPS-ConfigIndex-r15		OPTIONAL	-- Cond SPS
+		]]
+	}
+}
+
+SPS-ConfigSL-r14 ::=	SEQUENCE {
+	sps-ConfigIndex-r14				SPS-ConfigIndex-r14,
+	semiPersistSchedIntervalSL-r14	ENUMERATED {
+										sf20, sf50, sf100, sf200, sf300, sf400,
+										sf500, sf600, sf700, sf800, sf900, sf1000,
+										spare4, spare3, spare2, spare1}
+}
+
+SPS-ConfigIndex-r14 ::=			INTEGER (1..maxConfigSPS-r14)
+
+SPS-ConfigIndex-r15 ::=			INTEGER (1..maxConfigSPS-r15)
+
+N1PUCCH-AN-PersistentList ::=		SEQUENCE (SIZE (1..4)) OF INTEGER (0..2047)
+
+N1SPUCCH-AN-PersistentList-r15 ::=		SEQUENCE (SIZE (1..4)) OF INTEGER (0..2047)
+
+SPS-ConfigDL-STTI-r15 ::=	CHOICE{
+	release							NULL,
+	setup							SEQUENCE {
+		semiPersistSchedIntervalDL-STTI-r15		ENUMERATED {
+												sTTI1, sTTI2, sTTI3, sTTI4, sTTI6, sTTI8, sTTI12, sTTI16,
+												sTTI20, sTTI40, sTTI60, sTTI80, sTTI120, sTTI240,
+												spare2, spare1},
+		numberOfConfSPS-Processes-STTI-r15		INTEGER (1..12),
+		twoAntennaPortActivated-r15			CHOICE {
+				release							NULL,
+				setup							SEQUENCE {
+					n1SPUCCH-AN-PersistentListP1-r15		N1SPUCCH-AN-PersistentList-r15
+				}
+			}															OPTIONAL,	-- Need ON
+		sTTI-StartTimeDL-r15					INTEGER (0..5),
+		tpc-PDCCH-ConfigPUCCH-SPS-r15		TPC-PDCCH-Config			OPTIONAL,	-- Need ON
+		...
+	}
+}
+
+SPS-ConfigUL-STTI-r15 ::=	CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		semiPersistSchedIntervalUL-STTI-r15		ENUMERATED {
+												sTTI1, sTTI2, sTTI3, sTTI4, sTTI6, sTTI8, sTTI12, sTTI16,
+												sTTI20, sTTI40, sTTI60, sTTI80, sTTI120, sTTI240,
+												spare2, spare1},
+		implicitReleaseAfter					ENUMERATED {e2, e3, e4, e8},
+		p0-Persistent-r15					SEQUENCE {
+			p0-NominalSPUSCH-Persistent-r15		INTEGER (-126..24),
+			p0-UE-SPUSCH-Persistent-r15			INTEGER (-8..7)
+		}																OPTIONAL,	-- Need OP
+		twoIntervalsConfig-r15					ENUMERATED {true}		OPTIONAL,	-- Cond TDD
+		p0-PersistentSubframeSet2-r15		CHOICE {
+				release							NULL,
+				setup							SEQUENCE {
+					p0-NominalSPUSCH-PersistentSubframeSet2-r15			INTEGER (-126..24),
+					p0-UE-SPUSCH-PersistentSubframeSet2-r15				INTEGER (-8..7)
+				}
+			}															OPTIONAL,	-- Need ON
+		numberOfConfUL-SPS-Processes-STTI-r15	INTEGER (1..12)			OPTIONAL,	-- Need OR
+		sTTI-StartTimeUL-r15				INTEGER (0..5),
+		tpc-PDCCH-ConfigPUSCH-SPS-r15		TPC-PDCCH-Config			OPTIONAL,	-- Need ON
+		cyclicShiftSPS-sTTI-r15				ENUMERATED {cs0, cs1, cs2, cs3, cs4, cs5, cs6, cs7}																				OPTIONAL,	-- Need ON
+		ifdma-Config-SPS-r15				BOOLEAN						OPTIONAL,	-- Need ON
+		harq-ProcID-offset-r15				INTEGER (0..15)			OPTIONAL,	-- Need ON
+		rv-SPS-STTI-UL-Repetitions-r15		ENUMERATED {ulrvseq1, ulrvseq2, ulrvseq3}	OPTIONAL, -- Need ON
+		sps-ConfigIndex-r15		SPS-ConfigIndex-r15		OPTIONAL,	-- Need OR
+		tbs-scalingFactorSubslotSPS-UL-Repetitions-r15	ENUMERATED {n6, n12}		OPTIONAL, -- Need ON
+		totalNumberPUSCH-SPS-STTI-UL-Repetitions-r15	ENUMERATED {n2,n3,n4,n6}	OPTIONAL, -- Need ON
+		...
+	}
+}
+
+
+
+
+SPUCCH-Config-r15 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		spucch-Set-r15					SPUCCH-Set-r15		OPTIONAL, -- Need ON
+		twoAntennaPortActivatedSPUCCH-Format1a1b-r15	ENUMERATED {true}	OPTIONAL,	-- Need OR
+		dummy							SEQUENCE {
+			n3SPUCCH-AN-List-r15			SEQUENCE (SIZE (1..4)) OF INTEGER (0..549)
+		}
+	}
+}
+
+SPUCCH-Config-v1550 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		twoAntennaPortActivatedSPUCCH-Format3-v1550		SEQUENCE {
+			n3SPUCCH-AN-List-v1550		SEQUENCE (SIZE (1..4)) OF INTEGER (0..549)
+		}
+	}
+}
+
+SPUCCH-Set-r15 ::= SEQUENCE (SIZE (1..4)) OF SPUCCH-Elements-r15
+
+SPUCCH-Elements-r15 ::= CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		n1SubslotSPUCCH-AN-List-r15		SEQUENCE (SIZE(1..4)) OF INTEGER (0..1319) OPTIONAL, -- Need OR
+		n1SlotSPUCCH-FH-AN-List-r15		INTEGER (0..1319)		OPTIONAL, -- Need OR
+		n1SlotSPUCCH-NoFH-AN-List-r15	INTEGER (0..3959)		OPTIONAL, -- Need OR
+		n3SPUCCH-AN-List-r15			INTEGER (0..549)		OPTIONAL, -- Need OR
+		n4SPUCCHSlot-Resource-r15		SEQUENCE (SIZE(1..2)) OF N4SPUCCH-Resource-r15	OPTIONAL, -- Need OR
+		n4SPUCCHSubslot-Resource-r15	SEQUENCE (SIZE(1..2)) OF N4SPUCCH-Resource-r15	OPTIONAL, -- Need OR
+		n4maxCoderateSlotPUCCH-r15		INTEGER (0..7)			OPTIONAL, -- Need OR
+		n4maxCoderateSubslotPUCCH-r15	INTEGER (0..7)			OPTIONAL, -- Need OR
+		n4maxCoderateMultiResourceSlotPUCCH-r15	INTEGER (0..7)		OPTIONAL,	-- Need OR
+		n4maxCoderateMultiResourceSubslotPUCCH-r15	INTEGER (0..7)		OPTIONAL	-- Need OR
+	}
+}
+
+N4SPUCCH-Resource-r15 ::= SEQUENCE {
+	n4startingPRB-r15				INTEGER (0..109),
+	n4numberOfPRB-r15				INTEGER (0..7)
+}
+
+
+
+SRS-TPC-PDCCH-Config-r14 ::=					CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		srs-TPC-RNTI-r14									BIT STRING (SIZE (16)),
+		startingBitOfFormat3B-r14							INTEGER (0..31),
+		fieldTypeFormat3B-r14								INTEGER (1..4),
+		srs-CC-SetIndexlist-r14							SEQUENCE (SIZE(1..4)) OF SRS-CC-SetIndex-r14	OPTIONAL	-- Cond SRS-Trigger-TypeA
+
+	}
+}
+
+SRS-CC-SetIndex-r14 ::=			SEQUENCE {
+	cc-SetIndex-r14				INTEGER (0..3),
+	cc-IndexInOneCC-Set-r14		INTEGER (0..7)
+}
+
+
+
+TDD-Config ::=						SEQUENCE {
+	subframeAssignment					ENUMERATED {
+											sa0, sa1, sa2, sa3, sa4, sa5, sa6},
+	specialSubframePatterns				ENUMERATED {
+											ssp0, ssp1, ssp2, ssp3, ssp4,ssp5, ssp6, ssp7,
+											ssp8}
+}
+
+TDD-Config-v1130 ::=				SEQUENCE {
+	specialSubframePatterns-v1130		ENUMERATED {ssp7,ssp9}
+}
+
+TDD-Config-v1430 ::=				SEQUENCE {
+	specialSubframePatterns-v1430		ENUMERATED {ssp10}
+}
+
+TDD-Config-v1450 ::=				SEQUENCE {
+	specialSubframePatterns-v1450		ENUMERATED {ssp10-CRS-LessDwPTS}
+}
+
+TDD-ConfigSL-r12 ::=		SEQUENCE {
+	subframeAssignmentSL-r12				ENUMERATED {
+											none, sa0, sa1, sa2, sa3, sa4, sa5, sa6}
+}
+
+
+
+TDM-PatternConfig-r15 ::=		CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		subframeAssignment-r15		SubframeAssignment-r15,
+		harq-Offset-r15				INTEGER (0..9)
+	}
+}
+
+SubframeAssignment-r15 ::=		ENUMERATED {sa0, sa1, sa2, sa3, sa4, sa5, sa6}
+
+
+
+TimeAlignmentTimer ::=					ENUMERATED {
+												sf500, sf750, sf1280, sf1920, sf2560, sf5120,
+												sf10240, infinity}
+
+
+
+TimeReferenceInfo-r15 ::=		SEQUENCE {
+	time-r15							ReferenceTime-r15,
+	uncertainty-r15						INTEGER (0..12)				OPTIONAL,	-- Need OR
+	timeInfoType-r15					ENUMERATED {localClock}		OPTIONAL,	-- Need OR
+	referenceSFN-r15					INTEGER (0..1023)			OPTIONAL	-- Cond TimeRef
+}
+
+ReferenceTime-r15 ::=			SEQUENCE {
+	refDays-r15							INTEGER (0..72999),
+	refSeconds-r15						INTEGER (0..86399),
+	refMilliSeconds-r15					INTEGER (0..999),
+	refQuarterMicroSeconds-r15			INTEGER (0..3999)
+}
+
+
+
+TPC-PDCCH-Config ::=					CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		tpc-RNTI							BIT STRING (SIZE (16)),
+		tpc-Index							TPC-Index
+	}
+}
+
+TPC-PDCCH-ConfigSCell-r13 ::=					CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		tpc-Index-PUCCH-SCell-r13		TPC-Index
+	}
+}
+
+TPC-Index ::=							CHOICE {
+	indexOfFormat3							INTEGER (1..15),
+	indexOfFormat3A							INTEGER (1..31)
+}
+
+
+
+TunnelConfigLWIP-r13 ::= SEQUENCE {
+	ip-Address-r13			IP-Address-r13,
+	ike-Identity-r13			IKE-Identity-r13,
+	...,
+	[[	lwip-Counter-r13	INTEGER (0..65535)		OPTIONAL	-- Cond LWIP-Setup
+	]]
+}
+
+IKE-Identity-r13 ::= SEQUENCE {
+	idI-r13					OCTET STRING
+}
+
+IP-Address-r13 ::= CHOICE {
+	ipv4-r13					BIT STRING (SIZE (32)),
+	ipv6-r13					BIT STRING (SIZE (128))
+}
+
+
+
+UplinkPowerControlCommon ::=		SEQUENCE {
+	p0-NominalPUSCH						INTEGER (-126..24),
+	alpha								Alpha-r12,
+	p0-NominalPUCCH						INTEGER (-127..-96),
+	deltaFList-PUCCH					DeltaFList-PUCCH,
+	deltaPreambleMsg3					INTEGER (-1..6)
+}
+
+UplinkPowerControlCommon-v1020 ::=	SEQUENCE {
+	deltaF-PUCCH-Format3-r10				ENUMERATED {deltaF-1, deltaF0, deltaF1, deltaF2,
+														deltaF3, deltaF4, deltaF5, deltaF6},
+	deltaF-PUCCH-Format1bCS-r10				ENUMERATED {deltaF1, deltaF2, spare2, spare1}
+}
+
+UplinkPowerControlCommon-v1310 ::=	SEQUENCE {
+	deltaF-PUCCH-Format4-r13			ENUMERATED {deltaF16, deltaF15, deltaF14,deltaF13, deltaF12,
+										deltaF11, deltaF10, spare1}			OPTIONAL,	-- Need OR
+	deltaF-PUCCH-Format5-13				ENUMERATED { deltaF13, deltaF12, deltaF11, deltaF10, deltaF9,
+										deltaF8, deltaF7, spare1}				OPTIONAL	-- Need OR
+}
+
+UplinkPowerControlCommon-v1530 ::=	SEQUENCE {
+	deltaFList-SPUCCH-r15		DeltaFList-SPUCCH-r15
+}
+
+UplinkPowerControlCommon-v1610 ::=	SEQUENCE {
+	alphaSRS-Add-r16						Alpha-r12,
+	p0-NominalSRS-Add-r16					INTEGER (-126..24)
+}
+
+UplinkPowerControlCommonPSCell-r12 ::=		SEQUENCE {
+-- For uplink power control the additional/ missing fields are signalled (compared to SCell)
+	deltaF-PUCCH-Format3-r12				ENUMERATED {deltaF-1, deltaF0, deltaF1, deltaF2,
+														deltaF3, deltaF4, deltaF5, deltaF6},
+	deltaF-PUCCH-Format1bCS-r12				ENUMERATED {deltaF1, deltaF2, spare2, spare1},
+	p0-NominalPUCCH-r12						INTEGER (-127..-96),
+	deltaFList-PUCCH-r12					DeltaFList-PUCCH
+}
+
+
+UplinkPowerControlCommonSCell-r10 ::=	SEQUENCE {
+	p0-NominalPUSCH-r10					INTEGER (-126..24),
+	alpha-r10							Alpha-r12
+}
+
+UplinkPowerControlCommonSCell-v1130 ::=	SEQUENCE {
+	deltaPreambleMsg3-r11				INTEGER (-1..6)
+}
+
+UplinkPowerControlCommonSCell-v1310 ::=	SEQUENCE {
+-- For uplink power control the additional/ missing fields are signalled (compared to SCell)
+	p0-NominalPUCCH							INTEGER (-127..-96),
+	deltaFList-PUCCH						DeltaFList-PUCCH,
+	deltaF-PUCCH-Format3-r12				ENUMERATED {deltaF-1, deltaF0, deltaF1,
+											deltaF2, deltaF3, deltaF4, deltaF5,
+											deltaF6}						OPTIONAL,	-- Need OR
+	deltaF-PUCCH-Format1bCS-r12				ENUMERATED {deltaF1, deltaF2,
+											spare2, spare1}					OPTIONAL,	-- Need OR
+	deltaF-PUCCH-Format4-r13					ENUMERATED {deltaF16, deltaF15, deltaF14,
+												deltaF13, deltaF12, deltaF11, deltaF10,
+												spare1}							OPTIONAL,	-- Need OR
+	deltaF-PUCCH-Format5-13						ENUMERATED { deltaF13, deltaF12, deltaF11,
+												deltaF10, deltaF9, deltaF8, deltaF7,
+												spare1}							OPTIONAL	-- Need OR
+}
+
+UplinkPowerControlCommonPUSCH-LessCell-v1430 ::=	SEQUENCE {
+	p0-Nominal-PeriodicSRS-r14						INTEGER (-126..24)		OPTIONAL,	-- Need OR
+	p0-Nominal-AperiodicSRS-r14						INTEGER (-126..24)		OPTIONAL,	-- Need OR
+	alpha-SRS-r14								Alpha-r12					OPTIONAL	-- Need OR
+}
+
+UplinkPowerControlDedicated ::=		SEQUENCE {
+	p0-UE-PUSCH							INTEGER (-8..7),
+	deltaMCS-Enabled					ENUMERATED {en0, en1},
+	accumulationEnabled					BOOLEAN,
+	p0-UE-PUCCH							INTEGER (-8..7),
+	pSRS-Offset							INTEGER (0..15),
+	filterCoefficient					FilterCoefficient					DEFAULT fc4
+}
+
+UplinkPowerControlDedicated-v1020 ::= SEQUENCE {
+	deltaTxD-OffsetListPUCCH-r10		DeltaTxD-OffsetListPUCCH-r10		OPTIONAL,	-- Need OR
+	pSRS-OffsetAp-r10					INTEGER (0..15)						OPTIONAL	-- Need OR
+}
+
+UplinkPowerControlDedicated-v1130 ::=		SEQUENCE {
+	pSRS-Offset-v1130						INTEGER (16..31)				OPTIONAL,	-- Need OR
+	pSRS-OffsetAp-v1130						INTEGER (16..31)				OPTIONAL,	-- Need OR
+	deltaTxD-OffsetListPUCCH-v1130			DeltaTxD-OffsetListPUCCH-v1130	OPTIONAL	-- Need OR
+}
+
+UplinkPowerControlDedicated-v1250 ::=	SEQUENCE {
+	set2PowerControlParameter		CHOICE {
+		release							NULL,
+		setup							SEQUENCE {
+			tpc-SubframeSet-r12					BIT STRING (SIZE(10)),
+			p0-NominalPUSCH-SubframeSet2-r12		INTEGER (-126..24),
+			alpha-SubframeSet2-r12				Alpha-r12,
+			p0-UE-PUSCH-SubframeSet2-r12			INTEGER (-8..7)
+		}
+	}
+}
+
+UplinkPowerControlDedicated-v1530 ::= SEQUENCE {
+	alpha-UE-r15				Alpha-r12							OPTIONAL,	-- Need OR
+	p0-UE-PUSCH-r15				INTEGER (-16..15)					OPTIONAL	-- Need OR
+}
+
+UplinkPowerControlDedicatedSTTI-r15 ::= SEQUENCE {
+	accumulationEnabledSTTI-r15		BOOLEAN,
+	deltaTxD-OffsetListSPUCCH-r15	DeltaTxD-OffsetListSPUCCH-r15	OPTIONAL,	-- Need OR
+	uplinkPower-CSIPayload			BOOLEAN
+}
+
+UplinkPUSCH-LessPowerControlDedicated-v1430 ::=		SEQUENCE {
+	p0-UE-PeriodicSRS-r14						INTEGER (-8..7)			OPTIONAL,	-- Need OR
+	p0-UE-AperiodicSRS-r14						INTEGER (-8..7)			OPTIONAL,	-- Need OR
+	accumulationEnabled-r14						BOOLEAN
+}
+
+UplinkPowerControlAddSRS-r16 ::= SEQUENCE {
+	tpc-IndexSRS-Add-r16				TPC-Index					OPTIONAL,	-- Need ON
+	startingBitOfFormat3B-SRS-Add-r16	INTEGER (0..31)				OPTIONAL,	-- Need ON
+	fieldTypeFormat3B-SRS-Add-r16		INTEGER (1..2)				OPTIONAL,	-- Need ON
+	p0-UE-SRS-Add-r16					INTEGER (-16..15)			OPTIONAL,	-- Need ON
+	accumulationEnabledSRS-Add-r16		BOOLEAN
+}
+
+UplinkPowerControlDedicatedSCell-r10 ::=		SEQUENCE {
+	p0-UE-PUSCH-r10						INTEGER (-8..7),
+	deltaMCS-Enabled-r10					ENUMERATED {en0, en1},
+	accumulationEnabled-r10				BOOLEAN,
+	pSRS-Offset-r10						INTEGER (0..15),
+	pSRS-OffsetAp-r10					INTEGER (0..15)					OPTIONAL,	-- Need OR
+	filterCoefficient-r10				FilterCoefficient					DEFAULT fc4,
+	pathlossReferenceLinking-r10		ENUMERATED {pCell, sCell}
+}
+
+UplinkPowerControlDedicatedSCell-v1310 ::=	SEQUENCE {
+--Release 8
+	p0-UE-PUCCH							INTEGER (-8..7),
+--Release 10
+	deltaTxD-OffsetListPUCCH-r10		DeltaTxD-OffsetListPUCCH-r10		OPTIONAL	-- Need OR
+}
+
+DeltaFList-PUCCH ::=				SEQUENCE {
+	deltaF-PUCCH-Format1				ENUMERATED {deltaF-2, deltaF0, deltaF2},
+	deltaF-PUCCH-Format1b				ENUMERATED {deltaF1, deltaF3, deltaF5},
+	deltaF-PUCCH-Format2				ENUMERATED {deltaF-2, deltaF0, deltaF1, deltaF2},
+	deltaF-PUCCH-Format2a				ENUMERATED {deltaF-2, deltaF0, deltaF2},
+	deltaF-PUCCH-Format2b				ENUMERATED {deltaF-2, deltaF0, deltaF2}
+}
+
+DeltaFList-SPUCCH-r15 ::= CHOICE {
+		release					NULL,
+		setup					SEQUENCE {
+	deltaF-slotSPUCCH-Format1-r15	ENUMERATED {deltaF-1, deltaF0, deltaF1, deltaF2,
+										deltaF3, deltaF4, deltaF5, deltaF6}	OPTIONAL, --Need OR
+	deltaF-slotSPUCCH-Format1a-r15	ENUMERATED {deltaF1, deltaF2, deltaF3, deltaF4,
+										deltaF5, deltaF6, deltaF7, deltaF8}	OPTIONAL, --Need OR
+	deltaF-slotSPUCCH-Format1b-r15	ENUMERATED {deltaF3, deltaF4, deltaF5, deltaF6,
+										deltaF7, deltaF8, deltaF9, deltaF10}	OPTIONAL,--Need OR
+	deltaF-slotSPUCCH-Format3-r15	ENUMERATED {deltaF4, deltaF5, deltaF6, deltaF7,
+										deltaF8, deltaF9, deltaF10, deltaF11}	OPTIONAL,--Need OR
+	deltaF-slotSPUCCH-RM-Format4-r15	ENUMERATED {deltaF13, deltaF14, deltaF15, deltaF16,
+										deltaF17, deltaF18, deltaF19, deltaF20}	OPTIONAL,
+--Need OR
+	deltaF-slotSPUCCH-TBCC-Format4-r15	ENUMERATED {deltaF10, deltaF11, deltaF12, deltaF13,
+											deltaF14, deltaF15, deltaF16, deltaF17}	OPTIONAL,
+--Need OR
+	deltaF-subslotSPUCCH-Format1and1a-r15	ENUMERATED {deltaF5, deltaF6, deltaF7, deltaF8,
+												deltaF9, deltaF10, deltaF11, deltaF12}	OPTIONAL,
+--Need OR
+	deltaF-subslotSPUCCH-Format1b-r15	ENUMERATED {deltaF6, deltaF7, deltaF8, deltaF9,
+											deltaF10, deltaF11, deltaF12, deltaF13}	OPTIONAL,
+--Need OR
+	deltaF-subslotSPUCCH-RM-Format4-r15	ENUMERATED {deltaF15, deltaF16, deltaF17, deltaF18,
+											deltaF19, deltaF20, deltaF21, deltaF22}	OPTIONAL,
+--Need OR
+	deltaF-subslotSPUCCH-TBCC-Format4-r15	ENUMERATED {deltaF10, deltaF11, deltaF12, deltaF13,
+												deltaF14, deltaF15, deltaF16, deltaF17}	OPTIONAL,
+--Need OR
+	...
+	}
+}
+
+DeltaTxD-OffsetListPUCCH-r10 ::=	SEQUENCE {
+	deltaTxD-OffsetPUCCH-Format1-r10		ENUMERATED {dB0, dB-2},
+	deltaTxD-OffsetPUCCH-Format1a1b-r10		ENUMERATED {dB0, dB-2},
+	deltaTxD-OffsetPUCCH-Format22a2b-r10	ENUMERATED {dB0, dB-2},
+	deltaTxD-OffsetPUCCH-Format3-r10		ENUMERATED {dB0, dB-2},
+	...
+
+}
+
+DeltaTxD-OffsetListPUCCH-v1130 ::=	SEQUENCE {
+	deltaTxD-OffsetPUCCH-Format1bCS-r11		ENUMERATED {dB0, dB-1}
+}
+
+DeltaTxD-OffsetListSPUCCH-r15 ::=	SEQUENCE {
+	deltaTxD-OffsetSPUCCH-Format1-r15		ENUMERATED {dB0, dB-2},
+	deltaTxD-OffsetSPUCCH-Format1a-r15		ENUMERATED {dB0, dB-2},
+	deltaTxD-OffsetSPUCCH-Format1b-r15		ENUMERATED {dB0, dB-2},
+	deltaTxD-OffsetSPUCCH-Format3-r15		ENUMERATED {dB0, dB-2},
+	...
+}
+
+
+
+WLAN-Id-List-r13 ::=				SEQUENCE (SIZE (1..maxWLAN-Id-r13)) OF WLAN-Identifiers-r12
+
+
+
+WLAN-MobilityConfig-r13 ::=		SEQUENCE {
+	wlan-ToReleaseList-r13				WLAN-Id-List-r13			OPTIONAL,	-- Need ON
+	wlan-ToAddList-r13					WLAN-Id-List-r13			OPTIONAL,	-- Need ON
+	associationTimer-r13				ENUMERATED {s10, s30,
+										s60, s120, s240}			OPTIONAL,	-- Need OR
+	successReportRequested-r13			ENUMERATED {true}			OPTIONAL,	-- Need OR
+	...,
+	[[	wlan-SuspendConfig-r14			WLAN-SuspendConfig-r14		OPTIONAL	-- Need ON
+	]]
+}
+
+
+
+WUS-Config-r15 ::=				SEQUENCE {
+	maxDurationFactor-r15					ENUMERATED {one32th, one16th, one8th, one4th},
+	numPOs-r15						ENUMERATED {n1, n2, n4, spare1}		DEFAULT n1,
+	freqLocation-r15					ENUMERATED {n0, n2, n4, spare1},
+	timeOffsetDRX-r15				ENUMERATED {ms40, ms80, ms160, ms240},
+	timeOffset-eDRX-Short-r15		ENUMERATED {ms40, ms80, ms160, ms240},
+	timeOffset-eDRX-Long-r15		ENUMERATED {ms1000, ms2000}		OPTIONAL	-- Need OP
+}
+
+WUS-Config-v1560 ::=			SEQUENCE {
+	powerBoost-r15					ENUMERATED {dB0, dB1dot8, dB3, dB4dot8}
+}
+
+WUS-Config-v1610 ::=			SEQUENCE {
+	numDRX-CyclesRelaxed-r16		ENUMERATED {n1, n2, n4, n8}
+}
+
+
+
+NextHopChainingCount ::=					INTEGER (0..7)
+
+
+
+SecurityAlgorithmConfig ::=			SEQUENCE {
+	cipheringAlgorithm					CipheringAlgorithm-r12,
+	integrityProtAlgorithm				ENUMERATED {
+											eia0-v920, eia1, eia2, eia3-v1130, spare4, spare3,
+											spare2, spare1, ...}
+}
+
+CipheringAlgorithm-r12 ::=				ENUMERATED {
+											eea0, eea1, eea2, eea3-v1130, spare4, spare3,
+											spare2, spare1, ...}
+
+
+
+ShortMAC-I ::=						BIT STRING (SIZE (16))
+
+
+
+AdditionalSpectrumEmission ::=		INTEGER (1..32)
+
+AdditionalSpectrumEmission-v10l0 ::=	INTEGER (33..288)
+
+
+
+AdditionalSpectrumEmissionNR-r15 ::=		INTEGER (0..7)
+
+
+
+ARFCN-ValueCDMA2000 ::=			INTEGER (0..2047)
+
+
+
+ARFCN-ValueEUTRA ::=				INTEGER (0..maxEARFCN)
+
+ARFCN-ValueEUTRA-v9e0 ::=			INTEGER (maxEARFCN-Plus1..maxEARFCN2)
+
+ARFCN-ValueEUTRA-r9 ::=				INTEGER (0..maxEARFCN2)
+
+
+
+ARFCN-ValueGERAN ::=			INTEGER (0..1023)
+
+
+
+ARFCN-ValueNR-r15 ::=				INTEGER (0.. 3279165)
+
+
+
+ARFCN-ValueUTRA ::=					INTEGER (0..16383)
+
+
+
+BandclassCDMA2000 ::=					ENUMERATED {
+											bc0, bc1, bc2, bc3, bc4, bc5, bc6, bc7, bc8,
+											bc9, bc10, bc11, bc12, bc13, bc14, bc15, bc16,
+											bc17, bc18-v9a0, bc19-v9a0, bc20-v9a0, bc21-v9a0,
+											spare10, spare9, spare8, spare7, spare6, spare5, spare4,
+											spare3, spare2, spare1, ...}
+
+
+
+BandIndicatorGERAN ::=			ENUMERATED {dcs1800, pcs1900}
+
+
+
+CarrierFreqCDMA2000 ::=			SEQUENCE {
+	bandClass							BandclassCDMA2000,
+	arfcn							ARFCN-ValueCDMA2000
+}
+
+
+
+CarrierFreqGERAN ::=			SEQUENCE {
+	arfcn							ARFCN-ValueGERAN,
+	bandIndicator					BandIndicatorGERAN
+}
+
+
+
+CarrierFreqsGERAN ::=			SEQUENCE {
+	startingARFCN						ARFCN-ValueGERAN,
+	bandIndicator						BandIndicatorGERAN,
+	followingARFCNs						CHOICE {
+		explicitListOfARFCNs				ExplicitListOfARFCNs,
+		equallySpacedARFCNs					SEQUENCE {
+			arfcn-Spacing						INTEGER (1..8),
+			numberOfFollowingARFCNs				INTEGER (0..31)
+		},
+		variableBitMapOfARFCNs				OCTET STRING (SIZE (1..16))
+	}
+}
+
+ExplicitListOfARFCNs ::=			SEQUENCE (SIZE (0..31)) OF ARFCN-ValueGERAN
+
+
+
+CarrierFreqListMBMS-r11 ::=		SEQUENCE (SIZE (1..maxFreqMBMS-r11)) OF ARFCN-ValueEUTRA-r9
+
+
+
+CDMA2000-Type ::=					ENUMERATED {type1XRTT, typeHRPD}
+
+
+
+CellGlobalIdNR-r16 ::=					SEQUENCE {
+	plmn-Identity-r16							PLMN-Identity,
+	cellIdentity-r16							CellIdentityNR-r15,
+	trackingAreaCode-r16						TrackingAreaCodeNR-r15			OPTIONAL
+}
+
+
+
+CellIdentity ::=					BIT STRING (SIZE (28))
+
+
+
+CellIndexList ::=						SEQUENCE (SIZE (1..maxCellMeas)) OF CellIndex
+
+CellIndex ::=							INTEGER (1..maxCellMeas)
+
+
+
+CellReselectionPriority ::=				INTEGER (0..7)
+
+
+
+CellSelectionInfoCE-r13 ::=		SEQUENCE {
+	q-RxLevMinCE-r13				Q-RxLevMin,
+	q-QualMinRSRQ-CE-r13			Q-QualMin-r9						OPTIONAL	-- Need OR
+}
+
+CellSelectionInfoCE-v1530 ::=		SEQUENCE {
+	powerClass14dBm-Offset-r15			ENUMERATED {dB-6, dB-3, dB3, dB6, dB9, dB12}
+}
+
+
+
+CellSelectionInfoCE1-r13 ::=		SEQUENCE {
+	q-RxLevMinCE1-r13				Q-RxLevMin,
+	q-QualMinRSRQ-CE1-r13			Q-QualMin-r9						OPTIONAL	-- Need OR
+}
+
+CellSelectionInfoCE1-v1360 ::=		SEQUENCE {
+	delta-RxLevMinCE1-v1360					INTEGER (-8..-1)
+}
+
+
+CellReselectionSubPriority-r13 ::=			ENUMERATED {oDot2, oDot4, oDot6, oDot8}
+
+
+
+CSFB-RegistrationParam1XRTT ::=		SEQUENCE {
+	sid									BIT STRING (SIZE (15)),
+	nid									BIT STRING (SIZE (16)),
+	multipleSID							BOOLEAN,
+	multipleNID							BOOLEAN,
+	homeReg								BOOLEAN,
+	foreignSIDReg						BOOLEAN,
+	foreignNIDReg						BOOLEAN,
+	parameterReg						BOOLEAN,
+	powerUpReg							BOOLEAN,
+	registrationPeriod					BIT STRING (SIZE (7)),
+	registrationZone					BIT STRING (SIZE (12)),
+	totalZone							BIT STRING (SIZE (3)),
+	zoneTimer							BIT STRING (SIZE (3))
+}
+
+CSFB-RegistrationParam1XRTT-v920 ::=	SEQUENCE {
+	powerDownReg-r9						ENUMERATED {true}
+}
+
+
+
+CellGlobalIdEUTRA ::=					SEQUENCE {
+	plmn-Identity							PLMN-Identity,
+	cellIdentity							CellIdentity
+}
+
+
+
+CellGlobalIdUTRA ::=					SEQUENCE {
+	plmn-Identity							PLMN-Identity,
+	cellIdentity							BIT STRING (SIZE (28))
+}
+
+
+
+CellGlobalIdGERAN ::=					SEQUENCE {
+	plmn-Identity							PLMN-Identity,
+	locationAreaCode						BIT STRING (SIZE (16)),
+	cellIdentity						BIT STRING (SIZE (16))
+}
+
+
+
+CellGlobalIdCDMA2000 ::=				CHOICE {
+	cellGlobalId1XRTT						BIT STRING (SIZE (47)),
+	cellGlobalIdHRPD						BIT STRING (SIZE (128))
+}
+
+
+
+CellSelectionInfoNFreq-r13 ::=	SEQUENCE {
+	-- Cell selection information as in SIB1
+	q-RxLevMin-r13					Q-RxLevMin,
+	q-RxLevMinOffset					INTEGER (1..8)			OPTIONAL,	-- Need OP
+	-- Cell re-selection information as in SIB3
+	q-Hyst-r13							ENUMERATED {
+											dB0, dB1, dB2, dB3, dB4, dB5, dB6, dB8, dB10,
+											dB12, dB14, dB16, dB18, dB20, dB22, dB24},
+	q-RxLevMinReselection-r13			Q-RxLevMin,
+	t-ReselectionEUTRA-r13				T-Reselection
+}
+
+
+
+ConditionalReconfiguration-r16 ::= SEQUENCE {
+	condReconfigurationToAddModList-r16	CondReconfigurationToAddModList-r16		OPTIONAL, -- Need ON
+	condReconfigurationToRemoveList-r16	CondReconfigurationToRemoveList-r16		OPTIONAL, -- Need ON
+	attemptCondReconf-r16				ENUMERATED {true}						OPTIONAL, -- Cond CHO
+	...
+}
+
+CondReconfigurationToRemoveList-r16 ::= SEQUENCE (SIZE (1..maxCondConfig-r16)) OF CondReconfigurationId-r16
+
+
+
+CondReconfigurationId-r16 ::= INTEGER (1.. maxCondConfig-r16)
+
+
+
+CondReconfigurationToAddModList-r16 ::= SEQUENCE (SIZE (1.. maxCondConfig-r16)) OF CondReconfigurationAddMod-r16
+
+CondReconfigurationAddMod-r16 ::= SEQUENCE {
+	condReconfigurationId-r16			CondReconfigurationId-r16,
+	triggerCondition-r16				SEQUENCE (SIZE (1..2)) OF MeasId
+													OPTIONAL,  -- Cond CondReconfigurationAdd
+	condReconfigurationToApply-r16	OCTET STRING (CONTAINING RRCConnectionReconfiguration)
+													OPTIONAL,-- Cond CondReconfigurationAdd
+	...
+}
+
+
+
+CSG-Identity ::=					BIT STRING (SIZE (27))
+
+
+
+FreqBandIndicator ::=					INTEGER (1..maxFBI)
+
+FreqBandIndicator-v9e0 ::=				INTEGER (maxFBI-Plus1..maxFBI2)
+
+FreqBandIndicator-r11 ::=				INTEGER (1..maxFBI2)
+
+
+
+FreqBandIndicatorNR-r15 ::=			INTEGER (1.. maxFBI-NR-r15)
+
+
+
+MobilityControlInfo ::=		SEQUENCE {
+	targetPhysCellId					PhysCellId,
+	carrierFreq							CarrierFreqEUTRA					OPTIONAL,	-- Cond HO-toEUTRA2
+	carrierBandwidth					CarrierBandwidthEUTRA				OPTIONAL,	-- Cond HO-toEUTRA
+	additionalSpectrumEmission			AdditionalSpectrumEmission			OPTIONAL,	-- Cond HO-toEUTRA
+	t304								ENUMERATED {
+											ms50, ms100, ms150, ms200, ms500, ms1000,
+											ms2000, ms10000-v1310},
+	newUE-Identity						C-RNTI,
+	radioResourceConfigCommon			RadioResourceConfigCommon,
+	rach-ConfigDedicated				RACH-ConfigDedicated				OPTIONAL,	-- Need OP
+	...,
+	[[	carrierFreq-v9e0				CarrierFreqEUTRA-v9e0				OPTIONAL	-- Need ON
+	]],
+	[[	drb-ContinueROHC-r11			ENUMERATED {true}					OPTIONAL	-- Cond HO
+	]],
+	[[	mobilityControlInfoV2X-r14	MobilityControlInfoV2X-r14				OPTIONAL,	-- Need ON
+		handoverWithoutWT-Change-r14	ENUMERATED {keepLWA-Config, sendEndMarker}	OPTIONAL,	-- Cond HO
+		makeBeforeBreak-r14				ENUMERATED {true}					OPTIONAL,	-- Need OR
+		rach-Skip-r14					RACH-Skip-r14						OPTIONAL,	-- Need OR
+		sameSFN-Indication-r14			ENUMERATED {true}					OPTIONAL	-- Cond HO-SFNsynced
+	]],
+	[[
+		mib-RepetitionStatus-r14		BOOLEAN								OPTIONAL,	-- Need OR
+		schedulingInfoSIB1-BR-r14		INTEGER (0..31)						OPTIONAL	-- Cond HO-SFNsynced
+	]],
+	[[	daps-Config-r16					DAPS-Config-r16						OPTIONAL	-- Cond NotFullConfigHO
+	]]
+}
+
+MobilityControlInfo-v10l0 ::=		SEQUENCE {
+	additionalSpectrumEmission-v10l0	AdditionalSpectrumEmission-v10l0	OPTIONAL	-- Need ON
+}
+
+MobilityControlInfoSCG-r12 ::=		SEQUENCE {
+	t307-r12							ENUMERATED {
+											ms50, ms100, ms150, ms200, ms500, ms1000,
+											ms2000, spare1},
+	ue-IdentitySCG-r12					C-RNTI							OPTIONAL,	-- Cond SCGEst,
+	rach-ConfigDedicated-r12			RACH-ConfigDedicated			OPTIONAL,	-- Need OP
+	cipheringAlgorithmSCG-r12		CipheringAlgorithm-r12		OPTIONAL,	-- Need ON
+	...,
+	[[	makeBeforeBreakSCG-r14			ENUMERATED {true}				OPTIONAL,	-- Need OR
+		rach-SkipSCG-r14				RACH-Skip-r14					OPTIONAL	-- Need OR
+	]]
+}
+
+MobilityControlInfoV2X-r14 ::=	SEQUENCE {
+	v2x-CommTxPoolExceptional-r14		SL-CommResourcePoolV2X-r14		OPTIONAL,		-- Need OR
+	v2x-CommRxPool-r14					SL-CommRxPoolListV2X-r14		OPTIONAL,		-- Need OR
+	v2x-CommSyncConfig-r14				SL-SyncConfigListV2X-r14		OPTIONAL,		-- Need OR
+	cbr-MobilityTxConfigList-r14		SL-CBR-CommonTxConfigList-r14	OPTIONAL		-- Need OR
+}
+
+CarrierBandwidthEUTRA ::=			SEQUENCE {
+	dl-Bandwidth						ENUMERATED {
+												n6, n15, n25, n50, n75, n100, spare10,
+												spare9, spare8, spare7, spare6, spare5,
+												spare4, spare3, spare2, spare1},
+	ul-Bandwidth						ENUMERATED {
+												n6, n15, n25, n50, n75, n100, spare10,
+												spare9, spare8, spare7, spare6, spare5,
+												spare4, spare3, spare2, spare1}	OPTIONAL -- Need OP
+}
+
+CarrierFreqEUTRA ::=				SEQUENCE {
+	dl-CarrierFreq						ARFCN-ValueEUTRA,
+	ul-CarrierFreq						ARFCN-ValueEUTRA				OPTIONAL	-- Cond FDD
+}
+
+CarrierFreqEUTRA-v9e0 ::=			SEQUENCE {
+	dl-CarrierFreq-v9e0					ARFCN-ValueEUTRA-r9,
+	ul-CarrierFreq-v9e0					ARFCN-ValueEUTRA-r9			OPTIONAL	-- Cond FDD
+}
+
+DAPS-Config-r16 ::=					SEQUENCE {
+	daps-PowerCoordinationInfo-r16		DAPS-PowerCoordinationInfo-r16	OPTIONAL,	-- Need ON
+	...
+}
+
+DAPS-PowerCoordinationInfo-r16 ::=	SEQUENCE {
+	p-DAPS-Source-r16					INTEGER (1..16),
+	p-DAPS-Target-r16					INTEGER (1..16),
+	powerControlMode-r16				INTEGER (1..2)
+}
+
+RACH-Skip-r14 ::=					SEQUENCE {
+	targetTA-r14					CHOICE {
+		ta0-r14							NULL,
+		mcg-PTAG-r14						NULL,
+		scg-PTAG-r14						NULL,
+		mcg-STAG-r14					STAG-Id-r11,
+		scg-STAG-r14					STAG-Id-r11
+	},
+	ul-ConfigInfo-r14				SEQUENCE {
+		numberOfConfUL-Processes-r14			INTEGER (1..8),
+		ul-SchedInterval-r14			ENUMERATED {sf2, sf5, sf10},
+		ul-StartSubframe-r14			INTEGER (0..9),
+		ul-Grant-r14					BIT STRING (SIZE (16))
+	}																OPTIONAL	-- Need OR
+}
+
+
+
+MobilityParametersCDMA2000 ::=			OCTET STRING
+
+
+
+MobilityStateParameters ::=			SEQUENCE {
+	t-Evaluation						ENUMERATED {
+											s30, s60, s120, s180, s240, spare3, spare2, spare1},
+	t-HystNormal						ENUMERATED {
+											s30, s60, s120, s180, s240, spare3, spare2, spare1},
+	n-CellChangeMedium					INTEGER (1..16),
+	n-CellChangeHigh					INTEGER (1..16)
+}
+
+
+
+MultiBandInfoList ::=	SEQUENCE (SIZE (1..maxMultiBands)) OF FreqBandIndicator
+
+MultiBandInfoList-v9e0 ::=	SEQUENCE (SIZE (1..maxMultiBands)) OF MultiBandInfo-v9e0
+
+MultiBandInfoList-v10j0 ::=	SEQUENCE (SIZE (1..maxMultiBands)) OF NS-PmaxList-r10
+
+MultiBandInfoList-v10l0 ::=	SEQUENCE (SIZE (1..maxMultiBands)) OF NS-PmaxList-v10l0
+
+MultiBandInfoList-r11 ::=	SEQUENCE (SIZE (1..maxMultiBands)) OF FreqBandIndicator-r11
+
+MultiBandInfo-v9e0 ::=		SEQUENCE {
+	freqBandIndicator-v9e0				FreqBandIndicator-v9e0		OPTIONAL	-- Need OP
+}
+
+
+
+MultiFrequencyBandListNR-r15 ::=		SEQUENCE (SIZE (1.. maxMultiBandsNR-r15)) OF FreqBandIndicatorNR-r15
+
+
+
+NS-PmaxList-r10 ::=				SEQUENCE (SIZE (1..maxNS-Pmax-r10)) OF NS-PmaxValue-r10
+
+NS-PmaxList-v10l0 ::=			SEQUENCE (SIZE (1..maxNS-Pmax-r10)) OF NS-PmaxValue-v10l0
+
+NS-PmaxValue-r10 ::=			SEQUENCE {
+	additionalPmax-r10					P-Max							OPTIONAL,	-- Need OP
+	additionalSpectrumEmission			AdditionalSpectrumEmission
+}
+
+NS-PmaxValue-v10l0 ::=			SEQUENCE {
+	additionalSpectrumEmission-v10l0	AdditionalSpectrumEmission-v10l0	OPTIONAL	-- Need OP
+}
+
+
+
+NS-PmaxListNR-r15 ::=				SEQUENCE (SIZE (1..8)) OF NS-PmaxValueNR-r15
+
+NS-PmaxValueNR-r15 ::=			SEQUENCE {
+	additionalPmaxNR-r15					P-MaxNR-r15					OPTIONAL,	-- Need ON
+	additionalSpectrumEmissionNR-r15		AdditionalSpectrumEmissionNR-r15
+}
+
+
+
+PhysCellId ::=						INTEGER (0..503)
+
+
+
+PhysCellIdCDMA2000 ::=			INTEGER (0..maxPNOffset)
+
+
+
+PhysCellIdGERAN ::=				SEQUENCE {
+	networkColourCode					BIT STRING (SIZE (3)),
+	baseStationColourCode				BIT STRING (SIZE (3))
+}
+
+
+
+PhysCellIdNR-r15 ::=			INTEGER (0.. 1007)
+
+
+
+PhysCellIdRange ::=				SEQUENCE {
+	start							PhysCellId,
+	range							ENUMERATED {
+										n4, n8, n12, n16, n24, n32, n48, n64, n84,
+										n96, n128, n168, n252, n504, spare2,
+										spare1}					OPTIONAL	-- Need OP
+}
+
+
+
+PhysCellIdRangeNR-r16 ::=		SEQUENCE {
+	start							PhysCellIdNR-r15,
+	range							ENUMERATED {
+										n4, n8, n12, n16, n24, n32, n48, n64, n84,
+										n96, n128, n168, n252, n504, n1008,
+										spare1}					OPTIONAL	-- Need OP
+}
+
+
+
+PhysCellIdRangeUTRA-FDDList-r9::=		SEQUENCE (SIZE (1..maxPhysCellIdRange-r9)) OF PhysCellIdRangeUTRA-FDD-r9
+
+PhysCellIdRangeUTRA-FDD-r9 ::=			SEQUENCE {
+		start-r9							PhysCellIdUTRA-FDD,
+		range-r9							INTEGER (2..512)				OPTIONAL	-- Need OP
+}
+
+
+
+PhysCellIdUTRA-FDD ::=				INTEGER (0..511)
+
+
+
+PhysCellIdUTRA-TDD ::=				INTEGER (0..127)
+
+
+
+PLMN-Identity ::=					SEQUENCE {
+	mcc									MCC					OPTIONAL,					-- Cond MCC
+	mnc									MNC
+}
+
+MCC ::=								SEQUENCE (SIZE (3)) OF
+											MCC-MNC-Digit
+
+MNC ::=								SEQUENCE (SIZE (2..3)) OF
+											MCC-MNC-Digit
+
+MCC-MNC-Digit ::=					INTEGER (0..9)
+
+
+
+
+PLMN-IdentityList3-r11 ::=				SEQUENCE (SIZE (1..16)) OF PLMN-Identity
+
+
+
+P-MaxNR-r15 ::=				INTEGER (-30..33)
+
+
+
+PreRegistrationInfoHRPD ::=			SEQUENCE {
+	preRegistrationAllowed				BOOLEAN,
+	preRegistrationZoneId				PreRegistrationZoneIdHRPD	OPTIONAL, -- cond PreRegAllowed
+	secondaryPreRegistrationZoneIdList	SecondaryPreRegistrationZoneIdListHRPD	OPTIONAL -- Need OR
+}
+
+SecondaryPreRegistrationZoneIdListHRPD ::=	SEQUENCE (SIZE (1..2)) OF PreRegistrationZoneIdHRPD
+
+PreRegistrationZoneIdHRPD ::=			INTEGER (0..255)
+
+
+
+Q-QualMin-r9 ::=					INTEGER (-34..-3)
+
+
+
+Q-RxLevMin ::=						INTEGER (-70..-22)
+
+
+
+Q-OffsetRange ::=						ENUMERATED {
+												dB-24, dB-22, dB-20, dB-18, dB-16, dB-14,
+												dB-12, dB-10, dB-8, dB-6, dB-5, dB-4, dB-3,
+												dB-2, dB-1, dB0, dB1, dB2, dB3, dB4, dB5,
+												dB6, dB8, dB10, dB12, dB14, dB16, dB18,
+												dB20, dB22, dB24}
+
+
+
+Q-OffsetRangeInterRAT ::=					INTEGER (-15..15)
+
+
+
+ReselectionThreshold ::=				INTEGER (0..31)
+
+
+
+ReselectionThresholdQ-r9 ::=			INTEGER (0..31)
+
+
+
+RSS-ConfigCarrierInfo-r16 ::=	SEQUENCE {
+	narrowbandIndex-r16				BIT STRING (SIZE (1..maxAvailNarrowBands-1-r16)),
+	timeOffsetGranularity-r16		ENUMERATED {g1, g2, g4, g8, g16, g32, g64, g128}
+}
+
+
+
+RSS-MeasPowerBias-r16 ::=	ENUMERATED {dB-6, dB-3, dB0, dB3, dB6, dB9, dB12, rssNotUsed}
+
+
+
+SCellIndex-r10 ::=						INTEGER (1..7)
+SCellIndex-r13 ::=						INTEGER (1..31)
+
+
+
+ServCellIndex-r10 ::=					INTEGER (0..7)
+ServCellIndex-r13 ::=				INTEGER (0..31)
+
+
+
+SpeedStateScaleFactors ::=			SEQUENCE {
+	sf-Medium							ENUMERATED {oDot25, oDot5, oDot75, lDot0},
+	sf-High								ENUMERATED {oDot25, oDot5, oDot75, lDot0}
+}
+
+
+SystemInfoListGERAN ::=				SEQUENCE (SIZE (1..maxGERAN-SI)) OF
+										OCTET STRING (SIZE (1..23))
+
+
+
+SystemTimeInfoCDMA2000 ::=			SEQUENCE {
+	cdma-EUTRA-Synchronisation			BOOLEAN,
+	cdma-SystemTime						CHOICE {
+		synchronousSystemTime				BIT STRING (SIZE (39)),
+		asynchronousSystemTime				BIT STRING (SIZE (49))
+	}
+}
+
+
+
+ThresholdNR-r15 ::=				CHOICE{
+	nr-RSRP-r15							RSRP-RangeNR-r15,
+	nr-RSRQ-r15							RSRQ-RangeNR-r15,
+	nr-SINR-r15							RS-SINR-RangeNR-r15
+}
+
+ThresholdListNR-r15 ::=				SEQUENCE{
+	nr-RSRP-r15							RSRP-RangeNR-r15				OPTIONAL,	-- Need OR
+	nr-RSRQ-r15							RSRQ-RangeNR-r15				OPTIONAL,	-- Need OR
+	nr-SINR-r15							RS-SINR-RangeNR-r15			OPTIONAL	-- Need OR
+}
+
+
+
+TrackingAreaCode ::=				BIT STRING (SIZE (16))
+TrackingAreaCode-5GC-r15 ::=		BIT STRING (SIZE (24))
+
+
+
+T-Reselection ::=					INTEGER (0..7)
+
+
+
+T-ReselectionEUTRA-CE-r13 ::=				INTEGER (0..15)
+
+
+
+AllowedMeasBandwidth ::=				ENUMERATED {mbw6, mbw15, mbw25, mbw50, mbw75, mbw100}
+
+
+
+BT-NameListConfig-r15 ::=		CHOICE{
+	release						NULL,
+	setup						BT-NameList-r15
+}
+
+BT-NameList-r15 ::=			SEQUENCE (SIZE (1..maxBT-Name-r15)) OF BT-Name-r15
+
+BT-Name-r15 ::=		OCTET STRING (SIZE (1..248))
+
+
+
+CSI-RSRP-Range-r12 ::=						INTEGER(0..97)
+
+
+
+Hysteresis ::=							INTEGER (0..30)
+
+
+
+LocationInfo-r10 ::=	SEQUENCE {
+	locationCoordinates-r10					CHOICE {
+		ellipsoid-Point-r10						OCTET STRING,
+		ellipsoidPointWithAltitude-r10			OCTET STRING,
+	...,
+		ellipsoidPointWithUncertaintyCircle-r11					OCTET STRING,
+		ellipsoidPointWithUncertaintyEllipse-r11				OCTET STRING,
+		ellipsoidPointWithAltitudeAndUncertaintyEllipsoid-r11	OCTET STRING,
+		ellipsoidArc-r11										OCTET STRING,
+		polygon-r11												OCTET STRING
+	},
+	horizontalVelocity-r10					OCTET STRING				OPTIONAL,
+	gnss-TOD-msec-r10						OCTET STRING				OPTIONAL,
+	...,
+	[[	verticalVelocityInfo-r15		CHOICE {
+			verticalVelocity-r15				OCTET STRING,
+			verticalVelocityAndUncertainty-r15	OCTET STRING
+	}			OPTIONAL
+	]]
+}
+
+
+
+LogMeasResultListBT-r15 ::=		SEQUENCE (SIZE (1..maxBT-IdReport-r15)) OF LogMeasResultBT-r15
+
+LogMeasResultBT-r15 ::= SEQUENCE {
+	bt-Addr-r15						BIT STRING (SIZE (48)),
+	rssi-BT-r15						INTEGER (-128..127)			OPTIONAL,
+	...
+}
+
+
+
+LogMeasResultListWLAN-r15 ::=		SEQUENCE (SIZE (1..maxWLAN-Id-Report-r14)) OF LogMeasResultWLAN-r15
+
+LogMeasResultWLAN-r15 ::=	SEQUENCE {
+	wlan-Identifiers-r15			WLAN-Identifiers-r12,
+	rssiWLAN-r15					WLAN-RSSI-Range-r13				OPTIONAL,
+	rtt-WLAN-r15					WLAN-RTT-r15					OPTIONAL,
+	...
+}
+
+
+
+MaxRS-IndexCellQualNR-r15::=				INTEGER (1..maxRS-IndexCellQual-r15)
+
+
+
+MBSFN-RSRQ-Range-r12 ::=				INTEGER(0..31)
+
+
+MeasConfig ::=						SEQUENCE {
+	-- Measurement objects
+	measObjectToRemoveList				MeasObjectToRemoveList				OPTIONAL,	-- Need ON
+	measObjectToAddModList				MeasObjectToAddModList				OPTIONAL,	-- Need ON
+	-- Reporting configurations
+	reportConfigToRemoveList			ReportConfigToRemoveList			OPTIONAL,	-- Need ON
+	reportConfigToAddModList			ReportConfigToAddModList			OPTIONAL,	-- Need ON
+	-- Measurement identities
+	measIdToRemoveList					MeasIdToRemoveList					OPTIONAL,	-- Need ON
+	measIdToAddModList					MeasIdToAddModList					OPTIONAL,	-- Need ON
+	-- Other parameters
+	quantityConfig						QuantityConfig						OPTIONAL,	-- Need ON
+	measGapConfig						MeasGapConfig						OPTIONAL,	-- Need ON
+	s-Measure							RSRP-Range							OPTIONAL,	-- Need ON
+	preRegistrationInfoHRPD				PreRegistrationInfoHRPD				OPTIONAL,	-- Need OP
+	speedStatePars			CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			mobilityStateParameters				MobilityStateParameters,
+			timeToTrigger-SF					SpeedStateScaleFactors
+		}
+	}																		OPTIONAL,	-- Need ON
+	...,
+	[[	measObjectToAddModList-v9e0			MeasObjectToAddModList-v9e0		OPTIONAL	-- Need ON
+	]],
+	[[	allowInterruptions-r11				BOOLEAN							OPTIONAL	-- Need ON
+	]],
+	[[	measScaleFactor-r12			CHOICE {
+			release						NULL,
+			setup						MeasScaleFactor-r12
+		}																OPTIONAL,	-- Need ON
+		measIdToRemoveListExt-r12			MeasIdToRemoveListExt-r12		OPTIONAL,	-- Need ON
+		measIdToAddModListExt-r12			MeasIdToAddModListExt-r12		OPTIONAL,	-- Need ON
+		measRSRQ-OnAllSymbols-r12		BOOLEAN							OPTIONAL	-- Need ON
+	]],
+	[[
+		measObjectToRemoveListExt-r13		MeasObjectToRemoveListExt-r13	OPTIONAL,	-- Need ON
+		measObjectToAddModListExt-r13		MeasObjectToAddModListExt-r13	OPTIONAL,	-- Need ON
+		measIdToAddModList-v1310			MeasIdToAddModList-v1310		OPTIONAL,	-- Need ON
+		measIdToAddModListExt-v1310			MeasIdToAddModListExt-v1310		OPTIONAL	-- Need ON
+	]],
+	[[	measGapConfigPerCC-List-r14			MeasGapConfigPerCC-List-r14		OPTIONAL,	-- Need ON
+		measGapSharingConfig-r14			MeasGapSharingConfig-r14		OPTIONAL	-- Need ON
+	]],
+	[[	fr1-Gap-r15								BOOLEAN		OPTIONAL,	-- Need ON
+		mgta-r15								BOOLEAN						OPTIONAL	-- Need ON
+	]],
+	[[	measGapConfigDensePRS-r15			MeasGapConfigDensePRS-r15	OPTIONAL,	 -- Need ON
+		heightThreshRef-r15	CHOICE {
+			release					NULL,
+			setup					INTEGER (0..31)
+		}										OPTIONAL	--Need ON
+	]]
+}
+
+MeasIdToRemoveList ::=				SEQUENCE (SIZE (1..maxMeasId)) OF MeasId
+
+MeasIdToRemoveListExt-r12 ::=		SEQUENCE (SIZE (1..maxMeasId)) OF MeasId-v1250
+
+MeasObjectToRemoveList ::=			SEQUENCE (SIZE (1..maxObjectId)) OF MeasObjectId
+
+MeasObjectToRemoveListExt-r13 ::=	SEQUENCE (SIZE (1..maxObjectId)) OF MeasObjectId-v1310
+
+ReportConfigToRemoveList ::=		SEQUENCE (SIZE (1..maxReportConfigId)) OF ReportConfigId
+
+
+
+MeasDS-Config-r12 ::=			CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		dmtc-PeriodOffset-r12			CHOICE {
+			ms40-r12						INTEGER(0..39),
+			ms80-r12						INTEGER(0..79),
+			ms160-r12						INTEGER(0..159),
+			...
+		},
+		ds-OccasionDuration-r12		CHOICE {
+			durationFDD-r12				INTEGER(1..maxDS-Duration-r12),
+			durationTDD-r12				INTEGER(2..maxDS-Duration-r12)
+		},
+		measCSI-RS-ToRemoveList-r12	MeasCSI-RS-ToRemoveList-r12	OPTIONAL,	-- Need ON
+		measCSI-RS-ToAddModList-r12	MeasCSI-RS-ToAddModList-r12	OPTIONAL,	-- Need ON
+		...
+	}
+}
+
+MeasCSI-RS-ToRemoveList-r12 ::=	SEQUENCE (SIZE (1..maxCSI-RS-Meas-r12)) OF MeasCSI-RS-Id-r12
+
+MeasCSI-RS-ToAddModList-r12 ::=	SEQUENCE (SIZE (1..maxCSI-RS-Meas-r12)) OF MeasCSI-RS-Config-r12
+
+MeasCSI-RS-Id-r12 ::=			INTEGER (1..maxCSI-RS-Meas-r12)
+
+MeasCSI-RS-Config-r12 ::=		SEQUENCE {
+	measCSI-RS-Id-r12				MeasCSI-RS-Id-r12,
+	physCellId-r12					INTEGER (0..503),
+	scramblingIdentity-r12			INTEGER (0..503),
+	resourceConfig-r12				INTEGER (0..31),
+	subframeOffset-r12				INTEGER (0..4),
+	csi-RS-IndividualOffset-r12		Q-OffsetRange,
+	...
+}
+
+
+
+MeasGapConfig ::=					CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		gapOffset							CHOICE {
+				gp0									INTEGER (0..39),
+				gp1									INTEGER (0..79),
+				
+				...,
+				gp2-r14								INTEGER (0..39),
+				gp3-r14								INTEGER (0..79),
+				gp-ncsg0-r14						INTEGER (0..39),
+				gp-ncsg1-r14						INTEGER (0..79),
+				gp-ncsg2-r14						INTEGER (0..39),
+				gp-ncsg3-r14						INTEGER (0..79),
+				gp-nonUniform1-r14					INTEGER (0..1279),
+				gp-nonUniform2-r14					INTEGER (0..2559),
+				gp-nonUniform3-r14					INTEGER (0..5119),
+				gp-nonUniform4-r14					INTEGER (0..10239),
+				gp4-r15								INTEGER (0..19),
+				gp5-r15								INTEGER (0..159),
+				gp6-r15								INTEGER (0..19),
+				gp7-r15								INTEGER (0..39),
+				gp8-r15								INTEGER (0..79),
+				gp9-r15								INTEGER (0..159),
+				gp10-r15							INTEGER (0..19),
+				gp11-r15							INTEGER (0..159)
+		}
+	}
+}
+
+
+
+
+MeasGapConfigDensePRS-r15 ::=	CHOICE {
+	release							NULL,
+	setup							SEQUENCE {
+		gapOffsetDensePRS-r15			CHOICE {
+			rstd0-r15						INTEGER (0..79),
+			rstd1-r15						INTEGER (0..159),
+			rstd2-r15						INTEGER (0..319),
+			rstd3-r15						INTEGER (0..639),
+			rstd4-r15						INTEGER (0..1279),
+			rstd5-r15						INTEGER (0..159),
+			rstd6-r15						INTEGER (0..319),
+			rstd7-r15						INTEGER (0..639),
+			rstd8-r15						INTEGER (0..1279),
+			rstd9-r15						INTEGER (0..319),
+			rstd10-r15						INTEGER (0..639),
+			rstd11-r15						INTEGER (0..1279),
+			rstd12-r15						INTEGER (0..319),
+			rstd13-r15						INTEGER (0..639),
+			rstd14-r15						INTEGER (0..1279),
+			rstd15-r15						INTEGER (0..639),
+			rstd16-r15						INTEGER (0..1279),
+			rstd17-r15						INTEGER (0..639),
+			rstd18-r15						INTEGER (0..1279),
+			rstd19-r15						INTEGER (0..639),
+			rstd20-r15						INTEGER (0..1279),
+			...
+		}
+	}
+}
+
+
+
+MeasGapConfigPerCC-List-r14 ::=	CHOICE {
+	release						NULL,
+	setup						SEQUENCE {
+		measGapConfigToRemoveList-r14	MeasGapConfigToRemoveList-r14	OPTIONAL,	-- Need ON
+		measGapConfigToAddModList-r14	MeasGapConfigToAddModList-r14	OPTIONAL	-- Need ON
+	}
+}
+
+MeasGapConfigToRemoveList-r14 ::=	SEQUENCE (SIZE (1..maxServCell-r13)) OF ServCellIndex-r13
+
+MeasGapConfigToAddModList-r14 ::=	SEQUENCE (SIZE (1..maxServCell-r13)) OF MeasGapConfigPerCC-r14
+
+MeasGapConfigPerCC-r14 ::=	SEQUENCE {
+	servCellId-r14				ServCellIndex-r13,
+	measGapConfigCC-r14			MeasGapConfig
+}
+
+
+
+MeasGapSharingConfig-r14 ::=			CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		measGapSharingScheme-r14				ENUMERATED {scheme00, scheme01, scheme10, scheme11}	
+	}
+}
+
+
+
+MeasId ::=							INTEGER (1..maxMeasId)
+
+MeasId-v1250 ::=					INTEGER (maxMeasId-Plus1..maxMeasId-r12)
+
+
+
+MeasIdleConfigSIB-r15 ::= SEQUENCE {
+	measIdleCarrierListEUTRA-r15	EUTRA-CarrierList-r15,
+	...
+}
+
+MeasIdleConfigSIB-NR-r16 ::= SEQUENCE {
+	measIdleCarrierListNR-r16		NR-CarrierList-r16,
+	...
+}
+
+MeasIdleConfigDedicated-r15 ::= SEQUENCE {
+	measIdleCarrierListEUTRA-r15	EUTRA-CarrierList-r15				OPTIONAL,	-- Need OR
+	measIdleDuration-r15		ENUMERATED {sec10, sec30, sec60, sec120,
+												sec180, sec240, sec300, spare},
+	...,
+	[[
+	measIdleCarrierListNR-r16		NR-CarrierList-r16					OPTIONAL,  -- Need OR
+	validityAreaList-r16			ValidityAreaList-r16				OPTIONAL   -- Need OR
+	]]
+}
+
+EUTRA-CarrierList-r15 ::= SEQUENCE (SIZE (1..maxFreqIdle-r15)) OF MeasIdleCarrierEUTRA-r15
+NR-CarrierList-r16 ::= SEQUENCE (SIZE (1..maxFreqIdle-r15)) OF MeasIdleCarrierNR-r16
+
+MeasIdleCarrierEUTRA-r15::=			SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueEUTRA-r9,
+	allowedMeasBandwidth-r15			AllowedMeasBandwidth,
+	validityArea-r15					CellList-r15					OPTIONAL,	-- Need OR
+	measCellList-r15					CellList-r15					OPTIONAL,	-- Need OR
+	reportQuantities					ENUMERATED {rsrp, rsrq, both},
+	qualityThreshold-r15				SEQUENCE {
+		idleRSRP-Threshold-r15				RSRP-Range					OPTIONAL,	-- Need OR
+		idleRSRQ-Threshold-r15				RSRQ-Range-r13				OPTIONAL	-- Need OR
+	}																	OPTIONAL,	-- Need OP
+	...
+}
+
+ValidityAreaList-r16 ::= SEQUENCE (SIZE (1..maxFreqIdle-r15)) OF ValidityArea-r16
+
+ValidityArea-r16 ::= SEQUENCE {
+	carrierFreq-r16			ARFCN-ValueEUTRA-r9,
+	validityCellList-r16		ValidityCellList-r16					OPTIONAL  -- Need ON
+}
+
+ValidityCellList-r16 ::= SEQUENCE (SIZE (1.. maxCellMeasIdle-r15)) OF PhysCellIdRange
+
+MeasIdleCarrierNR-r16 ::=		SEQUENCE {
+	carrierFreqNR-r16				ARFCN-ValueNR-r15,
+	subcarrierSpacingSSB-r16		ENUMERATED {kHz15, kHz30, kHz120, kHz240},
+	frequencyBandList				MultiFrequencyBandListNR-r15		OPTIONAL,  -- Need OR
+	measCellListNR-r16				CellListNR-r16						OPTIONAL,  -- Need OR
+	reportQuantitiesNR-r16			ENUMERATED {rsrp, rsrq, both},
+	qualityThresholdNR-r16			SEQUENCE {
+		idleRSRP-ThresholdNR-r16		RSRP-RangeNR-r15				OPTIONAL,  -- Need OR
+		idleRSRQ-ThresholdNR-r16		RSRQ-RangeNR-r15				OPTIONAL   -- Need OR
+	}																	OPTIONAL,  -- Need OR
+	ssb-MeasConfig-r16				SEQUENCE {
+		maxRS-IndexCellQual-r16			MaxRS-IndexCellQualNR-r15		OPTIONAL,  -- Need OR
+		threshRS-Index-r16				ThresholdListNR-r15				OPTIONAL,  -- Need OR
+		measTimingConfig-r16			MTC-SSB-NR-r15					OPTIONAL,  -- Need OR
+		ssb-ToMeasure-r16				SSB-ToMeasure-r15				OPTIONAL,  -- Need OR
+		deriveSSB-IndexFromCell-r16		BOOLEAN,
+		ss-RSSI-Measurement-r16			SS-RSSI-Measurement-r15			OPTIONAL   -- Need OP
+	}																	OPTIONAL,   -- Need OP
+	beamMeasConfigIdle-r16			BeamMeasConfigIdleNR-r16			OPTIONAL,  -- Need OR
+	...
+}
+
+CellList-r15 ::=			SEQUENCE (SIZE (1..maxCellMeasIdle-r15)) OF PhysCellIdRange
+CellListNR-r16 ::=			SEQUENCE (SIZE (1..maxCellMeasIdle-r15)) OF PhysCellIdRangeNR-r16
+
+BeamMeasConfigIdleNR-r16 ::=		SEQUENCE {
+	reportQuantityRS-IndexNR-r16		ENUMERATED {rsrp, rsrq, both},
+	maxReportRS-Index-r16				INTEGER (0..maxRS-IndexReport-r15),
+	reportRS-IndexResultsNR-r16			BOOLEAN
+}
+
+
+
+MeasIdToAddModList ::=				SEQUENCE (SIZE (1..maxMeasId)) OF MeasIdToAddMod
+
+MeasIdToAddModList-v1310 ::=		SEQUENCE (SIZE (1..maxMeasId)) OF MeasIdToAddMod-v1310
+
+MeasIdToAddModListExt-r12 ::=		SEQUENCE (SIZE (1..maxMeasId)) OF MeasIdToAddModExt-r12
+
+MeasIdToAddModListExt-v1310 ::=		SEQUENCE (SIZE (1..maxMeasId)) OF MeasIdToAddMod-v1310
+
+MeasIdToAddMod ::=	SEQUENCE {
+	measId								MeasId,
+	measObjectId						MeasObjectId,
+	reportConfigId						ReportConfigId
+}
+
+MeasIdToAddModExt-r12 ::=	SEQUENCE {
+	measId-v1250						MeasId-v1250,
+	measObjectId-r12					MeasObjectId,
+	reportConfigId-r12					ReportConfigId
+}
+
+MeasIdToAddMod-v1310 ::=	SEQUENCE {
+	measObjectId-v1310			MeasObjectId-v1310		OPTIONAL
+}
+
+
+
+MeasObjectCDMA2000 ::=				SEQUENCE {
+	cdma2000-Type						CDMA2000-Type,
+	carrierFreq							CarrierFreqCDMA2000,
+	searchWindowSize					INTEGER (0..15)						OPTIONAL,	-- Need ON
+	offsetFreq							Q-OffsetRangeInterRAT				DEFAULT 0,
+	cellsToRemoveList					CellIndexList						OPTIONAL,	-- Need ON
+	cellsToAddModList					CellsToAddModListCDMA2000			OPTIONAL,	-- Need ON
+	cellForWhichToReportCGI				PhysCellIdCDMA2000					OPTIONAL,	-- Need ON
+	...
+}
+
+CellsToAddModListCDMA2000 ::=		SEQUENCE (SIZE (1..maxCellMeas)) OF CellsToAddModCDMA2000
+
+CellsToAddModCDMA2000 ::=	SEQUENCE {
+	cellIndex							INTEGER (1..maxCellMeas),
+	physCellId							PhysCellIdCDMA2000
+}
+
+
+
+MeasObjectEUTRA ::=					SEQUENCE {
+	carrierFreq							ARFCN-ValueEUTRA,
+	allowedMeasBandwidth				AllowedMeasBandwidth,
+	presenceAntennaPort1				PresenceAntennaPort1,
+	neighCellConfig						NeighCellConfig,
+	offsetFreq							Q-OffsetRange				DEFAULT dB0,
+	-- Cell list
+	cellsToRemoveList					CellIndexList				OPTIONAL,		-- Need ON
+	cellsToAddModList					CellsToAddModList			OPTIONAL,		-- Need ON
+	-- Black list
+	blackCellsToRemoveList				CellIndexList				OPTIONAL,		-- Need ON
+	blackCellsToAddModList				BlackCellsToAddModList		OPTIONAL,		-- Need ON
+	cellForWhichToReportCGI				PhysCellId					OPTIONAL,		-- Need ON
+	...,
+	[[measCycleSCell-r10				MeasCycleSCell-r10		OPTIONAL,		-- Need ON
+		measSubframePatternConfigNeigh-r10	MeasSubframePatternConfigNeigh-r10	OPTIONAL							-- Need ON
+	]],
+	[[widebandRSRQ-Meas-r11				BOOLEAN	OPTIONAL		-- Cond WB-RSRQ
+	]],
+	[[	altTTT-CellsToRemoveList-r12	CellIndexList				OPTIONAL,		-- Need ON
+		altTTT-CellsToAddModList-r12	AltTTT-CellsToAddModList-r12	OPTIONAL,		-- Need ON
+		t312-r12						CHOICE {
+			release							NULL,
+			setup							ENUMERATED {ms0, ms50, ms100, ms200,
+											ms300, ms400, ms500, ms1000}
+		}														OPTIONAL,		-- Need ON
+		reducedMeasPerformance-r12		BOOLEAN					OPTIONAL,		-- Need ON
+		measDS-Config-r12				MeasDS-Config-r12			OPTIONAL		-- Need ON
+	]],
+	[[	
+		whiteCellsToRemoveList-r13		CellIndexList				OPTIONAL,		-- Need ON
+		whiteCellsToAddModList-r13		WhiteCellsToAddModList-r13	OPTIONAL,		-- Need ON
+		rmtc-Config-r13				RMTC-Config-r13			OPTIONAL,		-- Need ON
+		carrierFreq-r13					ARFCN-ValueEUTRA-v9e0		OPTIONAL			-- Need ON
+	]],
+	[[	
+		tx-ResourcePoolToRemoveList-r14	Tx-ResourcePoolMeasList-r14		OPTIONAL,	-- Need ON
+		tx-ResourcePoolToAddList-r14	Tx-ResourcePoolMeasList-r14		OPTIONAL,	-- Need ON
+		fembms-MixedCarrier-r14				BOOLEAN					OPTIONAL			-- Need ON
+	]],
+	[[
+		measSensing-Config-r15			MeasSensing-Config-r15		OPTIONAL		-- Need ON
+	]],
+	[[
+		measRSS-DedicatedConfig-r16		SetupRelease {MeasRSS-DedicatedConfig-r16}		OPTIONAL	-- Need ON
+	]]
+}
+
+MeasObjectEUTRA-v9e0 ::=			SEQUENCE {
+	carrierFreq-v9e0					ARFCN-ValueEUTRA-v9e0
+}
+
+MeasRSS-DedicatedConfig-r16 ::= SEQUENCE {
+	rss-ConfigCarrierInfo-r16		RSS-ConfigCarrierInfo-r16	OPTIONAL,	-- Need OP
+	cellsToAddModList-v1610			CellsToAddModList-v1610		OPTIONAL	-- Need ON
+}
+
+CellsToAddModList ::=				SEQUENCE (SIZE (1..maxCellMeas)) OF CellsToAddMod
+
+CellsToAddModList-v1610 ::=			SEQUENCE (SIZE (1..maxCellMeas)) OF CellsToAddMod-v1610
+
+CellsToAddMod ::=	SEQUENCE {
+	cellIndex							INTEGER (1..maxCellMeas),
+	physCellId							PhysCellId,
+	cellIndividualOffset				Q-OffsetRange
+}
+
+CellsToAddMod-v1610 ::= 		SEQUENCE {
+	rss-MeasPowerBias-r16			RSS-MeasPowerBias-r16
+}
+
+
+BlackCellsToAddModList ::=			SEQUENCE (SIZE (1..maxCellMeas)) OF BlackCellsToAddMod
+
+BlackCellsToAddMod ::=	SEQUENCE {
+	cellIndex							INTEGER (1..maxCellMeas),
+	physCellIdRange						PhysCellIdRange
+}
+
+MeasCycleSCell-r10 ::=				ENUMERATED {sf160, sf256, sf320, sf512,
+													sf640, sf1024, sf1280, spare1}
+
+MeasSubframePatternConfigNeigh-r10 ::=	CHOICE {
+	release									NULL,
+	setup									SEQUENCE {
+		measSubframePatternNeigh-r10			MeasSubframePattern-r10,
+		measSubframeCellList-r10				MeasSubframeCellList-r10	OPTIONAL	-- Cond always
+	}
+}
+
+MeasSubframeCellList-r10 ::=	SEQUENCE (SIZE (1..maxCellMeas)) OF PhysCellIdRange
+
+AltTTT-CellsToAddModList-r12 ::=	SEQUENCE (SIZE (1..maxCellMeas)) OF AltTTT-CellsToAddMod-r12
+
+AltTTT-CellsToAddMod-r12 ::=	SEQUENCE {
+	cellIndex-r12							INTEGER (1..maxCellMeas),
+	physCellIdRange-r12						PhysCellIdRange
+}
+
+WhiteCellsToAddModList-r13 ::=			SEQUENCE (SIZE (1..maxCellMeas)) OF WhiteCellsToAddMod-r13
+
+WhiteCellsToAddMod-r13 ::=	SEQUENCE {
+	cellIndex-r13							INTEGER (1..maxCellMeas),
+	physCellIdRange-r13						PhysCellIdRange
+}
+
+RMTC-Config-r13 ::=	CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		rmtc-Period-r13					ENUMERATED {ms40, ms80, ms160, ms320, ms640},
+		rmtc-SubframeOffset-r13			INTEGER(0..639)					OPTIONAL,		-- Need ON
+		measDuration-r13				ENUMERATED {sym1, sym14, sym28, sym42, sym70},
+		...
+	}
+}
+
+Tx-ResourcePoolMeasList-r14 ::=	SEQUENCE (SIZE (1..maxSL-PoolToMeasure-r14)) OF SL-V2X-TxPoolReportIdentity-r14
+
+
+
+MeasObjectGERAN ::=					SEQUENCE {
+	carrierFreqs						CarrierFreqsGERAN,
+	offsetFreq							Q-OffsetRangeInterRAT		DEFAULT 0,
+	ncc-Permitted						BIT STRING(SIZE (8))		DEFAULT '11111111'B,
+	cellForWhichToReportCGI				PhysCellIdGERAN				OPTIONAL,	-- Need ON
+	...
+}
+
+
+
+MeasObjectId ::=					INTEGER (1..maxObjectId)
+
+MeasObjectId-v1310 ::=			INTEGER (maxObjectId-Plus1-r13..maxObjectId-r13)
+
+MeasObjectId-r13 ::=				INTEGER (1..maxObjectId-r13)
+
+
+
+MeasObjectNR-r15 ::=				SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueNR-r15,
+	rs-ConfigSSB-r15					RS-ConfigSSB-NR-r15,
+	threshRS-Index-r15					ThresholdListNR-r15				OPTIONAL,		-- Need OR
+	maxRS-IndexCellQual-r15				MaxRS-IndexCellQualNR-r15		OPTIONAL,		-- Need OR
+	offsetFreq-r15						Q-OffsetRangeInterRAT			DEFAULT 0,
+	blackCellsToRemoveList-r15			CellIndexList					OPTIONAL,		-- Need ON
+	blackCellsToAddModList-r15			CellsToAddModListNR-r15			OPTIONAL,		-- Need ON
+	quantityConfigSet-r15				INTEGER (1.. maxQuantSetsNR-r15),
+	cellsForWhichToReportSFTD-r15		SEQUENCE (SIZE (1..maxCellSFTD)) OF PhysCellIdNR-r15	OPTIONAL,	-- Need OR
+	...,
+	[[	cellForWhichToReportCGI-r15			PhysCellIdNR-r15				OPTIONAL,	-- Need ON
+		deriveSSB-IndexFromCell-r15			BOOLEAN							OPTIONAL,	-- Need ON
+		ss-RSSI-Measurement-r15				SS-RSSI-Measurement-r15			OPTIONAL,	-- Need ON
+		bandNR-r15					CHOICE {
+			release						NULL,
+			setup						FreqBandIndicatorNR-r15
+		}																OPTIONAL	-- Need ON
+	]],
+	[[
+	rmtc-ConfigNR-r16						SetupRelease {RMTC-ConfigNR-r16}			OPTIONAL		-- Cond SharedSpectrum
+	]]
+}
+
+RS-ConfigSSB-NR-r15 ::=			SEQUENCE {
+	measTimingConfig-r15			MTC-SSB-NR-r15,
+	subcarrierSpacingSSB-r15	ENUMERATED {kHz15, kHz30, kHz120, kHz240},
+	...,
+	[[	ssb-ToMeasure-r15			CHOICE {
+			release						NULL,
+			setup						SSB-ToMeasure-r15
+		}											OPTIONAL	-- Need ON
+	]],
+	[[
+	ssb-PositionQCL-CommonNR-r16	SSB-PositionQCL-RelationNR-r16	OPTIONAL,	-- Cond SharedSpectrum
+	ssb-PositionQCL-CellsToAddModListNR-r16	SSB-PositionQCL-CellsToAddModListNR-r16	OPTIONAL,	-- Cond SharedSpectrum
+	ssb-PositionQCL-CellsToRemoveListNR-r16	SEQUENCE (SIZE (1..maxCellMeas)) OF PhysCellIdNR-r15	OPTIONAL	-- Cond SharedSpectrum
+	]]
+}
+
+CellsToAddModListNR-r15 ::=			SEQUENCE (SIZE (1..maxCellMeas)) OF CellsToAddModNR-r15
+
+CellsToAddModNR-r15 ::=			SEQUENCE {
+	cellIndex-r15					INTEGER (1..maxCellMeas),
+	physCellId-r15					PhysCellIdNR-r15
+}
+
+SSB-PositionQCL-CellsToAddModListNR-r16 ::=	SEQUENCE (SIZE (1..maxCellMeas)) OF SSB-PositionQCL-CellsToAddNR-r16
+
+
+SSB-PositionQCL-CellsToAddNR-r16 ::=	SEQUENCE {
+	physCellId-r16							PhysCellIdNR-r15,
+	ssb-PositionQCL-r16						SSB-PositionQCL-RelationNR-r16
+}
+
+RMTC-ConfigNR-r16 ::=	SEQUENCE {
+	rmtc-PeriodicityNR-r16				ENUMERATED {ms40, ms80, ms160, ms320, ms640},
+	rmtc-SubframeOffsetNR-r16			INTEGER(0..639)			OPTIONAL,	-- Need ON
+	measDurationNR-r16					ENUMERATED {sym1, sym14or12, sym28or24, sym42or36, sym70or60},
+	rmtc-FrequencyNR-r16				ARFCN-ValueNR-r15,
+	refSCS-CP-NR-r16					ENUMERATED {kHz15, kHz30, kHz60-NCP, kHz60-ECP},
+	...
+}
+
+
+
+MeasObjectToAddModList ::=			SEQUENCE (SIZE (1..maxObjectId)) OF MeasObjectToAddMod
+
+MeasObjectToAddModListExt-r13 ::=	SEQUENCE (SIZE (1..maxObjectId)) OF MeasObjectToAddModExt-r13
+
+MeasObjectToAddModList-v9e0 ::=		SEQUENCE (SIZE (1..maxObjectId)) OF MeasObjectToAddMod-v9e0
+
+MeasObjectToAddMod ::=	SEQUENCE {
+	measObjectId						MeasObjectId,
+	measObject							CHOICE {
+		measObjectEUTRA						MeasObjectEUTRA,
+		measObjectUTRA						MeasObjectUTRA,
+		measObjectGERAN						MeasObjectGERAN,
+		measObjectCDMA2000					MeasObjectCDMA2000,
+		...,
+		measObjectWLAN-r13					MeasObjectWLAN-r13,
+		measObjectNR-r15					MeasObjectNR-r15
+	}
+}
+
+MeasObjectToAddModExt-r13 ::=	SEQUENCE {
+	measObjectId-r13					MeasObjectId-v1310,
+	measObject-r13							CHOICE {
+		measObjectEUTRA-r13						MeasObjectEUTRA,
+		measObjectUTRA-r13						MeasObjectUTRA,
+		measObjectGERAN-r13						MeasObjectGERAN,
+		measObjectCDMA2000-r13					MeasObjectCDMA2000,
+		...,
+		measObjectWLAN-v1320					MeasObjectWLAN-r13,
+		measObjectNR-r15						MeasObjectNR-r15
+	}
+}
+
+MeasObjectToAddMod-v9e0 ::=	SEQUENCE {
+	measObjectEUTRA-v9e0				MeasObjectEUTRA-v9e0		OPTIONAL	-- Cond eutra
+}
+
+
+
+MeasObjectUTRA ::=					SEQUENCE {
+	carrierFreq							ARFCN-ValueUTRA,
+	offsetFreq							Q-OffsetRangeInterRAT		DEFAULT 0,
+	cellsToRemoveList					CellIndexList				OPTIONAL,			-- Need ON
+	cellsToAddModList					CHOICE {
+		cellsToAddModListUTRA-FDD			CellsToAddModListUTRA-FDD,
+		cellsToAddModListUTRA-TDD			CellsToAddModListUTRA-TDD
+	}																OPTIONAL,			-- Need ON
+	cellForWhichToReportCGI				CHOICE {
+		utra-FDD							PhysCellIdUTRA-FDD,
+		utra-TDD							PhysCellIdUTRA-TDD
+	}																OPTIONAL,	-- Need ON
+	...,
+	[[	csg-allowedReportingCells-v930			CSG-AllowedReportingCells-r9	OPTIONAL		-- Need ON
+	]],
+	[[	reducedMeasPerformance-r12				BOOLEAN			OPTIONAL		-- Need ON
+	]]
+}
+
+CellsToAddModListUTRA-FDD ::=		SEQUENCE (SIZE (1..maxCellMeas)) OF CellsToAddModUTRA-FDD
+
+CellsToAddModUTRA-FDD ::=	SEQUENCE {
+	cellIndex							INTEGER (1..maxCellMeas),
+	physCellId							PhysCellIdUTRA-FDD
+}
+
+CellsToAddModListUTRA-TDD ::=		SEQUENCE (SIZE (1..maxCellMeas)) OF CellsToAddModUTRA-TDD
+
+CellsToAddModUTRA-TDD ::=	SEQUENCE {
+	cellIndex							INTEGER (1..maxCellMeas),
+	physCellId							PhysCellIdUTRA-TDD
+}
+
+CSG-AllowedReportingCells-r9 ::=		SEQUENCE {
+	physCellIdRangeUTRA-FDDList-r9			PhysCellIdRangeUTRA-FDDList-r9	OPTIONAL	-- Need OR
+}
+
+
+MeasObjectWLAN-r13 ::=	SEQUENCE {
+	carrierFreq-r13					CHOICE {
+		bandIndicatorListWLAN-r13		SEQUENCE (SIZE (1..maxWLAN-Bands-r13)) OF WLAN-BandIndicator-r13,
+		carrierInfoListWLAN-r13			SEQUENCE (SIZE (1..maxWLAN-CarrierInfo-r13)) OF WLAN-CarrierInfo-r13
+	}		OPTIONAL,	-- Need ON
+	wlan-ToAddModList-r13				WLAN-Id-List-r13			OPTIONAL,	-- Need ON
+	wlan-ToRemoveList-r13				WLAN-Id-List-r13			OPTIONAL,	-- Need ON
+	...
+}
+
+WLAN-BandIndicator-r13 ::=	ENUMERATED {band2dot4, band5, band60-v1430, spare5, spare4, spare3, spare2, spare1, ...}
+
+
+
+MeasResults ::=						SEQUENCE {
+	measId								MeasId,
+	measResultPCell						SEQUENCE {
+		rsrpResult							RSRP-Range,
+		rsrqResult							RSRQ-Range
+	},
+	measResultNeighCells				CHOICE {
+		measResultListEUTRA					MeasResultListEUTRA,
+		measResultListUTRA					MeasResultListUTRA,
+		measResultListGERAN					MeasResultListGERAN,
+		measResultsCDMA2000					MeasResultsCDMA2000,
+		...,
+		measResultNeighCellListNR-r15			MeasResultCellListNR-r15
+	}																		OPTIONAL,
+	...,
+	[[	measResultForECID-r9				MeasResultForECID-r9			OPTIONAL
+	]],
+	[[	locationInfo-r10					LocationInfo-r10				OPTIONAL,
+		measResultServFreqList-r10			MeasResultServFreqList-r10		OPTIONAL
+	]],
+	[[	measId-v1250						MeasId-v1250					OPTIONAL,
+		measResultPCell-v1250				RSRQ-Range-v1250				OPTIONAL,
+		measResultCSI-RS-List-r12			MeasResultCSI-RS-List-r12		OPTIONAL
+	]],
+	[[	measResultForRSSI-r13				MeasResultForRSSI-r13			OPTIONAL,
+		measResultServFreqListExt-r13		MeasResultServFreqListExt-r13	OPTIONAL,
+		measResultSSTD-r13					MeasResultSSTD-r13				OPTIONAL,
+		measResultPCell-v1310				SEQUENCE {
+			rs-sinr-Result-r13					RS-SINR-Range-r13
+		}																	OPTIONAL,
+		ul-PDCP-DelayResultList-r13			UL-PDCP-DelayResultList-r13		OPTIONAL,
+		measResultListWLAN-r13				MeasResultListWLAN-r13			OPTIONAL
+	]],
+	[[	measResultPCell-v1360				RSRP-Range-v1360				OPTIONAL
+	]],
+	[[	measResultListCBR-r14				MeasResultListCBR-r14			OPTIONAL,
+		measResultListWLAN-r14				MeasResultListWLAN-r14			OPTIONAL
+	]],
+	[[	measResultServFreqListNR-r15		MeasResultServFreqListNR-r15	OPTIONAL,
+		measResultCellListSFTD-r15		MeasResultCellListSFTD-r15			OPTIONAL
+	]],
+	[[	logMeasResultListBT-r15				LogMeasResultListBT-r15			OPTIONAL,
+		logMeasResultListWLAN-r15			LogMeasResultListWLAN-r15		OPTIONAL,
+		measResultSensing-r15			MeasResultSensing-r15				OPTIONAL,
+		heightUE-r15						INTEGER (-400..8880)		OPTIONAL
+	]],
+	[[	ul-PDCP-DelayValueResultList-r16		UL-PDCP-DelayValueResultList-r16	OPTIONAL,
+		measResultForRSSI-NR-r16				MeasResultForRSSI-NR-r16		OPTIONAL
+	]]
+}
+
+MeasResultListEUTRA ::=				SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultEUTRA
+
+MeasResultEUTRA ::=	SEQUENCE {
+	physCellId							PhysCellId,
+	cgi-Info							SEQUENCE {
+		cellGlobalId						CellGlobalIdEUTRA,
+		trackingAreaCode					TrackingAreaCode,
+		plmn-IdentityList					PLMN-IdentityList2				OPTIONAL
+	}															OPTIONAL,
+	measResult							SEQUENCE {
+		rsrpResult							RSRP-Range						OPTIONAL,
+		rsrqResult							RSRQ-Range						OPTIONAL,
+		...,
+		[[	additionalSI-Info-r9				AdditionalSI-Info-r9		OPTIONAL
+		]],
+		[[	primaryPLMN-Suitable-r12			ENUMERATED {true}			OPTIONAL,
+			measResult-v1250					RSRQ-Range-v1250			OPTIONAL
+		]],
+		[[	rs-sinr-Result-r13					RS-SINR-Range-r13			OPTIONAL,
+			cgi-Info-v1310						SEQUENCE {				
+				freqBandIndicator-r13				FreqBandIndicator-r11		OPTIONAL,
+				multiBandInfoList-r13				MultiBandInfoList-r11		OPTIONAL,
+				freqBandIndicatorPriority-r13		ENUMERATED {true}			OPTIONAL
+			}																OPTIONAL
+		]],
+		[[
+			measResult-v1360					RSRP-Range-v1360					OPTIONAL
+		]],
+		[[
+			cgi-Info-5GC-r15		SEQUENCE (SIZE (1..maxPLMN-r11)) OF CellAccessRelatedInfo-5GC-r15		OPTIONAL
+		]]
+	}
+}
+
+MeasResultListIdle-r15	::= SEQUENCE (SIZE (1..maxIdleMeasCarriers-r15)) OF MeasResultIdle-r15
+
+MeasResultIdle-r15	::= SEQUENCE {
+	measResultServingCell-r15					SEQUENCE {
+		rsrpResult-r15					RSRP-Range,
+		rsrqResult-r15					RSRQ-Range-r13
+	},
+	measResultNeighCells-r15		CHOICE {
+		measResultIdleListEUTRA-r15		MeasResultIdleListEUTRA-r15,
+		...
+	}																	OPTIONAL,
+	...
+}
+
+MeasResultIdleListEUTRA-r15 ::=	SEQUENCE (SIZE (1..maxCellMeasIdle-r15)) OF MeasResultIdleEUTRA-r15
+
+MeasResultIdleEUTRA-r15 ::=	SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueEUTRA-r9,
+	physCellId-r15						PhysCellId,
+	measResult-r15						SEQUENCE {
+		rsrpResult-r15						RSRP-Range,
+		rsrqResult-r15						RSRQ-Range-r13
+	},
+	...
+}
+
+MeasResultListExtIdle-r16 ::= SEQUENCE(SIZE (1..maxIdleMeasCarriersExt-r16)) OF MeasResultIdleListEUTRA-r15
+
+MeasResultListIdleNR-r16	::= SEQUENCE(SIZE (1..maxIdleMeasCarriers-r16)) OF MeasResultIdleNR-r16
+
+MeasResultIdleNR-r16 ::=		SEQUENCE {
+	carrierFreqNR-r16						ARFCN-ValueNR-r15,
+	measResultsPerCellListIdleNR-r16	SEQUENCE (SIZE (1..maxCellMeasIdle-r15)) OF MeasResultsPerCellIdleNR-r16,
+	...
+}
+
+MeasResultsPerCellIdleNR-r16 ::=	SEQUENCE {
+	physCellIdNR-r16					PhysCellIdNR-r15,
+	measIdleResultNR-r16					SEQUENCE {
+		rsrpResultNR-r16						RSRP-RangeNR-r15				OPTIONAL,
+		rsrqResultNR-r16						RSRQ-RangeNR-r15				OPTIONAL,
+		resultRS-IndexList-r16				ResultsPerSSB-IndexList-r16		OPTIONAL
+	},
+	...
+}
+
+ResultsPerSSB-IndexList-r16 ::=	SEQUENCE (SIZE (1..maxRS-IndexReport-r15)) OF ResultsPerSSB-IndexIdle-r16
+
+ResultsPerSSB-IndexIdle-r16 ::=		SEQUENCE {
+	ssb-Index-r16							RS-IndexNR-r15,
+	ssb-Results-r16							SEQUENCE {
+		ssb-RSRP-Result-r16						RSRP-RangeNR-r15			OPTIONAL,
+		ssb-RSRQ-Result-r16						RSRQ-RangeNR-r15			OPTIONAL
+	}																		OPTIONAL
+}
+
+MeasResultServFreqListNR-r15 ::=	SEQUENCE (SIZE (1..maxServCell-r13)) OF MeasResultServFreqNR-r15
+
+MeasResultServFreqNR-r15 ::=		SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueNR-r15,
+	measResultSCell-r15					MeasResultCellNR-r15				OPTIONAL,
+	measResultBestNeighCell-r15			MeasResultCellNR-r15				OPTIONAL,
+	...
+}
+
+MeasResultCellListNR-r15::=		SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultCellNR-r15
+
+MeasResultCellNR-r15 ::=			SEQUENCE {
+	pci-r15								PhysCellIdNR-r15,
+	measResultCell-r15					MeasResultNR-r15,
+	measResultRS-IndexList-r15			MeasResultSSB-IndexList-r15				OPTIONAL,
+	...,
+	[[	cgi-Info-r15						CGI-InfoNR-r15				OPTIONAL
+	]]
+}
+
+MeasResultNR-r15 ::=				SEQUENCE {
+	rsrpResult-r15						RSRP-RangeNR-r15						OPTIONAL,
+	rsrqResult-r15						RSRQ-RangeNR-r15						OPTIONAL,
+	rs-sinr-Result-r15					RS-SINR-RangeNR-r15						OPTIONAL,
+	...
+}
+
+MeasResultSSB-IndexList-r15::=		SEQUENCE (SIZE (1..maxRS-IndexReport-r15)) OF MeasResultSSB-Index-r15
+
+MeasResultSSB-Index-r15 ::=		SEQUENCE {
+	ssb-Index-r15						RS-IndexNR-r15,
+	measResultSSB-Index-r15				MeasResultNR-r15					OPTIONAL,
+	...
+}
+
+MeasResultServFreqList-r10 ::=	SEQUENCE (SIZE (1..maxServCell-r10)) OF MeasResultServFreq-r10
+
+MeasResultServFreqListExt-r13 ::=	SEQUENCE (SIZE (1..maxServCell-r13)) OF MeasResultServFreq-r13
+
+MeasResultServFreq-r10 ::=			SEQUENCE {
+	servFreqId-r10						ServCellIndex-r10,
+	measResultSCell-r10					SEQUENCE {
+		rsrpResultSCell-r10					RSRP-Range,
+		rsrqResultSCell-r10					RSRQ-Range
+	}															OPTIONAL,
+	measResultBestNeighCell-r10			SEQUENCE {
+		physCellId-r10						PhysCellId,
+		rsrpResultNCell-r10					RSRP-Range,
+		rsrqResultNCell-r10					RSRQ-Range
+	}															OPTIONAL,
+	...,
+	[[	measResultSCell-v1250				RSRQ-Range-v1250	OPTIONAL,
+		measResultBestNeighCell-v1250		RSRQ-Range-v1250	OPTIONAL
+	]],
+	[[	measResultSCell-v1310				SEQUENCE {
+			rs-sinr-Result-r13					RS-SINR-Range-r13
+		}		OPTIONAL,
+		measResultBestNeighCell-v1310		SEQUENCE {
+			rs-sinr-Result-r13					RS-SINR-Range-r13
+		}		OPTIONAL
+	]]
+}
+
+MeasResultServFreq-r13 ::=			SEQUENCE {
+	servFreqId-r13						ServCellIndex-r13,
+	measResultSCell-r13					SEQUENCE {
+		rsrpResultSCell-r13					RSRP-Range,
+		rsrqResultSCell-r13					RSRQ-Range-r13,
+		rs-sinr-Result-r13					RS-SINR-Range-r13	OPTIONAL
+	}															OPTIONAL,
+	measResultBestNeighCell-r13			SEQUENCE {
+		physCellId-r13						PhysCellId,
+		rsrpResultNCell-r13					RSRP-Range,
+		rsrqResultNCell-r13					RSRQ-Range-r13,
+		rs-sinr-Result-r13					RS-SINR-Range-r13	OPTIONAL
+	}															OPTIONAL,
+	...,
+	[[	measResultBestNeighCell-v1360		SEQUENCE {
+			rsrpResultNCell-v1360				RSRP-Range-v1360
+		}														OPTIONAL
+	]]
+}
+
+MeasResultCSI-RS-List-r12 ::=	SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultCSI-RS-r12
+
+MeasResultCSI-RS-r12 ::=		SEQUENCE {
+	measCSI-RS-Id-r12				MeasCSI-RS-Id-r12,
+	csi-RSRP-Result-r12				CSI-RSRP-Range-r12,
+	...
+}
+
+MeasResultListUTRA ::=				SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultUTRA
+
+MeasResultUTRA ::=	SEQUENCE {
+	physCellId							CHOICE {
+		fdd									PhysCellIdUTRA-FDD,
+		tdd									PhysCellIdUTRA-TDD
+	},
+	cgi-Info							SEQUENCE {
+		cellGlobalId						CellGlobalIdUTRA,
+		locationAreaCode					BIT STRING (SIZE (16))			OPTIONAL,
+		routingAreaCode						BIT STRING (SIZE (8))			OPTIONAL,
+		plmn-IdentityList					PLMN-IdentityList2				OPTIONAL
+	}															OPTIONAL,
+	measResult							SEQUENCE {
+		utra-RSCP							INTEGER (-5..91)				OPTIONAL,
+		utra-EcN0							INTEGER (0..49)					OPTIONAL,
+		...,
+		[[	additionalSI-Info-r9				AdditionalSI-Info-r9				OPTIONAL
+		]],
+		[[	primaryPLMN-Suitable-r12			ENUMERATED {true}			OPTIONAL
+		]]
+	}
+}
+
+MeasResultListGERAN ::=				SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultGERAN
+
+MeasResultGERAN ::=	SEQUENCE {
+	carrierFreq							CarrierFreqGERAN,
+	physCellId							PhysCellIdGERAN,
+	cgi-Info							SEQUENCE {
+		cellGlobalId						CellGlobalIdGERAN,
+		routingAreaCode						BIT STRING (SIZE (8))			OPTIONAL
+	}																		OPTIONAL,
+	measResult							SEQUENCE {
+		rssi								INTEGER (0..63),
+		...
+	}
+}
+
+MeasResultsCDMA2000 ::=				SEQUENCE {
+	preRegistrationStatusHRPD			BOOLEAN,
+	measResultListCDMA2000				MeasResultListCDMA2000
+}
+
+MeasResultListCDMA2000 ::=			SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultCDMA2000
+
+MeasResultCDMA2000 ::=	SEQUENCE {
+	physCellId							PhysCellIdCDMA2000,
+	cgi-Info							CellGlobalIdCDMA2000				OPTIONAL,
+	measResult							SEQUENCE {
+		pilotPnPhase						INTEGER	(0..32767)				OPTIONAL,
+		pilotStrength						INTEGER (0..63),
+		...
+	}
+}
+
+MeasResultListWLAN-r13 ::=		SEQUENCE (SIZE (1..maxCellReport)) OF MeasResultWLAN-r13
+
+MeasResultListWLAN-r14 ::=		SEQUENCE (SIZE (1..maxWLAN-Id-Report-r14)) OF MeasResultWLAN-r13
+
+MeasResultWLAN-r13 ::=	SEQUENCE {
+	wlan-Identifiers-r13					WLAN-Identifiers-r12,
+	carrierInfoWLAN-r13						WLAN-CarrierInfo-r13	OPTIONAL,
+	bandWLAN-r13							WLAN-BandIndicator-r13	OPTIONAL,
+	rssiWLAN-r13							WLAN-RSSI-Range-r13,
+	availableAdmissionCapacityWLAN-r13		INTEGER (0..31250)		OPTIONAL,
+	backhaulDL-BandwidthWLAN-r13			WLAN-backhaulRate-r12	OPTIONAL,
+	backhaulUL-BandwidthWLAN-r13			WLAN-backhaulRate-r12	OPTIONAL,
+	channelUtilizationWLAN-r13				INTEGER (0..255)		OPTIONAL,
+	stationCountWLAN-r13					INTEGER (0..65535)		OPTIONAL,
+	connectedWLAN-r13						ENUMERATED {true}		OPTIONAL,
+	...
+}
+
+MeasResultListCBR-r14 ::=			SEQUENCE (SIZE (1..maxCBR-Report-r14)) OF MeasResultCBR-r14
+
+MeasResultCBR-r14 ::=	SEQUENCE {
+	poolIdentity-r14		SL-V2X-TxPoolReportIdentity-r14,
+	cbr-PSSCH-r14			SL-CBR-r14,
+	cbr-PSCCH-r14			SL-CBR-r14				OPTIONAL
+}
+
+MeasResultSensing-r15 ::=	SEQUENCE {
+	sl-SubframeRef-r15			INTEGER (0..10239),
+	sensingResult-r15			SEQUENCE (SIZE (0..400)) OF SensingResult-r15
+}
+
+SensingResult-r15 ::=	SEQUENCE {
+	resourceIndex-r15			INTEGER (1..2000)
+}
+
+MeasResultForECID-r9 ::=		SEQUENCE {
+	ue-RxTxTimeDiffResult-r9				INTEGER (0..4095),
+	currentSFN-r9							BIT STRING (SIZE (10))
+}
+
+PLMN-IdentityList2 ::=				SEQUENCE (SIZE (1..5)) OF PLMN-Identity
+
+AdditionalSI-Info-r9 ::=			SEQUENCE {
+	csg-MemberStatus-r9				ENUMERATED {member}				OPTIONAL,
+	csg-Identity-r9						CSG-Identity						OPTIONAL
+}
+MeasResultForRSSI-r13 ::=			SEQUENCE {
+	rssi-Result-r13							RSSI-Range-r13,
+	channelOccupancy-r13					INTEGER (0..100),
+	...
+}
+
+MeasResultForRSSI-NR-r16 ::=		SEQUENCE {
+	rssi-ResultNR-r16					RSSI-Range-r13,
+	channelOccupancyNR-r16			INTEGER (0..100),
+	...
+}
+
+UL-PDCP-DelayResultList-r13 ::=		SEQUENCE (SIZE (1..maxQCI-r13)) OF UL-PDCP-DelayResult-r13
+
+
+UL-PDCP-DelayResult-r13 ::=			SEQUENCE {
+	qci-Id-r13							ENUMERATED {qci1, qci2, qci3, qci4, spare4, spare3, spare2, spare1},
+	excessDelay-r13						INTEGER (0..31),
+	...
+}
+
+UL-PDCP-DelayValueResultList-r16 ::=		SEQUENCE (SIZE (1..maxDRB)) OF UL-PDCP-DelayValueResult-r16
+
+UL-PDCP-DelayValueResult-r16 ::=		SEQUENCE {
+	drb-Id-r16								DRB-Identity,
+	averageDelay-r16						INTEGER (0..10000),
+	...
+}
+
+CGI-InfoNR-r15 ::=					SEQUENCE {
+	plmn-IdentityInfoList-r15			PLMN-IdentityInfoListNR-r15			OPTIONAL,
+	frequencyBandList-r15				MultiFrequencyBandListNR-r15		OPTIONAL,
+	noSIB1-r15							SEQUENCE {
+		ssb-SubcarrierOffset-r15				INTEGER (0..15),
+		pdcch-ConfigSIB1-r15					INTEGER (0..255)
+	}																		OPTIONAL,
+	...
+}
+
+CellIdentityNR-r15 ::=				BIT STRING (SIZE (36))
+
+PLMN-IdentityListNR-r15 ::=			SEQUENCE (SIZE (1.. maxPLMN-NR-r15)) OF PLMN-Identity
+
+PLMN-IdentityInfoListNR-r15 ::=		SEQUENCE (SIZE (1..maxPLMN-NR-r15)) OF PLMN-IdentityInfoNR-r15
+
+PLMN-IdentityInfoNR-r15 ::=			SEQUENCE {
+	plmn-IdentityList-r15				PLMN-IdentityListNR-r15,
+	trackingAreaCode-r15				TrackingAreaCodeNR-r15			OPTIONAL,
+	ran-AreaCode-r15					RAN-AreaCode-r15				OPTIONAL,
+	cellIdentity-r15					CellIdentityNR-r15
+}
+
+TrackingAreaCodeNR-r15 ::=			BIT STRING (SIZE (24))
+
+
+
+MeasResultCellListSFTD-r15 ::=			SEQUENCE (SIZE (1..maxCellSFTD)) OF MeasResultCellSFTD-r15
+
+MeasResultCellSFTD-r15 ::=				SEQUENCE {
+	physCellId-r15							PhysCellIdNR-r15,
+	sfn-OffsetResult-r15					INTEGER (0..1023),
+	frameBoundaryOffsetResult-r15			INTEGER (-30720..30719),
+	rsrpResult-r15							RSRP-RangeNR-r15						OPTIONAL
+}
+
+
+
+MeasResultSCG-FailureMRDC-r15 ::=	SEQUENCE {
+	measResultFreqListEUTRA-r15		MeasResultList3EUTRA-r15,
+	...,
+	[[	locationInfo-r16				LocationInfo-r10						OPTIONAL,
+		logMeasResultListBT-r16			LogMeasResultListBT-r15					OPTIONAL,
+		logMeasResultListWLAN-r16		LogMeasResultListWLAN-r15				OPTIONAL
+	]]
+}
+
+MeasResultList3EUTRA-r15 ::=		SEQUENCE (SIZE (1..maxFreq)) OF MeasResult3EUTRA-r15
+
+MeasResult3EUTRA-r15 ::=			SEQUENCE {
+	carrierFreq-r15						ARFCN-ValueEUTRA-r9,
+	measResultServingCell-r15			MeasResultEUTRA					OPTIONAL,
+	measResultNeighCellList-r15		MeasResultListEUTRA				OPTIONAL,
+	...
+}
+
+
+
+MeasResultSSTD-r13 ::=						SEQUENCE {
+	sfn-OffsetResult-r13						INTEGER (0..1023),
+	frameBoundaryOffsetResult-r13				INTEGER (-5..4),
+	subframeBoundaryOffsetResult-r13			INTEGER (0..127)
+}
+
+
+
+MeasScaleFactor-r12 ::=			ENUMERATED {sf-EUTRA-cf1, sf-EUTRA-cf2}
+
+
+
+MeasSensing-Config-r15 ::=			SEQUENCE {
+		sensingSubchannelNumber-r15		INTEGER (1..20),
+		sensingPeriodicity-r15			ENUMERATED {ms20, ms50, ms100, ms200,
+											ms300, ms400, ms500, ms600,
+											ms700, ms800, ms900, ms1000},
+		sensingReselectionCounter-r15	INTEGER (5..75),
+		sensingPriority-r15				INTEGER (1..8)
+}
+
+
+
+MTC-SSB-NR-r15 ::=	SEQUENCE {
+	periodicityAndOffset-r15		CHOICE {
+		sf5-r15						INTEGER (0..4),
+		sf10-r15						INTEGER (0..9),
+		sf20-r15						INTEGER (0..19),
+		sf40-r15						INTEGER (0..39),
+		sf80-r15						INTEGER (0..79),
+		sf160-r15					INTEGER (0..159)
+	},
+	ssb-Duration-r15					ENUMERATED {sf1, sf2, sf3, sf4, sf5 }
+}
+
+MTC-SSB2-LP-NR-r16::= SEQUENCE {
+	pci-List-r16			SEQUENCE (SIZE (1..maxNrofPCI-PerSMTC-r16)) OF PhysCellIdNR-r15
+																		OPTIONAL,   -- Need OR
+	periodicity-r16		ENUMERATED {sf10, sf20, sf40, sf80, sf160, spare3, spare2, spare1}
+}
+
+
+
+QuantityConfig ::=					SEQUENCE {
+	quantityConfigEUTRA					QuantityConfigEUTRA					OPTIONAL,	-- Need ON
+	quantityConfigUTRA					QuantityConfigUTRA					OPTIONAL,	-- Need ON
+	quantityConfigGERAN					QuantityConfigGERAN					OPTIONAL,	-- Need ON
+	quantityConfigCDMA2000				QuantityConfigCDMA2000				OPTIONAL,	-- Need ON
+	...,
+	[[	quantityConfigUTRA-v1020		QuantityConfigUTRA-v1020			OPTIONAL	-- Need ON
+	]],
+	[[	quantityConfigEUTRA-v1250		QuantityConfigEUTRA-v1250			OPTIONAL	-- Need ON
+	]],
+	[[	quantityConfigEUTRA-v1310		QuantityConfigEUTRA-v1310			OPTIONAL,	-- Need ON
+		quantityConfigWLAN-r13			QuantityConfigWLAN-r13				OPTIONAL	-- Need ON
+	]],
+	[[	quantityConfigNRList-r15		QuantityConfigNRList-r15			OPTIONAL	-- Need ON
+	]]
+}
+
+QuantityConfigEUTRA ::=				SEQUENCE {
+	filterCoefficientRSRP				FilterCoefficient					DEFAULT fc4,
+	filterCoefficientRSRQ				FilterCoefficient					DEFAULT fc4
+}
+
+QuantityConfigEUTRA-v1250 ::=		SEQUENCE {
+	filterCoefficientCSI-RSRP-r12		FilterCoefficient					OPTIONAL		-- Need OR
+}
+
+QuantityConfigEUTRA-v1310 ::=		SEQUENCE {
+	filterCoefficientRS-SINR-r13		FilterCoefficient					DEFAULT fc4
+}
+
+QuantityConfigUTRA ::=				SEQUENCE {
+	measQuantityUTRA-FDD				ENUMERATED {cpich-RSCP, cpich-EcN0},
+	measQuantityUTRA-TDD				ENUMERATED {pccpch-RSCP},
+	filterCoefficient					FilterCoefficient					DEFAULT fc4
+}
+
+QuantityConfigUTRA-v1020 ::=		SEQUENCE {
+	filterCoefficient2-FDD-r10			FilterCoefficient					DEFAULT fc4
+}
+
+QuantityConfigGERAN ::=				SEQUENCE {
+	measQuantityGERAN					ENUMERATED {rssi},
+	filterCoefficient					FilterCoefficient					DEFAULT fc2
+}
+
+QuantityConfigCDMA2000 ::=			SEQUENCE {
+	measQuantityCDMA2000				ENUMERATED {pilotStrength, pilotPnPhaseAndPilotStrength}
+}
+
+QuantityConfigNRList-r15 ::=		SEQUENCE (SIZE (1..maxQuantSetsNR-r15)) OF QuantityConfigNR-r15
+
+QuantityConfigNR-r15 ::=			SEQUENCE {
+	measQuantityCellNR-r15				QuantityConfigRS-NR-r15,
+	measQuantityRS-IndexNR-r15			QuantityConfigRS-NR-r15				OPTIONAL
+}
+
+QuantityConfigRS-NR-r15 ::=				SEQUENCE {
+	filterCoeff-RSRP-r15				FilterCoefficient					DEFAULT fc4,
+	filterCoeff-RSRQ-r15				FilterCoefficient					DEFAULT fc4,
+	filterCoefficient-SINR-r13			FilterCoefficient					DEFAULT fc4
+}
+
+QuantityConfigWLAN-r13 ::=			SEQUENCE {
+	measQuantityWLAN-r13				ENUMERATED {rssiWLAN},
+	filterCoefficient-r13				FilterCoefficient					DEFAULT fc4
+}
+
+
+
+ReportConfigEUTRA ::=				SEQUENCE {
+	triggerType							CHOICE {
+		event								SEQUENCE {
+			eventId								CHOICE {
+				eventA1								SEQUENCE {
+					a1-Threshold						ThresholdEUTRA
+				},
+				eventA2								SEQUENCE {
+					a2-Threshold						ThresholdEUTRA
+				},
+				eventA3								SEQUENCE {
+					a3-Offset							INTEGER (-30..30),
+					reportOnLeave						BOOLEAN
+				},
+				eventA4								SEQUENCE {
+					a4-Threshold						ThresholdEUTRA
+				},
+				eventA5								SEQUENCE {
+					a5-Threshold1						ThresholdEUTRA,
+					a5-Threshold2						ThresholdEUTRA
+				},
+				...,
+				eventA6-r10							SEQUENCE {
+					a6-Offset-r10						INTEGER (-30..30),
+					a6-ReportOnLeave-r10				BOOLEAN
+				},
+				eventC1-r12							SEQUENCE {
+					c1-Threshold-r12					ThresholdEUTRA-v1250,
+					c1-ReportOnLeave-r12				BOOLEAN
+				},
+				eventC2-r12							SEQUENCE {
+					c2-RefCSI-RS-r12					MeasCSI-RS-Id-r12,
+					c2-Offset-r12						INTEGER (-30..30),
+					c2-ReportOnLeave-r12				BOOLEAN
+				},
+				eventV1-r14							SEQUENCE {
+					v1-Threshold-r14					SL-CBR-r14
+				},
+				eventV2-r14							SEQUENCE {
+					v2-Threshold-r14					SL-CBR-r14
+				},
+				eventH1-r15							SEQUENCE {
+					h1-ThresholdOffset-r15				INTEGER (0..300),
+					h1-Hysteresis-r15					INTEGER (1..16)
+				},
+				eventH2-r15							SEQUENCE {
+					h2-ThresholdOffset-r15				INTEGER (0..300),
+					h2-Hysteresis-r15					INTEGER (1..16)
+				}
+			},
+			hysteresis							Hysteresis,
+			timeToTrigger						TimeToTrigger
+		},
+		periodical								SEQUENCE {
+			purpose									ENUMERATED {
+														reportStrongestCells, reportCGI}
+		}
+	},
+	triggerQuantity						ENUMERATED {rsrp, rsrq},
+	reportQuantity						ENUMERATED {sameAsTriggerQuantity, both},
+	maxReportCells						INTEGER (1..maxCellReport),
+	reportInterval						ReportInterval,
+	reportAmount						ENUMERATED {r1, r2, r4, r8, r16, r32, r64, infinity},
+	...,
+	[[	si-RequestForHO-r9					ENUMERATED {setup}		OPTIONAL,	-- Cond reportCGI
+		ue-RxTxTimeDiffPeriodical-r9		ENUMERATED {setup}		OPTIONAL	-- Need OR
+	]],
+	[[	includeLocationInfo-r10				ENUMERATED {true}		OPTIONAL,	-- Need OR
+		reportAddNeighMeas-r10				ENUMERATED {setup}		OPTIONAL	-- Need OR
+	]],
+	[[	alternativeTimeToTrigger-r12		CHOICE {
+			release								NULL,
+			setup								TimeToTrigger
+		}													OPTIONAL,	-- Need ON
+		useT312-r12							BOOLEAN			OPTIONAL,	-- Need ON
+		usePSCell-r12						BOOLEAN			OPTIONAL,	-- Need ON
+		aN-Threshold1-v1250					RSRQ-RangeConfig-r12		OPTIONAL,	-- Need ON
+		a5-Threshold2-v1250					RSRQ-RangeConfig-r12		OPTIONAL,	-- Need ON
+		reportStrongestCSI-RSs-r12			BOOLEAN			OPTIONAL,	-- Need ON
+		reportCRS-Meas-r12					BOOLEAN			OPTIONAL,	-- Need ON
+		triggerQuantityCSI-RS-r12			BOOLEAN			OPTIONAL		-- Need ON
+	]],
+	[[	reportSSTD-Meas-r13					BOOLEAN			OPTIONAL,		-- Need ON
+		rs-sinr-Config-r13					CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				triggerQuantity-v1310				ENUMERATED {sinr}		OPTIONAL,	-- Need ON
+				aN-Threshold1-r13					RS-SINR-Range-r13		OPTIONAL,	-- Need ON
+				a5-Threshold2-r13					RS-SINR-Range-r13		OPTIONAL,	-- Need ON
+				reportQuantity-v1310				ENUMERATED {rsrpANDsinr, rsrqANDsinr, all}
+			}
+		}																OPTIONAL,	-- Need ON
+		useWhiteCellList-r13				BOOLEAN						OPTIONAL,	-- Need ON
+		measRSSI-ReportConfig-r13			MeasRSSI-ReportConfig-r13	OPTIONAL,	-- Need ON
+		includeMultiBandInfo-r13			ENUMERATED {true}			OPTIONAL,	-- Cond reportCGI
+		ul-DelayConfig-r13					UL-DelayConfig-r13			OPTIONAL	-- Need ON
+	]],
+	[[	ue-RxTxTimeDiffPeriodicalTDD-r13	BOOLEAN						OPTIONAL	-- Need ON
+	]],
+	[[	
+		purpose-v1430			ENUMERATED {reportLocation, sidelink, spare2, spare1}		
+															OPTIONAL	-- Need ON
+	]],
+	[[	
+		maxReportRS-Index-r15		INTEGER (0..maxRS-IndexReport-r15)	OPTIONAL	-- Need ON
+	]],
+	[[	includeBT-Meas-r15				BT-NameListConfig-r15			OPTIONAL,	-- Need ON
+		includeWLAN-Meas-r15				WLAN-NameListConfig-r15			OPTIONAL,		-- Need ON
+		purpose-r15				ENUMERATED {sensing}					OPTIONAL,	-- Need ON
+		numberOfTriggeringCells-r15			INTEGER	(2..maxCellReport)	OPTIONAL,	-- Cond a3a4a5
+		a4-a5-ReportOnLeave-r15				BOOLEAN						OPTIONAL	-- Cond a4a5
+	]],
+	[[ condReconfigurationTriggerEUTRA-r16	CondReconfigurationTriggerEUTRA-r16	OPTIONAL,
+-- Need ON
+		ul-DelayValueConfig-r16				UL-DelayValueConfig-r16		OPTIONAL	-- Need ON
+	]]
+}
+
+CondReconfigurationTriggerEUTRA-r16 ::= SEQUENCE {
+	condEventId-r16							CHOICE {
+		condEventA3-r16							SEQUENCE {
+			a3-Offset-r16								INTEGER (-30..30),
+			hysteresis-r16								Hysteresis,
+			timeToTrigger-r16							TimeToTrigger
+		},
+		condEventA5-r16							SEQUENCE {
+			a5-Threshold1-r16							ThresholdEUTRA,
+			a5-Threshold2-r16							ThresholdEUTRA,
+			hysteresis-r16								Hysteresis,
+			timeToTrigger-r16							TimeToTrigger
+		},
+		...
+	}
+}
+
+RSRQ-RangeConfig-r12 ::=			CHOICE {
+	release								NULL,
+	setup								RSRQ-Range-v1250
+}
+
+ThresholdEUTRA ::=					CHOICE{
+	threshold-RSRP						RSRP-Range,
+	threshold-RSRQ						RSRQ-Range
+}
+
+ThresholdEUTRA-v1250 ::=			CSI-RSRP-Range-r12
+
+MeasRSSI-ReportConfig-r13 ::=	SEQUENCE {
+	channelOccupancyThreshold-r13			RSSI-Range-r13				OPTIONAL	-- Need OR
+}
+
+
+
+ReportConfigId ::=					INTEGER (1..maxReportConfigId)
+
+
+
+ReportConfigInterRAT ::=			SEQUENCE {
+	triggerType							CHOICE {
+		event								SEQUENCE {
+			eventId								CHOICE {
+				eventB1								SEQUENCE {
+					b1-Threshold						CHOICE {
+						b1-ThresholdUTRA					ThresholdUTRA,
+						b1-ThresholdGERAN					ThresholdGERAN,
+						b1-ThresholdCDMA2000				ThresholdCDMA2000
+					}
+				},
+				eventB2								SEQUENCE {
+					b2-Threshold1						ThresholdEUTRA,
+					b2-Threshold2						CHOICE {
+						b2-Threshold2UTRA					ThresholdUTRA,
+						b2-Threshold2GERAN					ThresholdGERAN,
+						b2-Threshold2CDMA2000				ThresholdCDMA2000
+					}
+				},
+				...,
+				eventW1-r13						SEQUENCE {
+					w1-Threshold-r13			WLAN-RSSI-Range-r13
+				},
+				eventW2-r13						SEQUENCE {
+					w2-Threshold1-r13			WLAN-RSSI-Range-r13,
+					w2-Threshold2-r13			WLAN-RSSI-Range-r13
+				},
+				eventW3-r13						SEQUENCE {
+					w3-Threshold-r13			WLAN-RSSI-Range-r13
+				},
+				eventB1-NR-r15							SEQUENCE {
+					b1-ThresholdNR-r15					ThresholdNR-r15,
+					reportOnLeave-r15					BOOLEAN
+				},
+				eventB2-NR-r15							SEQUENCE {
+					b2-Threshold1-r15					ThresholdEUTRA,
+					b2-Threshold2NR-r15					ThresholdNR-r15,
+					reportOnLeave-r15					BOOLEAN
+				}
+			},
+			hysteresis						Hysteresis,
+			timeToTrigger					TimeToTrigger
+		},
+		periodical								SEQUENCE {
+			purpose									ENUMERATED {
+														reportStrongestCells,
+														reportStrongestCellsForSON,
+														reportCGI}
+		}
+	},
+	maxReportCells					INTEGER (1..maxCellReport),
+	reportInterval					ReportInterval,	
+	reportAmount					ENUMERATED {r1, r2, r4, r8, r16, r32, r64, infinity},
+	...,
+	[[	si-RequestForHO-r9				ENUMERATED {setup}		OPTIONAL	-- Cond reportCGI
+	]],
+	[[	reportQuantityUTRA-FDD-r10		ENUMERATED {both}		OPTIONAL	-- Need OR
+	]],
+	[[	includeLocationInfo-r11			BOOLEAN					OPTIONAL	-- Need ON
+	]],
+	[[	b2-Threshold1-v1250				CHOICE {
+			release							NULL,
+			setup							RSRQ-Range-v1250
+		}														OPTIONAL	-- Need ON
+	]],
+	[[	reportQuantityWLAN-r13			ReportQuantityWLAN-r13	OPTIONAL	-- Need ON
+	]],
+	[[	reportAnyWLAN-r14				BOOLEAN					OPTIONAL	-- Need ON
+	]],
+	[[	reportQuantityCellNR-r15		ReportQuantityNR-r15	OPTIONAL,	-- Need ON
+		maxReportRS-Index-r15			INTEGER (0..maxRS-IndexReport-r15)	OPTIONAL,	-- Need ON
+		reportQuantityRS-IndexNR-r15	ReportQuantityNR-r15	OPTIONAL,	-- Need ON
+		reportRS-IndexResultsNR			BOOLEAN					OPTIONAL,	-- Need ON
+		reportSFTD-Meas-r15				ENUMERATED {pSCell, neighborCells }	OPTIONAL	-- Need ON
+	]],
+	[[
+		useAutonomousGapsNR-r16			ENUMERATED {setup}		OPTIONAL,	-- Cond reportCGI-NR
+		measRSSI-ReportConfigNR-r16		MeasRSSI-ReportConfig-r13	OPTIONAL	-- Need ON
+	]]
+}
+
+ThresholdUTRA ::=					CHOICE{
+	utra-RSCP							INTEGER (-5..91),
+	utra-EcN0							INTEGER (0..49)
+}
+
+ThresholdGERAN ::=				INTEGER (0..63)
+
+ThresholdCDMA2000 ::=			INTEGER (0..63)
+
+ReportQuantityNR-r15::=						SEQUENCE {
+	ss-rsrp										BOOLEAN,
+	ss-rsrq										BOOLEAN,
+	ss-sinr										BOOLEAN
+}
+
+ReportQuantityWLAN-r13 ::=		SEQUENCE {
+	bandRequestWLAN-r13							ENUMERATED {true}	OPTIONAL,	-- Need OR
+	carrierInfoRequestWLAN-r13					ENUMERATED {true}	OPTIONAL,	-- Need OR
+	availableAdmissionCapacityRequestWLAN-r13	ENUMERATED {true}	OPTIONAL,	-- Need OR
+	backhaulDL-BandwidthRequestWLAN-r13			ENUMERATED {true}	OPTIONAL,	-- Need OR
+	backhaulUL-BandwidthRequestWLAN-r13			ENUMERATED {true}	OPTIONAL,	-- Need OR
+	channelUtilizationRequestWLAN-r13			ENUMERATED {true}	OPTIONAL,	-- Need OR
+	stationCountRequestWLAN-r13					ENUMERATED {true}	OPTIONAL,	-- Need OR
+	...
+}
+
+
+
+ReportConfigToAddModList ::=		SEQUENCE (SIZE (1..maxReportConfigId)) OF ReportConfigToAddMod
+
+ReportConfigToAddMod ::=	SEQUENCE {
+	reportConfigId						ReportConfigId,
+	reportConfig						CHOICE {
+		reportConfigEUTRA					ReportConfigEUTRA,
+		reportConfigInterRAT				ReportConfigInterRAT
+	}
+}
+
+
+
+
+ReportInterval ::=					ENUMERATED {
+										ms120, ms240, ms480, ms640, ms1024, ms2048, ms5120, ms10240,
+										min1, min6, min12, min30, min60, spare3, spare2, spare1}
+
+
+
+RS-IndexNR-r15 ::=			INTEGER (0.. maxRS-Index-1-r15)
+
+
+
+RSRP-Range ::=						INTEGER(0..97)
+
+RSRP-Range-v1360 ::=				INTEGER(-17..-1)
+
+RSRP-RangeSL-r12 ::=				INTEGER(0..13)
+
+RSRP-RangeSL2-r12 ::=				INTEGER(0..7)
+
+RSRP-RangeSL3-r12 ::=				INTEGER(0..11)
+
+RSRP-RangeSL4-r13 ::=				INTEGER(0..49)
+
+
+
+RSRP-RangeNR-r15 ::=						INTEGER (0..127)
+
+
+
+RSRQ-Range ::=					INTEGER(0..34)
+
+RSRQ-Range-v1250 ::=			INTEGER(-30..46)
+
+RSRQ-Range-r13 ::=				INTEGER(-30..46)
+
+
+
+RSRQ-RangeNR-r15 ::=			INTEGER (0..127)
+
+
+
+RSRQ-Type-r12 ::=					SEQUENCE {
+	allSymbols-r12							BOOLEAN,
+	wideBand-r12							BOOLEAN
+}
+
+
+
+RS-SINR-Range-r13 ::=						INTEGER(0..127)
+
+
+
+RS-SINR-RangeNR-r15 ::=					INTEGER (0..127)
+
+
+
+RSSI-Range-r13 ::=						INTEGER(0..76)
+
+
+
+SS-RSSI-Measurement-r15 ::=			SEQUENCE {
+	measurementSlots-r15				BIT STRING (SIZE(1..80)),
+	endSymbol-r15						INTEGER(0..3)
+}
+
+
+
+SSB-PositionQCL-RelationNR-r16 ::=		ENUMERATED {n1, n2, n4, n8}
+
+
+
+SSB-ToMeasure-r15 ::=		CHOICE {
+	shortBitmap-r15				BIT STRING (SIZE (4)),
+	mediumBitmap-r15				BIT STRING (SIZE (8)),
+	longBitmap-r15					BIT STRING (SIZE (64))
+}
+
+
+
+TimeToTrigger ::=					ENUMERATED {
+										ms0, ms40, ms64, ms80, ms100, ms128, ms160, ms256,
+										ms320, ms480, ms512, ms640, ms1024, ms1280, ms2560,
+										ms5120}
+
+
+
+UL-DelayConfig-r13 ::=					CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			delayThreshold-r13							ENUMERATED {
+												ms30, ms40, ms50, ms60, ms70, ms80,
+												ms90,ms100, ms150, ms300, ms500, ms750, spare4,
+												spare3, spare2, spare1}
+		}
+}
+
+
+
+UL-DelayValueConfig-r16 ::=			CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			delay-DRBlist-r16						SEQUENCE (SIZE(1..maxDRB)) OF DRB-Identity
+		}
+}
+
+
+
+WLAN-CarrierInfo-r13 ::=	SEQUENCE {
+	operatingClass-r13			INTEGER (0..255)			OPTIONAL,	-- Need ON
+	countryCode-r13				ENUMERATED {unitedStates, europe, japan, global, ...}
+															OPTIONAL,	-- Need ON
+	channelNumbers-r13			WLAN-ChannelList-r13		OPTIONAL,	-- Need ON
+	...
+}
+
+WLAN-ChannelList-r13 ::=	SEQUENCE (SIZE (1..maxWLAN-Channels-r13)) OF WLAN-Channel-r13
+
+WLAN-Channel-r13 ::=	INTEGER(0..255)
+
+
+
+WLAN-NameListConfig-r15 ::=		CHOICE{
+	release						NULL,
+	setup						WLAN-NameList-r15
+}
+
+WLAN-NameList-r15 ::=			SEQUENCE (SIZE (1..maxWLAN-Name-r15)) OF WLAN-Name-r15
+
+WLAN-Name-r15 ::=		OCTET STRING (SIZE (1..32))
+
+
+
+WLAN-RSSI-Range-r13 ::=						INTEGER(0..141)
+
+
+
+WLAN-RTT-r15 ::= SEQUENCE {
+	rttValue-r15					INTEGER (0..16777215),
+	rttUnits-r15					ENUMERATED {	microseconds,
+									hundredsofnanoseconds,
+									tensofnanoseconds,
+									nanoseconds,
+									tenthsofnanoseconds,
+									... },
+	rttAccuracy-r15				INTEGER (0..255)							OPTIONAL,
+	...
+}
+
+
+
+WLAN-Status-r13 ::=		ENUMERATED {successfulAssociation, failureWlanRadioLink, failureWlanUnavailable, failureTimeout}
+
+WLAN-Status-v1430 ::=	ENUMERATED {suspended, resumed}
+
+
+
+WLAN-SuspendConfig-r14 ::=	SEQUENCE {
+	wlan-SuspendResumeAllowed-r14				BOOLEAN		OPTIONAL,	-- Need ON
+	wlan-SuspendTriggersStatusReport-r14		BOOLEAN		OPTIONAL	-- Need ON
+}
+
+
+
+AbsoluteTimeInfo-r10 ::=				BIT STRING (SIZE (48))
+
+
+
+AMF-Identifier-r15 ::=						BIT STRING (SIZE (24))
+
+
+
+AreaConfiguration-r10 ::=	CHOICE {
+	cellGlobalIdList-r10			CellGlobalIdList-r10,
+	trackingAreaCodeList-r10		TrackingAreaCodeList-r10
+}
+
+AreaConfiguration-v1130 ::=		SEQUENCE {
+	trackingAreaCodeList-v1130		TrackingAreaCodeList-v1130
+}
+
+CellGlobalIdList-r10 ::=				SEQUENCE (SIZE (1..32)) OF CellGlobalIdEUTRA
+
+TrackingAreaCodeList-r10 ::=			SEQUENCE (SIZE (1..8)) OF TrackingAreaCode
+
+TrackingAreaCodeList-v1130 ::=	SEQUENCE {
+	plmn-Identity-perTAC-List-r11			SEQUENCE (SIZE (1..8)) OF PLMN-Identity
+}
+
+
+
+BandCombinationList-r14 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombination-r14
+
+BandCombination-r14 ::= SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF BandIndication-r14
+
+BandIndication-r14 ::=	SEQUENCE {
+	bandEUTRA-r14					FreqBandIndicator-r11,
+	ca-BandwidthClassDL-r14			CA-BandwidthClass-r10,
+	ca-BandwidthClassUL-r14			CA-BandwidthClass-r10			OPTIONAL
+}
+
+
+
+C-RNTI ::=							BIT STRING (SIZE (16))
+
+
+
+DedicatedInfoCDMA2000 ::=				OCTET STRING
+
+
+
+DedicatedInfoF1c-r16 ::=		OCTET STRING
+
+
+
+DedicatedInfoNAS ::=		OCTET STRING
+
+
+
+FilterCoefficient ::=					ENUMERATED {
+											fc0, fc1, fc2, fc3, fc4, fc5,
+											fc6, fc7, fc8, fc9, fc11, fc13,
+											fc15, fc17, fc19, spare1, ...}
+
+
+
+FlightPathInfoReportConfig-r15 ::= SEQUENCE {		
+	maxWayPointNumber-r15				INTEGER (1..maxWayPoint-r15),
+	includeTimeStamp-r15				ENUMERATED {true}					OPTIONAL
+}
+
+
+
+GNSS-ID-r15 ::= SEQUENCE {
+	gnss-id-r15				ENUMERATED{gps, sbas, qzss, galileo, glonass, bds, ..., navic-v1610},
+	...
+}
+
+
+
+I-RNTI-r15 ::=						BIT STRING (SIZE(40))
+
+
+
+LoggingDuration-r10 ::=			ENUMERATED {
+									min10, min20, min40, min60, min90, min120, spare2, spare1}
+
+
+
+LoggingInterval-r10 ::=			ENUMERATED {
+									ms1280, ms2560, ms5120, ms10240, ms20480,
+									ms30720, ms40960, ms61440}
+
+
+
+MeasSubframePattern-r10 ::= CHOICE {
+	subframePatternFDD-r10				BIT STRING (SIZE (40)),
+	subframePatternTDD-r10				CHOICE {
+		subframeConfig1-5-r10					BIT STRING (SIZE (20)),
+		subframeConfig0-r10						BIT STRING (SIZE (70)),
+		subframeConfig6-r10						BIT STRING (SIZE (60)),
+		...
+	},
+	...
+}
+
+
+
+MMEC ::=							BIT STRING (SIZE (8))
+
+
+
+NeighCellConfig ::=			BIT STRING (SIZE (2))
+
+
+
+NG-5G-S-TMSI-r15::=							BIT STRING (SIZE (48))
+
+
+
+OtherConfig-r9 ::= SEQUENCE	{
+	reportProximityConfig-r9			ReportProximityConfig-r9		OPTIONAL,	-- Need ON
+	...,
+	[[	idc-Config-r11					IDC-Config-r11					OPTIONAL,	-- Need ON
+		powerPrefIndicationConfig-r11	PowerPrefIndicationConfig-r11	OPTIONAL,	-- Need ON
+		obtainLocationConfig-r11		ObtainLocationConfig-r11		OPTIONAL	-- Need ON
+	]],
+	[[	bw-PreferenceIndicationTimer-r14	ENUMERATED {s0, s0dot5, s1, s2, s5, s10, s20,
+												s30, s60, s90, s120, s300, s600, spare3,
+												spare2, spare1}			OPTIONAL,	-- Need OR
+		sps-AssistanceInfoReport-r14		BOOLEAN			OPTIONAL,	-- Need ON
+		delayBudgetReportingConfig-r14	CHOICE{
+			release					NULL,
+			setup					SEQUENCE{
+				delayBudgetReportingProhibitTimer-r14	ENUMERATED {
+																s0, s0dot4, s0dot8,
+																s1dot6, s3, s6, s12, s30}
+			}
+		}																OPTIONAL,	-- Need ON
+		rlm-ReportConfig-r14			CHOICE {
+			release					NULL,
+			setup					SEQUENCE{
+				rlmReportTimer-r14				ENUMERATED {s0, s0dot5, s1, s2, s5, s10, s20, s30,
+												s60, s90, s120, s300, s600, spare3, spare2, spare1},
+				rlmReportRep-MPDCCH-r14			ENUMERATED {setup}		OPTIONAL	-- Need OR
+			}
+		}	OPTIONAL	-- Need ON
+	]],
+	[[	overheatingAssistanceConfig-r14	CHOICE{
+			release					NULL,
+			setup					SEQUENCE{
+				overheatingIndicationProhibitTimer-r14	ENUMERATED {s0, s0dot5, s1, s2, s5, s10,
+														s20, s30, s60, s90, s120, s300, s600,
+														spare3, spare2, spare1}
+			}
+		}	OPTIONAL		-- Need ON
+	]],
+	[[	measConfigAppLayer-r15		CHOICE{
+			release					NULL,
+			setup					SEQUENCE{
+				measConfigAppLayerContainer-r15		OCTET STRING (SIZE(1..1000)),
+				serviceType-r15						ENUMERATED {qoe, qoemtsi, spare6, spare5, spare4, spare3, spare2, spare1}
+			}
+		}	OPTIONAL,	-- Need ON	
+		ailc-BitConfig-r15				BOOLEAN							OPTIONAL,	-- Need ON
+		bt-NameListConfig-r15		BT-NameListConfig-r15					OPTIONAL,	--Need ON
+		wlan-NameListConfig-r15		WLAN-NameListConfig-r15					OPTIONAL		--Need ON
+	]],
+	[[	overheatingAssistanceConfigForSCG-r16	BOOLEAN		OPTIONAL	-- Cond overheating
+	]]
+}
+
+IDC-Config-r11 ::=				SEQUENCE {
+	idc-Indication-r11					ENUMERATED {setup}				OPTIONAL,	-- Need OR
+	autonomousDenialParameters-r11		SEQUENCE {
+			autonomousDenialSubframes-r11			ENUMERATED {n2, n5, n10, n15,
+														n20, n30, spare2, spare1},
+			autonomousDenialValidity-r11			ENUMERATED {
+														sf200, sf500, sf1000, sf2000,
+														spare4, spare3, spare2, spare1}
+	}		OPTIONAL,		-- Need OR
+	...,
+	[[	idc-Indication-UL-CA-r11			ENUMERATED {setup}		OPTIONAL	-- Cond idc-Ind
+	]],
+	[[	idc-HardwareSharingIndication-r13	ENUMERATED {setup}		OPTIONAL	-- Need OR
+	]],
+	[[	idc-Indication-MRDC-r15		CHOICE{
+			release					NULL,
+			setup					CandidateServingFreqListNR-r15
+		}			OPTIONAL	-- Cond idc-Ind
+	]]
+}
+
+ObtainLocationConfig-r11 ::= SEQUENCE {
+	obtainLocation-r11				ENUMERATED {setup}					OPTIONAL	-- Need OR
+}
+
+PowerPrefIndicationConfig-r11 ::= CHOICE{
+	release					NULL,
+	setup					SEQUENCE{
+		powerPrefIndicationTimer-r11		ENUMERATED {s0, s0dot5, s1, s2, s5, s10, s20,
+											s30, s60, s90, s120, s300, s600, spare3,
+											spare2, spare1}
+	}
+}
+
+ReportProximityConfig-r9 ::= SEQUENCE {
+	proximityIndicationEUTRA-r9		ENUMERATED {enabled}			OPTIONAL,	-- Need OR
+	proximityIndicationUTRA-r9		ENUMERATED {enabled}			OPTIONAL	-- Need OR
+}
+
+CandidateServingFreqListNR-r15 ::= SEQUENCE (SIZE (1..maxFreqIDC-r11)) OF ARFCN-ValueNR-r15
+
+
+
+RAN-AreaCode-r15 ::=					INTEGER (0..255)
+
+
+
+RAND-CDMA2000 ::=						BIT STRING (SIZE (32))
+
+
+
+RAT-Type ::=						ENUMERATED {
+										eutra, utra, geran-cs, geran-ps, cdma2000-1XRTT,
+										nr, eutra-nr, spare1, ...}
+
+
+
+ResumeIdentity-r13 ::=						BIT STRING (SIZE(40))
+
+
+
+RRC-TransactionIdentifier ::=		INTEGER (0..3)
+
+
+
+SBAS-ID-r15 ::= SEQUENCE {
+	sbas-id-r15				ENUMERATED {waas, egnos, msas, gagan, ...},
+	...
+}
+
+
+
+ShortI-RNTI-r15 ::=						BIT STRING (SIZE(24))
+
+
+
+S-NSSAI-r15 ::=			CHOICE{
+	sst							BIT STRING (SIZE (8)),
+	sst-SD						BIT STRING (SIZE (32))		
+}
+
+
+
+S-TMSI ::=							SEQUENCE {
+	mmec								MMEC,
+	m-TMSI								BIT STRING (SIZE (32))
+}
+
+
+
+TraceReference-r10 ::=			SEQUENCE {
+	plmn-Identity-r10				PLMN-Identity,
+	traceId-r10						OCTET STRING (SIZE (3))
+}
+
+
+
+UE-CapabilityRAT-ContainerList ::=SEQUENCE (SIZE (0..maxRAT-Capabilities)) OF UE-CapabilityRAT-Container
+
+UE-CapabilityRAT-Container ::= SEQUENCE {
+	rat-Type							RAT-Type,
+	ueCapabilityRAT-Container			OCTET STRING
+}
+
+
+
+UE-EUTRA-Capability ::=			SEQUENCE {
+	accessStratumRelease			AccessStratumRelease,
+	ue-Category						INTEGER (1..5),
+	pdcp-Parameters					PDCP-Parameters,
+	phyLayerParameters				PhyLayerParameters,
+	rf-Parameters					RF-Parameters,
+	measParameters					MeasParameters,
+	featureGroupIndicators			BIT STRING (SIZE (32))					OPTIONAL,
+	interRAT-Parameters				SEQUENCE {
+		utraFDD							IRAT-ParametersUTRA-FDD				OPTIONAL,
+		utraTDD128						IRAT-ParametersUTRA-TDD128			OPTIONAL,
+		utraTDD384						IRAT-ParametersUTRA-TDD384			OPTIONAL,
+		utraTDD768						IRAT-ParametersUTRA-TDD768			OPTIONAL,
+		geran							IRAT-ParametersGERAN				OPTIONAL,
+		cdma2000-HRPD					IRAT-ParametersCDMA2000-HRPD		OPTIONAL,
+		cdma2000-1xRTT					IRAT-ParametersCDMA2000-1XRTT		OPTIONAL
+	},
+	nonCriticalExtension			UE-EUTRA-Capability-v920-IEs			OPTIONAL
+}
+
+-- Late non critical extensions
+UE-EUTRA-Capability-v9a0-IEs ::=	SEQUENCE {
+	featureGroupIndRel9Add-r9			BIT STRING (SIZE (32))				OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-r9	UE-EUTRA-CapabilityAddXDD-Mode-r9	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-r9	UE-EUTRA-CapabilityAddXDD-Mode-r9	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v9c0-IEs		OPTIONAL
+}
+
+UE-EUTRA-Capability-v9c0-IEs ::=	SEQUENCE {
+	interRAT-ParametersUTRA-v9c0		IRAT-ParametersUTRA-v9c0		OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v9d0-IEs	OPTIONAL
+}
+
+UE-EUTRA-Capability-v9d0-IEs ::=	SEQUENCE {
+	phyLayerParameters-v9d0				PhyLayerParameters-v9d0			OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v9e0-IEs	OPTIONAL
+}
+
+UE-EUTRA-Capability-v9e0-IEs ::=	SEQUENCE {
+	rf-Parameters-v9e0					RF-Parameters-v9e0						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v9h0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v9h0-IEs ::=	SEQUENCE {
+	interRAT-ParametersUTRA-v9h0		IRAT-ParametersUTRA-v9h0				OPTIONAL,
+	-- Following field is only to be used for late REL-9 extensions
+	lateNonCriticalExtension			OCTET STRING							OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v10c0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v10c0-IEs ::=	SEQUENCE {
+	otdoa-PositioningCapabilities-r10	OTDOA-PositioningCapabilities-r10		OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v10f0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v10f0-IEs ::=	SEQUENCE {
+	rf-Parameters-v10f0					RF-Parameters-v10f0						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v10i0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v10i0-IEs ::=	SEQUENCE {
+	rf-Parameters-v10i0					RF-Parameters-v10i0						OPTIONAL,
+	-- Following field is only to be used for late REL-10 extensions
+	lateNonCriticalExtension			OCTET STRING (CONTAINING UE-EUTRA-Capability-v10j0-IEs)	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v11d0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v10j0-IEs ::=	SEQUENCE {
+	rf-Parameters-v10j0					RF-Parameters-v10j0						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}								OPTIONAL
+}
+
+UE-EUTRA-Capability-v11d0-IEs ::=	SEQUENCE {
+	rf-Parameters-v11d0					RF-Parameters-v11d0						OPTIONAL,
+	otherParameters-v11d0				Other-Parameters-v11d0					OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v11x0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v11x0-IEs ::=	SEQUENCE {
+	-- Following field is only to be used for late REL-11 extensions
+	lateNonCriticalExtension			OCTET STRING								OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v12b0-IEs				OPTIONAL
+}
+
+UE-EUTRA-Capability-v12b0-IEs ::= SEQUENCE {
+	rf-Parameters-v12b0					RF-Parameters-v12b0						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v12x0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v12x0-IEs ::= SEQUENCE {
+	-- Following field is only to be used for late REL-12 extensions
+	lateNonCriticalExtension			OCTET STRING							OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1370-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1370-IEs ::= SEQUENCE {
+	ce-Parameters-v1370					CE-Parameters-v1370						OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1370	UE-EUTRA-CapabilityAddXDD-Mode-v1370	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1370	UE-EUTRA-CapabilityAddXDD-Mode-v1370	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1380-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1380-IEs ::= SEQUENCE {
+	rf-Parameters-v1380					RF-Parameters-v1380						OPTIONAL,
+	ce-Parameters-v1380					CE-Parameters-v1380,
+	fdd-Add-UE-EUTRA-Capabilities-v1380	UE-EUTRA-CapabilityAddXDD-Mode-v1380,
+	tdd-Add-UE-EUTRA-Capabilities-v1380	UE-EUTRA-CapabilityAddXDD-Mode-v1380,
+	nonCriticalExtension				UE-EUTRA-Capability-v1390-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1390-IEs ::= SEQUENCE {
+	rf-Parameters-v1390					RF-Parameters-v1390						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v13e0a-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v13e0a-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING UE-EUTRA-Capability-v13e0b-IEs)							OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1470-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v13e0b-IEs ::= SEQUENCE {
+	phyLayerParameters-v13e0			PhyLayerParameters-v13e0,
+	-- Following field is only to be used for late REL-13 extensions
+	nonCriticalExtension				SEQUENCE {}								OPTIONAL
+}
+
+UE-EUTRA-Capability-v1470-IEs ::= SEQUENCE {
+	mbms-Parameters-v1470				MBMS-Parameters-v1470					OPTIONAL,
+	phyLayerParameters-v1470			PhyLayerParameters-v1470				OPTIONAL,
+	rf-Parameters-v1470					RF-Parameters-v1470						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v14a0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v14a0-IEs ::= SEQUENCE {
+	phyLayerParameters-v14a0				PhyLayerParameters-v14a0,
+	-- Following field is only to be used for late REL-14 extensions
+	nonCriticalExtension					UE-EUTRA-Capability-v14b0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v14b0-IEs ::= SEQUENCE {
+	rf-Parameters-v14b0				RF-Parameters-v14b0				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+-- Regular non critical extensions
+UE-EUTRA-Capability-v920-IEs ::=		SEQUENCE {
+	phyLayerParameters-v920					PhyLayerParameters-v920,
+	interRAT-ParametersGERAN-v920			IRAT-ParametersGERAN-v920,
+	interRAT-ParametersUTRA-v920			IRAT-ParametersUTRA-v920			OPTIONAL,
+	interRAT-ParametersCDMA2000-v920		IRAT-ParametersCDMA2000-1XRTT-v920	OPTIONAL,
+	deviceType-r9							ENUMERATED {noBenFromBatConsumpOpt}	OPTIONAL,
+	csg-ProximityIndicationParameters-r9	CSG-ProximityIndicationParameters-r9,
+	neighCellSI-AcquisitionParameters-r9	NeighCellSI-AcquisitionParameters-r9,
+	son-Parameters-r9						SON-Parameters-r9,
+	nonCriticalExtension					UE-EUTRA-Capability-v940-IEs		OPTIONAL
+}
+
+UE-EUTRA-Capability-v940-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING UE-EUTRA-Capability-v9a0-IEs)			OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1020-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1020-IEs ::=	SEQUENCE {
+	ue-Category-v1020					INTEGER (6..8)							OPTIONAL,
+	phyLayerParameters-v1020			PhyLayerParameters-v1020				OPTIONAL,
+	rf-Parameters-v1020					RF-Parameters-v1020						OPTIONAL,
+	measParameters-v1020				MeasParameters-v1020					OPTIONAL,
+	featureGroupIndRel10-r10			BIT STRING (SIZE (32))					OPTIONAL,
+	interRAT-ParametersCDMA2000-v1020	IRAT-ParametersCDMA2000-1XRTT-v1020		OPTIONAL,
+	ue-BasedNetwPerfMeasParameters-r10	UE-BasedNetwPerfMeasParameters-r10		OPTIONAL,
+	interRAT-ParametersUTRA-TDD-v1020	IRAT-ParametersUTRA-TDD-v1020			OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1060-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1060-IEs ::=	SEQUENCE {
+	fdd-Add-UE-EUTRA-Capabilities-v1060	UE-EUTRA-CapabilityAddXDD-Mode-v1060	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1060	UE-EUTRA-CapabilityAddXDD-Mode-v1060	OPTIONAL,
+	rf-Parameters-v1060					RF-Parameters-v1060						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1090-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1090-IEs ::=	SEQUENCE {
+	rf-Parameters-v1090					RF-Parameters-v1090						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1130-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1130-IEs ::=	SEQUENCE {
+	pdcp-Parameters-v1130				PDCP-Parameters-v1130,
+	phyLayerParameters-v1130			PhyLayerParameters-v1130				OPTIONAL,
+	rf-Parameters-v1130					RF-Parameters-v1130,
+	measParameters-v1130				MeasParameters-v1130,
+	interRAT-ParametersCDMA2000-v1130	IRAT-ParametersCDMA2000-v1130,
+	otherParameters-r11					Other-Parameters-r11,
+	fdd-Add-UE-EUTRA-Capabilities-v1130	UE-EUTRA-CapabilityAddXDD-Mode-v1130	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1130	UE-EUTRA-CapabilityAddXDD-Mode-v1130	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1170-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1170-IEs ::=	SEQUENCE {
+	phyLayerParameters-v1170			PhyLayerParameters-v1170				OPTIONAL,
+	ue-Category-v1170					INTEGER (9..10)							OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1180-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1180-IEs ::=	SEQUENCE {
+	rf-Parameters-v1180					RF-Parameters-v1180						OPTIONAL,
+	mbms-Parameters-r11					MBMS-Parameters-r11						OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1180	UE-EUTRA-CapabilityAddXDD-Mode-v1180	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1180	UE-EUTRA-CapabilityAddXDD-Mode-v1180	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v11a0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v11a0-IEs ::=	SEQUENCE {
+	ue-Category-v11a0					INTEGER (11..12)						OPTIONAL,
+	measParameters-v11a0				MeasParameters-v11a0					OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1250-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1250-IEs ::=	SEQUENCE {
+	phyLayerParameters-v1250				PhyLayerParameters-v1250				OPTIONAL,
+	rf-Parameters-v1250						RF-Parameters-v1250						OPTIONAL,
+	rlc-Parameters-r12						RLC-Parameters-r12						OPTIONAL,
+	ue-BasedNetwPerfMeasParameters-v1250	UE-BasedNetwPerfMeasParameters-v1250	OPTIONAL,
+	ue-CategoryDL-r12						INTEGER (0..14)							OPTIONAL,
+	ue-CategoryUL-r12						INTEGER (0..13)							OPTIONAL,
+	wlan-IW-Parameters-r12					WLAN-IW-Parameters-r12					OPTIONAL,
+	measParameters-v1250					MeasParameters-v1250					OPTIONAL,
+	dc-Parameters-r12						DC-Parameters-r12						OPTIONAL,
+	mbms-Parameters-v1250					MBMS-Parameters-v1250					OPTIONAL,
+	mac-Parameters-r12						MAC-Parameters-r12						OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1250		UE-EUTRA-CapabilityAddXDD-Mode-v1250	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1250		UE-EUTRA-CapabilityAddXDD-Mode-v1250	OPTIONAL,
+	sl-Parameters-r12						SL-Parameters-r12						OPTIONAL,
+	nonCriticalExtension					UE-EUTRA-Capability-v1260-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1260-IEs ::=	SEQUENCE {
+	ue-CategoryDL-v1260					INTEGER (15..16)						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1270-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1270-IEs ::= SEQUENCE {
+	rf-Parameters-v1270					RF-Parameters-v1270						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1280-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1280-IEs ::= SEQUENCE {
+	phyLayerParameters-v1280			PhyLayerParameters-v1280				OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1310-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1310-IEs ::= SEQUENCE {
+	ue-CategoryDL-v1310					ENUMERATED {n17, m1}					OPTIONAL,
+	ue-CategoryUL-v1310					ENUMERATED {n14, m1}					OPTIONAL,
+	pdcp-Parameters-v1310				PDCP-Parameters-v1310,
+	rlc-Parameters-v1310				RLC-Parameters-v1310,
+	mac-Parameters-v1310				MAC-Parameters-v1310					OPTIONAL,
+	phyLayerParameters-v1310			PhyLayerParameters-v1310				OPTIONAL,
+	rf-Parameters-v1310					RF-Parameters-v1310						OPTIONAL,
+	measParameters-v1310				MeasParameters-v1310					OPTIONAL,
+	dc-Parameters-v1310					DC-Parameters-v1310						OPTIONAL,
+	sl-Parameters-v1310					SL-Parameters-v1310						OPTIONAL,
+	scptm-Parameters-r13				SCPTM-Parameters-r13					OPTIONAL,
+	ce-Parameters-r13					CE-Parameters-r13						OPTIONAL,
+	interRAT-ParametersWLAN-r13			IRAT-ParametersWLAN-r13,
+	laa-Parameters-r13					LAA-Parameters-r13						OPTIONAL,
+	lwa-Parameters-r13					LWA-Parameters-r13						OPTIONAL,
+	wlan-IW-Parameters-v1310			WLAN-IW-Parameters-v1310,
+	lwip-Parameters-r13					LWIP-Parameters-r13,
+	fdd-Add-UE-EUTRA-Capabilities-v1310	UE-EUTRA-CapabilityAddXDD-Mode-v1310	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1310	UE-EUTRA-CapabilityAddXDD-Mode-v1310	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1320-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1320-IEs ::= SEQUENCE {
+	ce-Parameters-v1320					CE-Parameters-v1320						OPTIONAL,
+	phyLayerParameters-v1320			PhyLayerParameters-v1320				OPTIONAL,
+	rf-Parameters-v1320					RF-Parameters-v1320						OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1320	UE-EUTRA-CapabilityAddXDD-Mode-v1320	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1320	UE-EUTRA-CapabilityAddXDD-Mode-v1320	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1330-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1330-IEs ::= SEQUENCE {
+	ue-CategoryDL-v1330					INTEGER (18..19)						OPTIONAL,
+	phyLayerParameters-v1330			PhyLayerParameters-v1330				OPTIONAL,
+	ue-CE-NeedULGaps-r13				ENUMERATED {true}						OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1340-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1340-IEs ::= SEQUENCE {
+	ue-CategoryUL-v1340					INTEGER (15)							OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1350-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1350-IEs ::= SEQUENCE {
+	ue-CategoryDL-v1350					ENUMERATED {oneBis}						OPTIONAL,
+	ue-CategoryUL-v1350					ENUMERATED {oneBis}						OPTIONAL,
+	ce-Parameters-v1350					CE-Parameters-v1350,
+	nonCriticalExtension				UE-EUTRA-Capability-v1360-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1360-IEs ::= SEQUENCE {
+	other-Parameters-v1360				Other-Parameters-v1360					OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1430-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1430-IEs ::= SEQUENCE {
+	phyLayerParameters-v1430			PhyLayerParameters-v1430,
+	ue-CategoryDL-v1430					ENUMERATED {m2}								OPTIONAL,
+	ue-CategoryUL-v1430					ENUMERATED {n16, n17, n18, n19, n20, m2}	OPTIONAL,
+	ue-CategoryUL-v1430b				ENUMERATED {n21}							OPTIONAL,
+	mac-Parameters-v1430				MAC-Parameters-v1430						OPTIONAL,
+	measParameters-v1430				MeasParameters-v1430						OPTIONAL,
+	pdcp-Parameters-v1430				PDCP-Parameters-v1430						OPTIONAL,
+	rlc-Parameters-v1430				RLC-Parameters-v1430,
+	rf-Parameters-v1430					RF-Parameters-v1430							OPTIONAL,
+	laa-Parameters-v1430				LAA-Parameters-v1430						OPTIONAL,
+	lwa-Parameters-v1430				LWA-Parameters-v1430						OPTIONAL,
+	lwip-Parameters-v1430				LWIP-Parameters-v1430						OPTIONAL,
+	otherParameters-v1430				Other-Parameters-v1430,
+	mmtel-Parameters-r14				MMTEL-Parameters-r14						OPTIONAL,
+	mobilityParameters-r14				MobilityParameters-r14						OPTIONAL,
+	ce-Parameters-v1430					CE-Parameters-v1430,
+	fdd-Add-UE-EUTRA-Capabilities-v1430	UE-EUTRA-CapabilityAddXDD-Mode-v1430		OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1430	UE-EUTRA-CapabilityAddXDD-Mode-v1430		OPTIONAL,
+	mbms-Parameters-v1430				MBMS-Parameters-v1430						OPTIONAL,
+	sl-Parameters-v1430					SL-Parameters-v1430							OPTIONAL,
+	ue-BasedNetwPerfMeasParameters-v1430	UE-BasedNetwPerfMeasParameters-v1430	OPTIONAL,
+	highSpeedEnhParameters-r14			HighSpeedEnhParameters-r14					OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1440-IEs				OPTIONAL
+}
+
+UE-EUTRA-Capability-v1440-IEs ::= SEQUENCE {
+	lwa-Parameters-v1440				LWA-Parameters-v1440,
+	mac-Parameters-v1440				MAC-Parameters-v1440,
+	nonCriticalExtension				UE-EUTRA-Capability-v1450-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1450-IEs ::= SEQUENCE {
+	phyLayerParameters-v1450			PhyLayerParameters-v1450		OPTIONAL,
+	rf-Parameters-v1450					RF-Parameters-v1450			OPTIONAL,
+	otherParameters-v1450				OtherParameters-v1450,
+	ue-CategoryDL-v1450					INTEGER (20)					OPTIONAL,
+	nonCriticalExtension					UE-EUTRA-Capability-v1460-IEs	OPTIONAL
+}
+
+UE-EUTRA-Capability-v1460-IEs ::= SEQUENCE {
+	ue-CategoryDL-v1460				INTEGER (21)							OPTIONAL,
+	otherParameters-v1460				Other-Parameters-v1460,
+	nonCriticalExtension				UE-EUTRA-Capability-v1510-IEs		OPTIONAL
+}
+
+UE-EUTRA-Capability-v1510-IEs ::= SEQUENCE {
+	irat-ParametersNR-r15					IRAT-ParametersNR-r15					OPTIONAL,
+	featureSetsEUTRA-r15					FeatureSetsEUTRA-r15					OPTIONAL,
+	pdcp-ParametersNR-r15					PDCP-ParametersNR-r15					OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1510		UE-EUTRA-CapabilityAddXDD-Mode-v1510	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1510		UE-EUTRA-CapabilityAddXDD-Mode-v1510	OPTIONAL,
+	nonCriticalExtension					UE-EUTRA-Capability-v1520-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1520-IEs ::= SEQUENCE {
+	measParameters-v1520					MeasParameters-v1520,
+	nonCriticalExtension					UE-EUTRA-Capability-v1530-IEs	OPTIONAL
+}
+
+UE-EUTRA-Capability-v1530-IEs ::= SEQUENCE {
+	measParameters-v1530					MeasParameters-v1530					OPTIONAL,
+	otherParameters-v1530					Other-Parameters-v1530					OPTIONAL,
+	neighCellSI-AcquisitionParameters-v1530	NeighCellSI-AcquisitionParameters-v1530	OPTIONAL,
+	mac-Parameters-v1530					MAC-Parameters-v1530					OPTIONAL,
+	phyLayerParameters-v1530				PhyLayerParameters-v1530				OPTIONAL,
+	rf-Parameters-v1530						RF-Parameters-v1530						OPTIONAL,
+	pdcp-Parameters-v1530					PDCP-Parameters-v1530					OPTIONAL,
+	ue-CategoryDL-v1530						INTEGER (22..26)						OPTIONAL,
+	ue-BasedNetwPerfMeasParameters-v1530	UE-BasedNetwPerfMeasParameters-v1530	OPTIONAL,
+	rlc-Parameters-v1530					RLC-Parameters-v1530					OPTIONAL,
+	sl-Parameters-v1530						SL-Parameters-v1530						OPTIONAL,
+	extendedNumberOfDRBs-r15				ENUMERATED {supported}					OPTIONAL,
+	reducedCP-Latency-r15					ENUMERATED {supported}					OPTIONAL,
+	laa-Parameters-v1530					LAA-Parameters-v1530					OPTIONAL,
+	ue-CategoryUL-v1530						INTEGER (22..26)						OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1530		UE-EUTRA-CapabilityAddXDD-Mode-v1530	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1530		UE-EUTRA-CapabilityAddXDD-Mode-v1530	OPTIONAL,
+	nonCriticalExtension					UE-EUTRA-Capability-v1540-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1540-IEs ::= SEQUENCE {
+	phyLayerParameters-v1540				PhyLayerParameters-v1540				OPTIONAL,
+	otherParameters-v1540					Other-Parameters-v1540,
+	fdd-Add-UE-EUTRA-Capabilities-v1540		UE-EUTRA-CapabilityAddXDD-Mode-v1540	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1540		UE-EUTRA-CapabilityAddXDD-Mode-v1540	OPTIONAL,
+	sl-Parameters-v1540						SL-Parameters-v1540						OPTIONAL,
+	irat-ParametersNR-v1540					IRAT-ParametersNR-v1540					OPTIONAL,
+	nonCriticalExtension					UE-EUTRA-Capability-v1550-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1550-IEs ::= SEQUENCE {
+	neighCellSI-AcquisitionParameters-v1550	NeighCellSI-AcquisitionParameters-v1550	OPTIONAL,
+	phyLayerParameters-v1550				PhyLayerParameters-v1550,
+	mac-Parameters-v1550					MAC-Parameters-v1550,
+	fdd-Add-UE-EUTRA-Capabilities-v1550		UE-EUTRA-CapabilityAddXDD-Mode-v1550,
+	tdd-Add-UE-EUTRA-Capabilities-v1550		UE-EUTRA-CapabilityAddXDD-Mode-v1550,
+	nonCriticalExtension					UE-EUTRA-Capability-v1560-IEs	OPTIONAL
+}
+
+UE-EUTRA-Capability-v1560-IEs ::= SEQUENCE {
+	pdcp-ParametersNR-v1560				PDCP-ParametersNR-v1560,
+	irat-ParametersNR-v1560				IRAT-ParametersNR-v1560,
+	appliedCapabilityFilterCommon-r15		OCTET STRING							OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1560	UE-EUTRA-CapabilityAddXDD-Mode-v1560,
+	tdd-Add-UE-EUTRA-Capabilities-v1560	UE-EUTRA-CapabilityAddXDD-Mode-v1560,
+	nonCriticalExtension					UE-EUTRA-Capability-v1570-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1570-IEs ::= SEQUENCE {
+	rf-Parameters-v1570				RF-Parameters-v1570					OPTIONAL,
+	irat-ParametersNR-v1570			IRAT-ParametersNR-v1570				OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v15a0-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v15a0-IEs ::= SEQUENCE {
+	neighCellSI-AcquisitionParameters-v15a0	NeighCellSI-AcquisitionParameters-v15a0,
+	eutra-5GC-Parameters-r15				EUTRA-5GC-Parameters-r15				OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v15a0	UE-EUTRA-CapabilityAddXDD-Mode-v15a0	OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v15a0	UE-EUTRA-CapabilityAddXDD-Mode-v15a0	OPTIONAL,
+	nonCriticalExtension				UE-EUTRA-Capability-v1610-IEs			OPTIONAL
+}
+
+UE-EUTRA-Capability-v1610-IEs ::= SEQUENCE {
+	highSpeedEnhParameters-v1610			HighSpeedEnhParameters-v1610				OPTIONAL,
+	neighCellSI-AcquisitionParameters-v1610	NeighCellSI-AcquisitionParameters-v1610		OPTIONAL,
+	mbms-Parameters-v1610					MBMS-Parameters-v1610						OPTIONAL,
+	pdcp-Parameters-v1610					PDCP-Parameters-v1610						OPTIONAL,
+	mac-Parameters-v1610					MAC-Parameters-v1610						OPTIONAL,
+	phyLayerParameters-v1610				PhyLayerParameters-v1610					OPTIONAL,
+	measParameters-v1610 					MeasParameters-v1610 						OPTIONAL,
+	pur-Parameters-r16						PUR-Parameters-r16							OPTIONAL,
+	eutra-5GC-Parameters-v1610				EUTRA-5GC-Parameters-v1610					OPTIONAL,
+	otherParameters-v1610					Other-Parameters-v1610						OPTIONAL,
+	dl-DedicatedMessageSegmentation-r16		ENUMERATED {supported}						OPTIONAL,
+	mmtel-Parameters-v1610					MMTEL-Parameters-v1610,
+	irat-ParametersNR-v1610					IRAT-ParametersNR-v1610						OPTIONAL,
+	rf-Parameters-v1610						RF-Parameters-v1610							OPTIONAL,
+	mobilityParameters-v1610				MobilityParameters-v1610					OPTIONAL,
+	ue-BasedNetwPerfMeasParameters-v1610	UE-BasedNetwPerfMeasParameters-v1610,
+	sl-Parameters-v1610						SL-Parameters-v1610							OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1610		UE-EUTRA-CapabilityAddXDD-Mode-v1610		OPTIONAL,
+	tdd-Add-UE-EUTRA-Capabilities-v1610		UE-EUTRA-CapabilityAddXDD-Mode-v1610		OPTIONAL,
+	nonCriticalExtension					UE-EUTRA-Capability-v1630-IEs				OPTIONAL
+}
+
+UE-EUTRA-Capability-v1630-IEs ::= SEQUENCE {
+	rf-Parameters-v1630						RF-Parameters-v1630							OPTIONAL,
+	sl-Parameters-v1630						SL-Parameters-v1630							OPTIONAL,
+	earlySecurityReactivation-r16			ENUMERATED {supported}					OPTIONAL,
+	mac-Parameters-v1630					MAC-Parameters-v1630,
+	measParameters-v1630					MeasParameters-v1630						OPTIONAL,
+	fdd-Add-UE-EUTRA-Capabilities-v1630		UE-EUTRA-CapabilityAddXDD-Mode-v1630,
+	tdd-Add-UE-EUTRA-Capabilities-v1630		UE-EUTRA-CapabilityAddXDD-Mode-v1630,
+	nonCriticalExtension					SEQUENCE {}									OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-r9 ::=	SEQUENCE {
+	phyLayerParameters-r9					PhyLayerParameters						OPTIONAL,
+	featureGroupIndicators-r9				BIT STRING (SIZE (32))					OPTIONAL,
+	featureGroupIndRel9Add-r9				BIT STRING (SIZE (32))					OPTIONAL,
+	interRAT-ParametersGERAN-r9				IRAT-ParametersGERAN					OPTIONAL,
+	interRAT-ParametersUTRA-r9				IRAT-ParametersUTRA-v920				OPTIONAL,
+	interRAT-ParametersCDMA2000-r9			IRAT-ParametersCDMA2000-1XRTT-v920		OPTIONAL,
+	neighCellSI-AcquisitionParameters-r9	NeighCellSI-AcquisitionParameters-r9	OPTIONAL,
+	...
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1060 ::=	SEQUENCE {
+	phyLayerParameters-v1060				PhyLayerParameters-v1020				OPTIONAL,
+	featureGroupIndRel10-v1060				BIT STRING (SIZE (32))					OPTIONAL,
+	interRAT-ParametersCDMA2000-v1060		IRAT-ParametersCDMA2000-1XRTT-v1020		OPTIONAL,
+	interRAT-ParametersUTRA-TDD-v1060		IRAT-ParametersUTRA-TDD-v1020			OPTIONAL,
+	...,
+	[[	otdoa-PositioningCapabilities-r10	OTDOA-PositioningCapabilities-r10		OPTIONAL
+	]]
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1130 ::=	SEQUENCE {
+	phyLayerParameters-v1130					PhyLayerParameters-v1130			OPTIONAL,
+	measParameters-v1130						MeasParameters-v1130				OPTIONAL,
+	otherParameters-r11							Other-Parameters-r11				OPTIONAL,
+	...
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1180 ::=	SEQUENCE {
+	mbms-Parameters-r11					MBMS-Parameters-r11
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1250 ::=	SEQUENCE {
+	phyLayerParameters-v1250			PhyLayerParameters-v1250			OPTIONAL,
+	measParameters-v1250				MeasParameters-v1250				OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1310 ::=	SEQUENCE {
+	phyLayerParameters-v1310			PhyLayerParameters-v1310			OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1320 ::=	SEQUENCE {
+	phyLayerParameters-v1320			PhyLayerParameters-v1320			OPTIONAL,
+	scptm-Parameters-r13				SCPTM-Parameters-r13				OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1370 ::=	SEQUENCE {
+	ce-Parameters-v1370					CE-Parameters-v1370					OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1380 ::=	SEQUENCE {
+	ce-Parameters-v1380					CE-Parameters-v1380
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1430 ::=	SEQUENCE {
+	phyLayerParameters-v1430			PhyLayerParameters-v1430			OPTIONAL,
+	mmtel-Parameters-r14				MMTEL-Parameters-r14				OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1510 ::=	SEQUENCE {
+	pdcp-ParametersNR-r15						PDCP-ParametersNR-r15		OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1530 ::=	SEQUENCE {
+	neighCellSI-AcquisitionParameters-v1530	NeighCellSI-AcquisitionParameters-v1530	OPTIONAL,
+	reducedCP-Latency-r15			ENUMERATED {supported}					OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1540 ::=	SEQUENCE {
+	eutra-5GC-Parameters-r15					EUTRA-5GC-Parameters-r15		OPTIONAL,
+	irat-ParametersNR-v1540						IRAT-ParametersNR-v1540			OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1550 ::=	SEQUENCE {
+	neighCellSI-AcquisitionParameters-v1550	NeighCellSI-AcquisitionParameters-v1550	OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1560 ::=	SEQUENCE {
+	pdcp-ParametersNR-v1560					PDCP-ParametersNR-v1560
+}
+
+
+UE-EUTRA-CapabilityAddXDD-Mode-v15a0 ::=	SEQUENCE {
+	phyLayerParameters-v1530				PhyLayerParameters-v1530				OPTIONAL,
+	phyLayerParameters-v1540				PhyLayerParameters-v1540				OPTIONAL,
+	phyLayerParameters-v1550				PhyLayerParameters-v1550				OPTIONAL,
+	neighCellSI-AcquisitionParameters-v15a0	NeighCellSI-AcquisitionParameters-v15a0
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1610 ::= SEQUENCE {
+	phyLayerParameters-v1610					PhyLayerParameters-v1610				OPTIONAL,
+	pur-Parameters-r16							PUR-Parameters-r16						OPTIONAL,
+	measParameters-v1610						MeasParameters-v1610					OPTIONAL,
+	eutra-5GC-Parameters-v1610					EUTRA-5GC-Parameters-v1610				OPTIONAL,
+	irat-ParametersNR-v1610						IRAT-ParametersNR-v1610					OPTIONAL,
+	neighCellSI-AcquisitionParameters-v1610		NeighCellSI-AcquisitionParameters-v1610	OPTIONAL,
+	mobilityParameters-v1610					MobilityParameters-v1610				OPTIONAL
+}
+
+UE-EUTRA-CapabilityAddXDD-Mode-v1630 ::= SEQUENCE {
+	measParameters-v1630						MeasParameters-v1630
+}
+
+AccessStratumRelease ::=			ENUMERATED {
+										rel8, rel9, rel10, rel11, rel12, rel13,
+										rel14, rel15, ..., rel16}
+
+FeatureSetsEUTRA-r15 ::=	SEQUENCE {
+	featureSetsDL-r15			SEQUENCE (SIZE (1..maxFeatureSets-r15)) OF FeatureSetDL-r15		OPTIONAL,
+	featureSetsDL-PerCC-r15		SEQUENCE (SIZE (1..maxPerCC-FeatureSets-r15)) OF FeatureSetDL-PerCC-r15		OPTIONAL,
+	featureSetsUL-r15			SEQUENCE (SIZE (1..maxFeatureSets-r15)) OF FeatureSetUL-r15		OPTIONAL,
+	featureSetsUL-PerCC-r15		SEQUENCE (SIZE (1..maxPerCC-FeatureSets-r15)) OF FeatureSetUL-PerCC-r15		OPTIONAL,
+	...,
+	[[	featureSetsDL-v1550		SEQUENCE (SIZE (1..maxFeatureSets-r15)) OF FeatureSetDL-v1550	OPTIONAL
+	]]
+
+}
+
+MobilityParameters-r14 ::=			SEQUENCE {
+	makeBeforeBreak-r14					ENUMERATED {supported}					OPTIONAL,
+	rach-Less-r14						ENUMERATED {supported}					OPTIONAL
+}
+
+MobilityParameters-v1610 ::=		SEQUENCE {
+	cho-r16								ENUMERATED {supported}					OPTIONAL,
+	cho-FDD-TDD-r16						ENUMERATED {supported}					OPTIONAL,
+	cho-Failure-r16						ENUMERATED {supported}					OPTIONAL,
+	cho-TwoTriggerEvents-r16			ENUMERATED {supported}					OPTIONAL
+}
+
+DC-Parameters-r12 ::=			SEQUENCE {
+	drb-TypeSplit-r12						ENUMERATED {supported}			OPTIONAL,
+	drb-TypeSCG-r12							ENUMERATED {supported}			OPTIONAL
+}
+
+DC-Parameters-v1310 ::=			SEQUENCE {
+	pdcp-TransferSplitUL-r13				ENUMERATED {supported}			OPTIONAL,
+	ue-SSTD-Meas-r13						ENUMERATED {supported}			OPTIONAL
+}
+
+MAC-Parameters-r12 ::=				SEQUENCE {
+	logicalChannelSR-ProhibitTimer-r12	ENUMERATED {supported}					OPTIONAL,
+	longDRX-Command-r12					ENUMERATED {supported}					OPTIONAL
+}
+
+MAC-Parameters-v1310 ::=				SEQUENCE {
+	extendedMAC-LengthField-r13		ENUMERATED {supported}				OPTIONAL,
+	extendedLongDRX-r13				ENUMERATED {supported}				OPTIONAL
+}
+
+MAC-Parameters-v1430 ::=				SEQUENCE {
+	shortSPS-IntervalFDD-r14			ENUMERATED {supported}				OPTIONAL,
+	shortSPS-IntervalTDD-r14			ENUMERATED {supported}				OPTIONAL,
+	skipUplinkDynamic-r14				ENUMERATED {supported}				OPTIONAL,
+	skipUplinkSPS-r14					ENUMERATED {supported}				OPTIONAL,
+	multipleUplinkSPS-r14				ENUMERATED {supported}				OPTIONAL,
+	dataInactMon-r14					ENUMERATED {supported}				OPTIONAL
+}
+
+MAC-Parameters-v1440 ::=				SEQUENCE {
+	rai-Support-r14					ENUMERATED {supported}			OPTIONAL
+}
+
+MAC-Parameters-v1530 ::=		SEQUENCE {
+	min-Proc-TimelineSubslot-r15	SEQUENCE (SIZE(1..3)) OF ProcessingTimelineSet-r15	OPTIONAL,
+	skipSubframeProcessing-r15			SkipSubframeProcessing-r15						OPTIONAL,
+	earlyData-UP-r15					ENUMERATED {supported}							OPTIONAL,
+	dormantSCellState-r15				ENUMERATED {supported}							OPTIONAL,
+	directSCellActivation-r15			ENUMERATED {supported}							OPTIONAL,
+	directSCellHibernation-r15			ENUMERATED {supported}							OPTIONAL,
+	extendedLCID-Duplication-r15		ENUMERATED {supported}							OPTIONAL,
+	sps-ServingCell-r15					ENUMERATED {supported}							OPTIONAL
+}
+
+MAC-Parameters-v1550 ::=				SEQUENCE {
+	eLCID-Support-r15					ENUMERATED {supported}			OPTIONAL
+}
+
+MAC-Parameters-v1610 ::=		SEQUENCE {
+	directMCG-SCellActivationResume-r16	ENUMERATED {supported}			OPTIONAL,
+	directSCG-SCellActivationResume-r16	ENUMERATED {supported}			OPTIONAL,
+	earlyData-UP-5GC-r16				ENUMERATED {supported}			OPTIONAL,
+	rai-SupportEnh-r16					ENUMERATED {supported}			OPTIONAL
+}
+
+MAC-Parameters-v1630 ::=		SEQUENCE {
+	directSCG-SCellActivationNEDC-r16	ENUMERATED {supported}			OPTIONAL
+}
+
+ProcessingTimelineSet-r15 ::=		ENUMERATED {set1, set2}
+
+RLC-Parameters-r12 ::=				SEQUENCE {
+	extended-RLC-LI-Field-r12			ENUMERATED {supported}
+}
+
+RLC-Parameters-v1310 ::=				SEQUENCE {
+	extendedRLC-SN-SO-Field-r13				ENUMERATED {supported}				OPTIONAL
+}
+
+RLC-Parameters-v1430 ::=				SEQUENCE {
+	extendedPollByte-r14						ENUMERATED {supported}			OPTIONAL
+}
+
+RLC-Parameters-v1530 ::=				SEQUENCE {
+	flexibleUM-AM-Combinations-r15			ENUMERATED {supported}			OPTIONAL,
+	rlc-AM-Ooo-Delivery-r15					ENUMERATED {supported}			OPTIONAL,
+	rlc-UM-Ooo-Delivery-r15					ENUMERATED {supported}			OPTIONAL
+}
+
+PDCP-Parameters ::=				SEQUENCE {
+	supportedROHC-Profiles				ROHC-ProfileSupportList-r15,
+	maxNumberROHC-ContextSessions		ENUMERATED {
+											cs2, cs4, cs8, cs12, cs16, cs24, cs32,
+											cs48, cs64, cs128, cs256, cs512, cs1024,
+											cs16384, spare2, spare1}				DEFAULT cs16,
+	...
+}
+
+PDCP-Parameters-v1130 ::=		SEQUENCE {
+	pdcp-SN-Extension-r11					ENUMERATED {supported}			OPTIONAL,
+	supportRohcContextContinue-r11			ENUMERATED {supported}			OPTIONAL
+}
+
+PDCP-Parameters-v1310 ::=				SEQUENCE {
+	pdcp-SN-Extension-18bits-r13			ENUMERATED {supported}	OPTIONAL
+}
+
+PDCP-Parameters-v1430 ::=				SEQUENCE {
+	supportedUplinkOnlyROHC-Profiles-r14		SEQUENCE {
+		profile0x0006-r14						BOOLEAN
+	},
+	maxNumberROHC-ContextSessions-r14		ENUMERATED {
+											cs2, cs4, cs8, cs12, cs16, cs24, cs32,
+											cs48, cs64, cs128, cs256, cs512, cs1024,
+											cs16384, spare2, spare1}				DEFAULT cs16
+}
+
+PDCP-Parameters-v1530 ::=			SEQUENCE {
+	supportedUDC-r15					SupportedUDC-r15				OPTIONAL,
+	pdcp-Duplication-r15				ENUMERATED {supported}		OPTIONAL
+}
+
+PDCP-Parameters-v1610 ::=			SEQUENCE {
+	pdcp-VersionChangeWithoutHO-r16		ENUMERATED {supported}		OPTIONAL,
+	ehc-r16								ENUMERATED {supported}		OPTIONAL,
+	continueEHC-Context-r16				ENUMERATED {supported}		OPTIONAL,
+		maxNumberEHC-Contexts-r16 			ENUMERATED {cs2, cs4, cs8, cs16, cs32, cs64, cs128, cs256,
+														cs512, cs1024, cs2048, cs4096, cs8192, cs16384,
+														cs32768, cs65536}	OPTIONAL,
+	jointEHC-ROHC-Config-r16			ENUMERATED {supported}		OPTIONAL
+}
+
+SupportedUDC-r15 ::=				SEQUENCE {
+	supportedStandardDic-r15			ENUMERATED {supported}		OPTIONAL,
+	supportedOperatorDic-r15			SupportedOperatorDic-r15	OPTIONAL
+}
+
+SupportedOperatorDic-r15 ::=		SEQUENCE {
+	versionOfDictionary-r15				INTEGER (0..15),
+	associatedPLMN-ID-r15				PLMN-Identity
+}
+
+PhyLayerParameters ::=				SEQUENCE {
+	ue-TxAntennaSelectionSupported		BOOLEAN,
+	ue-SpecificRefSigsSupported		BOOLEAN
+}
+
+PhyLayerParameters-v920 ::=		SEQUENCE {
+	enhancedDualLayerFDD-r9			ENUMERATED {supported}			OPTIONAL,
+	enhancedDualLayerTDD-r9			ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v9d0 ::=			SEQUENCE {
+	tm5-FDD-r9						ENUMERATED {supported}			OPTIONAL,
+	tm5-TDD-r9						ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v1020 ::=			SEQUENCE {
+	twoAntennaPortsForPUCCH-r10				ENUMERATED {supported}					OPTIONAL,
+	tm9-With-8Tx-FDD-r10					ENUMERATED {supported}					OPTIONAL,
+	pmi-Disabling-r10						ENUMERATED {supported}					OPTIONAL,
+	crossCarrierScheduling-r10				ENUMERATED {supported}					OPTIONAL,
+	simultaneousPUCCH-PUSCH-r10				ENUMERATED {supported}					OPTIONAL,
+	multiClusterPUSCH-WithinCC-r10			ENUMERATED {supported}					OPTIONAL,
+	nonContiguousUL-RA-WithinCC-List-r10	NonContiguousUL-RA-WithinCC-List-r10	OPTIONAL
+}
+
+PhyLayerParameters-v1130 ::=			SEQUENCE {
+	crs-InterfHandl-r11						ENUMERATED {supported}					OPTIONAL,
+	ePDCCH-r11								ENUMERATED {supported}					OPTIONAL,
+	multiACK-CSI-Reporting-r11				ENUMERATED {supported}					OPTIONAL,
+	ss-CCH-InterfHandl-r11					ENUMERATED {supported}					OPTIONAL,
+	tdd-SpecialSubframe-r11					ENUMERATED {supported}					OPTIONAL,
+	txDiv-PUCCH1b-ChSelect-r11				ENUMERATED {supported}					OPTIONAL,
+	ul-CoMP-r11								ENUMERATED {supported}					OPTIONAL
+}
+
+PhyLayerParameters-v1170 ::=			SEQUENCE {
+	interBandTDD-CA-WithDifferentConfig-r11	BIT STRING (SIZE (2))			OPTIONAL
+}
+
+PhyLayerParameters-v1250 ::=			SEQUENCE {
+	e-HARQ-Pattern-FDD-r12					ENUMERATED {supported}			OPTIONAL,
+	enhanced-4TxCodebook-r12				ENUMERATED {supported}			OPTIONAL,
+	tdd-FDD-CA-PCellDuplex-r12				BIT STRING (SIZE (2))			OPTIONAL,
+	phy-TDD-ReConfig-TDD-PCell-r12			ENUMERATED {supported}			OPTIONAL,
+	phy-TDD-ReConfig-FDD-PCell-r12			ENUMERATED {supported}			OPTIONAL,
+	pusch-FeedbackMode-r12					ENUMERATED {supported}			OPTIONAL,
+	pusch-SRS-PowerControl-SubframeSet-r12	ENUMERATED {supported}			OPTIONAL,
+	csi-SubframeSet-r12						ENUMERATED {supported}			OPTIONAL,
+	noResourceRestrictionForTTIBundling-r12	ENUMERATED {supported}			OPTIONAL,
+	discoverySignalsInDeactSCell-r12		ENUMERATED {supported}			OPTIONAL,
+	naics-Capability-List-r12				NAICS-Capability-List-r12		OPTIONAL
+}
+
+PhyLayerParameters-v1280 ::=			SEQUENCE {
+	alternativeTBS-Indices-r12				ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v1310 ::=			SEQUENCE {
+	aperiodicCSI-Reporting-r13				BIT STRING (SIZE (2))			OPTIONAL,
+	codebook-HARQ-ACK-r13					BIT STRING (SIZE (2))			OPTIONAL,
+	crossCarrierScheduling-B5C-r13			ENUMERATED {supported}			OPTIONAL,
+	fdd-HARQ-TimingTDD-r13					ENUMERATED {supported}			OPTIONAL,
+	maxNumberUpdatedCSI-Proc-r13			INTEGER(5..32)					OPTIONAL,
+	pucch-Format4-r13						ENUMERATED {supported}			OPTIONAL,
+	pucch-Format5-r13						ENUMERATED {supported}			OPTIONAL,
+	pucch-SCell-r13							ENUMERATED {supported}			OPTIONAL,
+	spatialBundling-HARQ-ACK-r13			ENUMERATED {supported}			OPTIONAL,
+	supportedBlindDecoding-r13				SEQUENCE {
+		maxNumberDecoding-r13					INTEGER(1..32)				OPTIONAL,
+		pdcch-CandidateReductions-r13			ENUMERATED {supported}		OPTIONAL,
+		skipMonitoringDCI-Format0-1A-r13		ENUMERATED {supported}		OPTIONAL
+	}																		OPTIONAL,
+	uci-PUSCH-Ext-r13						ENUMERATED {supported}			OPTIONAL,
+	crs-InterfMitigationTM10-r13			ENUMERATED {supported}			OPTIONAL,
+	pdsch-CollisionHandling-r13				ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v1320 ::=			SEQUENCE {
+	mimo-UE-Parameters-r13					MIMO-UE-Parameters-r13			OPTIONAL
+}
+
+PhyLayerParameters-v1330 ::=			SEQUENCE {
+	cch-InterfMitigation-RefRecTypeA-r13	ENUMERATED {supported}			OPTIONAL,
+	cch-InterfMitigation-RefRecTypeB-r13	ENUMERATED {supported}			OPTIONAL,
+	cch-InterfMitigation-MaxNumCCs-r13		INTEGER (1.. maxServCell-r13)	OPTIONAL,
+	crs-InterfMitigationTM1toTM9-r13		INTEGER (1.. maxServCell-r13)	OPTIONAL
+}
+
+PhyLayerParameters-v13e0 ::=			SEQUENCE {
+	mimo-UE-Parameters-v13e0				MIMO-UE-Parameters-v13e0	
+}
+
+PhyLayerParameters-v1430 ::=			SEQUENCE {
+	ce-PUSCH-NB-MaxTBS-r14					ENUMERATED {supported}			OPTIONAL,
+	ce-PDSCH-PUSCH-MaxBandwidth-r14			ENUMERATED {bw5, bw20}			OPTIONAL,
+	ce-HARQ-AckBundling-r14					ENUMERATED {supported}			OPTIONAL,
+	ce-PDSCH-TenProcesses-r14				ENUMERATED {supported}			OPTIONAL,
+	ce-RetuningSymbols-r14					ENUMERATED {n0, n1}				OPTIONAL,
+	ce-PDSCH-PUSCH-Enhancement-r14			ENUMERATED {supported}			OPTIONAL,
+	ce-SchedulingEnhancement-r14			ENUMERATED {supported}			OPTIONAL,
+	ce-SRS-Enhancement-r14					ENUMERATED {supported}			OPTIONAL,
+	ce-PUCCH-Enhancement-r14				ENUMERATED {supported}			OPTIONAL,
+	ce-ClosedLoopTxAntennaSelection-r14		ENUMERATED {supported}			OPTIONAL,
+	tdd-SpecialSubframe-r14					ENUMERATED {supported}			OPTIONAL,
+	tdd-TTI-Bundling-r14					ENUMERATED {supported}			OPTIONAL,
+	dmrs-LessUpPTS-r14						ENUMERATED {supported}			OPTIONAL,
+	mimo-UE-Parameters-v1430				MIMO-UE-Parameters-v1430		OPTIONAL,
+	alternativeTBS-Index-r14				ENUMERATED {supported}			OPTIONAL,
+	feMBMS-Unicast-Parameters-r14			FeMBMS-Unicast-Parameters-r14	OPTIONAL
+}
+
+PhyLayerParameters-v1450 ::=			SEQUENCE {
+	ce-SRS-EnhancementWithoutComb4-r14		ENUMERATED {supported}			OPTIONAL,
+	crs-LessDwPTS-r14						ENUMERATED {supported}			OPTIONAL}
+
+PhyLayerParameters-v1470 ::=			SEQUENCE {
+	mimo-UE-Parameters-v1470				MIMO-UE-Parameters-v1470		OPTIONAL,
+	srs-UpPTS-6sym-r14						ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v14a0 ::=			SEQUENCE {
+	ssp10-TDD-Only-r14						ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v1530 ::=			SEQUENCE {
+	stti-SPT-Capabilities-r15				SEQUENCE {
+		aperiodicCsi-ReportingSTTI-r15			ENUMERATED {supported}			OPTIONAL,
+		dmrs-BasedSPDCCH-MBSFN-r15				ENUMERATED {supported}			OPTIONAL,
+		dmrs-BasedSPDCCH-nonMBSFN-r15			ENUMERATED {supported}			OPTIONAL,
+		dmrs-PositionPattern-r15				ENUMERATED {supported}			OPTIONAL,
+		dmrs-SharingSubslotPDSCH-r15			ENUMERATED {supported}			OPTIONAL,
+		dmrs-RepetitionSubslotPDSCH-r15			ENUMERATED {supported}			OPTIONAL,
+		epdcch-SPT-differentCells-r15			ENUMERATED {supported}			OPTIONAL,
+		epdcch-STTI-differentCells-r15			ENUMERATED {supported}			OPTIONAL,
+		maxLayersSlotOrSubslotPUSCH-r15			ENUMERATED {oneLayer,twoLayers,fourLayers}
+		OPTIONAL,
+		maxNumberUpdatedCSI-Proc-SPT-r15		INTEGER(5..32)					OPTIONAL,
+		maxNumberUpdatedCSI-Proc-STTI-Comb77-r15		INTEGER(1..32)			OPTIONAL,
+		maxNumberUpdatedCSI-Proc-STTI-Comb27-r15		INTEGER(1..32)			OPTIONAL,
+		maxNumberUpdatedCSI-Proc-STTI-Comb22-Set1-r15	INTEGER(1..32)			OPTIONAL,
+		maxNumberUpdatedCSI-Proc-STTI-Comb22-Set2-r15	INTEGER(1..32)			OPTIONAL,
+		mimo-UE-ParametersSTTI-r15				MIMO-UE-Parameters-r13			OPTIONAL,
+		mimo-UE-ParametersSTTI-v1530			MIMO-UE-Parameters-v1430		OPTIONAL,
+		numberOfBlindDecodesUSS-r15				INTEGER(4..32)					OPTIONAL,
+		pdsch-SlotSubslotPDSCH-Decoding-r15		ENUMERATED {supported}			OPTIONAL,
+		powerUCI-SlotPUSCH						ENUMERATED {supported}			OPTIONAL,
+		powerUCI-SubslotPUSCH					ENUMERATED {supported}			OPTIONAL,
+		slotPDSCH-TxDiv-TM9and10				ENUMERATED {supported}			OPTIONAL,
+		subslotPDSCH-TxDiv-TM9and10				ENUMERATED {supported}			OPTIONAL,
+		spdcch-differentRS-types-r15			ENUMERATED {supported}			OPTIONAL,
+		srs-DCI7-TriggeringFS2-r15				ENUMERATED {supported}			OPTIONAL,
+		sps-cyclicShift-r15						ENUMERATED {supported}			OPTIONAL,
+		spdcch-Reuse-r15						ENUMERATED {supported}			OPTIONAL,
+		sps-STTI-r15							ENUMERATED {slot, subslot, slotAndSubslot}
+		OPTIONAL,
+		tm8-slotPDSCH-r15						ENUMERATED {supported}			OPTIONAL,
+		tm9-slotSubslot-r15						ENUMERATED {supported}			OPTIONAL,
+		tm9-slotSubslotMBSFN-r15				ENUMERATED {supported}			OPTIONAL,
+		tm10-slotSubslot-r15					ENUMERATED {supported}			OPTIONAL,
+		tm10-slotSubslotMBSFN-r15				ENUMERATED {supported}			OPTIONAL,
+		txDiv-SPUCCH-r15						ENUMERATED {supported}			OPTIONAL,
+		ul-AsyncHarqSharingDiff-TTI-Lengths-r15	ENUMERATED {supported}			OPTIONAL
+	}																			OPTIONAL,
+	ce-Capabilities-r15					SEQUENCE {
+		ce-CRS-IntfMitig-r15					ENUMERATED {supported}			OPTIONAL,
+		ce-CQI-AlternativeTable-r15				ENUMERATED {supported}			OPTIONAL,
+		ce-PDSCH-FlexibleStartPRB-CE-ModeA-r15	ENUMERATED {supported}			OPTIONAL,
+		ce-PDSCH-FlexibleStartPRB-CE-ModeB-r15	ENUMERATED {supported}			OPTIONAL,
+		ce-PDSCH-64QAM-r15						ENUMERATED {supported}			OPTIONAL,
+		ce-PUSCH-FlexibleStartPRB-CE-ModeA-r15	ENUMERATED {supported}			OPTIONAL,
+		ce-PUSCH-FlexibleStartPRB-CE-ModeB-r15	ENUMERATED {supported}			OPTIONAL,
+		ce-PUSCH-SubPRB-Allocation-r15			ENUMERATED {supported}			OPTIONAL,
+		ce-UL-HARQ-ACK-Feedback-r15				ENUMERATED {supported}			OPTIONAL
+	}	OPTIONAL,
+	shortCQI-ForSCellActivation-r15			ENUMERATED {supported}			OPTIONAL,
+	mimo-CBSR-AdvancedCSI-r15				ENUMERATED {supported}			OPTIONAL,
+	crs-IntfMitig-r15						ENUMERATED {supported}			OPTIONAL,
+	ul-PowerControlEnhancements-r15			ENUMERATED {supported}			OPTIONAL,
+	urllc-Capabilities-r15					SEQUENCE {
+		pdsch-RepSubframe-r15					ENUMERATED {supported}		OPTIONAL,
+		pdsch-RepSlot-r15						ENUMERATED {supported}		OPTIONAL,
+		pdsch-RepSubslot-r15					ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-MultiConfigSubframe-r15		INTEGER (0..6)				OPTIONAL,
+		pusch-SPS-MaxConfigSubframe-r15			INTEGER (0..31)				OPTIONAL,
+		pusch-SPS-MultiConfigSlot-r15			INTEGER (0..6)				OPTIONAL,
+		pusch-SPS-MaxConfigSlot-r15				INTEGER (0..31)				OPTIONAL,
+		pusch-SPS-MultiConfigSubslot-r15		INTEGER (0..6)				OPTIONAL,
+		pusch-SPS-MaxConfigSubslot-r15			INTEGER (0..31)				OPTIONAL,
+		pusch-SPS-SlotRepPCell-r15				ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SlotRepPSCell-r15				ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SlotRepSCell-r15				ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SubframeRepPCell-r15			ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SubframeRepPSCell-r15			ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SubframeRepSCell-r15			ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SubslotRepPCell-r15			ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SubslotRepPSCell-r15			ENUMERATED {supported}		OPTIONAL,
+		pusch-SPS-SubslotRepSCell-r15			ENUMERATED {supported}		OPTIONAL,
+		semiStaticCFI-r15						ENUMERATED {supported}		OPTIONAL,
+		semiStaticCFI-Pattern-r15				ENUMERATED {supported}		OPTIONAL
+	}	OPTIONAL,
+	altMCS-Table-r15						ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v1540 ::=			SEQUENCE {
+	stti-SPT-Capabilities-v1540			SEQUENCE {
+		slotPDSCH-TxDiv-TM8-r15					ENUMERATED {supported}
+	}												OPTIONAL,
+	crs-IM-TM1-toTM9-OneRX-Port-v1540		ENUMERATED {supported}			OPTIONAL,
+	cch-IM-RefRecTypeA-OneRX-Port-v1540		ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v1550 ::=			SEQUENCE {
+	dmrs-OverheadReduction-r15				ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-v1610 ::=			SEQUENCE {
+	ce-Capabilities-v1610	SEQUENCE {
+		ce-CSI-RS-Feedback-r16						ENUMERATED {supported}			OPTIONAL,
+		ce-CSI-RS-FeedbackCodebookRestriction-r16	ENUMERATED {supported}			OPTIONAL,
+		crs-ChEstMPDCCH-CE-ModeA-r16				ENUMERATED {supported}			OPTIONAL,
+		crs-ChEstMPDCCH-CE-ModeB-r16				ENUMERATED {supported}			OPTIONAL,
+		crs-ChEstMPDCCH-CSI-r16						ENUMERATED {supported}			OPTIONAL,
+		crs-ChEstMPDCCH-ReciprocityTDD-r16			ENUMERATED {supported}			OPTIONAL,
+		etws-CMAS-RxInConnCE-ModeA-r16				ENUMERATED {supported}			OPTIONAL,
+		etws-CMAS-RxInConnCE-ModeB-r16				ENUMERATED {supported}			OPTIONAL,
+		mpdcch-InLteControlRegionCE-ModeA-r16		ENUMERATED {supported}			OPTIONAL,
+		mpdcch-InLteControlRegionCE-ModeB-r16		ENUMERATED {supported}			OPTIONAL,
+		pdsch-InLteControlRegionCE-ModeA-r16		ENUMERATED {supported}			OPTIONAL,
+		pdsch-InLteControlRegionCE-ModeB-r16		ENUMERATED {supported}			OPTIONAL,
+		multiTB-Parameters-r16						CE-MultiTB-Parameters-r16 		OPTIONAL,
+		resourceResvParameters-r16					CE-ResourceResvParameters-r16	OPTIONAL
+	}	OPTIONAL,
+	widebandPRG-Slot-r16				ENUMERATED {supported}			OPTIONAL,
+	widebandPRG-Subslot-r16				ENUMERATED {supported}			OPTIONAL,
+	widebandPRG-Subframe-r16			ENUMERATED {supported}			OPTIONAL,
+	addSRS-r16		SEQUENCE {
+		addSRS-FrequencyHopping-r16		ENUMERATED {supported}			OPTIONAL,
+		addSRS-AntennaSwitching-r16		ENUMERATED {useBasic}			OPTIONAL,
+		addSRS-CarrierSwitching-r16		ENUMERATED {supported}			OPTIONAL
+	} OPTIONAL,
+	virtualCellID-BasicSRS-r16			ENUMERATED {supported}			OPTIONAL,
+	virtualCellID-AddSRS-r16		ENUMERATED {supported}			OPTIONAL
+}
+
+MIMO-UE-Parameters-r13 ::=				SEQUENCE {
+	parametersTM9-r13						MIMO-UE-ParametersPerTM-r13		OPTIONAL,
+	parametersTM10-r13						MIMO-UE-ParametersPerTM-r13		OPTIONAL,
+	srs-EnhancementsTDD-r13					ENUMERATED {supported}			OPTIONAL,
+	srs-Enhancements-r13					ENUMERATED {supported}			OPTIONAL,
+	interferenceMeasRestriction-r13			ENUMERATED {supported}			OPTIONAL
+}
+
+MIMO-UE-Parameters-v13e0 ::=			SEQUENCE {
+	mimo-WeightedLayersCapabilities-r13		MIMO-WeightedLayersCapabilities-r13	OPTIONAL
+}
+
+MIMO-UE-Parameters-v1430 ::=			SEQUENCE {
+	parametersTM9-v1430						MIMO-UE-ParametersPerTM-v1430	OPTIONAL,
+	parametersTM10-v1430					MIMO-UE-ParametersPerTM-v1430	OPTIONAL
+}
+
+MIMO-UE-Parameters-v1470 ::=			SEQUENCE {
+	parametersTM9-v1470					MIMO-UE-ParametersPerTM-v1470,
+	parametersTM10-v1470					MIMO-UE-ParametersPerTM-v1470
+}
+
+MIMO-UE-ParametersPerTM-r13 ::=			SEQUENCE {
+	nonPrecoded-r13							MIMO-NonPrecodedCapabilities-r13	OPTIONAL,
+	beamformed-r13							MIMO-UE-BeamformedCapabilities-r13	OPTIONAL,
+	channelMeasRestriction-r13				ENUMERATED {supported}				OPTIONAL,
+	dmrs-Enhancements-r13					ENUMERATED {supported}				OPTIONAL,
+	csi-RS-EnhancementsTDD-r13				ENUMERATED {supported}				OPTIONAL
+}
+
+MIMO-UE-ParametersPerTM-v1430 ::=		SEQUENCE {
+	nzp-CSI-RS-AperiodicInfo-r14			SEQUENCE {
+		nMaxProc-r14							INTEGER(5..32),
+		nMaxResource-r14						ENUMERATED {n1, n2, n4, n8}
+	}																			OPTIONAL,
+	nzp-CSI-RS-PeriodicInfo-r14				SEQUENCE {
+		nMaxResource-r14						ENUMERATED {n1, n2, n4, n8}
+	}																			OPTIONAL,
+	zp-CSI-RS-AperiodicInfo-r14					ENUMERATED {supported}			OPTIONAL,
+	ul-dmrs-Enhancements-r14				ENUMERATED {supported}				OPTIONAL,
+	densityReductionNP-r14					ENUMERATED {supported}				OPTIONAL,
+	densityReductionBF-r14					ENUMERATED {supported}				OPTIONAL,
+	hybridCSI-r14							ENUMERATED {supported}				OPTIONAL,
+	semiOL-r14								ENUMERATED {supported}				OPTIONAL,
+	csi-ReportingNP-r14						ENUMERATED {supported}				OPTIONAL,
+	csi-ReportingAdvanced-r14				ENUMERATED {supported}				OPTIONAL
+}
+
+MIMO-UE-ParametersPerTM-v1470 ::=		SEQUENCE {
+	csi-ReportingAdvancedMaxPorts-r14		ENUMERATED {n8, n12, n16, n20, n24, n28}	OPTIONAL
+}
+
+MIMO-CA-ParametersPerBoBC-r13 ::=		SEQUENCE {
+	parametersTM9-r13						MIMO-CA-ParametersPerBoBCPerTM-r13		OPTIONAL,
+	parametersTM10-r13						MIMO-CA-ParametersPerBoBCPerTM-r13		OPTIONAL
+}
+
+MIMO-CA-ParametersPerBoBC-r15 ::=		SEQUENCE {
+	parametersTM9-r15						MIMO-CA-ParametersPerBoBCPerTM-r15	OPTIONAL,
+	parametersTM10-r15						MIMO-CA-ParametersPerBoBCPerTM-r15	OPTIONAL
+}
+
+MIMO-CA-ParametersPerBoBC-v1430 ::=		SEQUENCE {
+	parametersTM9-v1430						MIMO-CA-ParametersPerBoBCPerTM-v1430	OPTIONAL,
+	parametersTM10-v1430					MIMO-CA-ParametersPerBoBCPerTM-v1430	OPTIONAL
+}
+
+MIMO-CA-ParametersPerBoBC-v1470 ::=		SEQUENCE {
+	parametersTM9-v1470						MIMO-CA-ParametersPerBoBCPerTM-v1470,
+	parametersTM10-v1470						MIMO-CA-ParametersPerBoBCPerTM-v1470
+}
+
+MIMO-CA-ParametersPerBoBCPerTM-r13 ::=	SEQUENCE {
+	nonPrecoded-r13							MIMO-NonPrecodedCapabilities-r13	OPTIONAL,
+	beamformed-r13							MIMO-BeamformedCapabilityList-r13	OPTIONAL,
+	dmrs-Enhancements-r13					ENUMERATED {different}				OPTIONAL
+}
+
+MIMO-CA-ParametersPerBoBCPerTM-v1430 ::=	SEQUENCE {
+	csi-ReportingNP-r14						ENUMERATED {different}				OPTIONAL,
+	csi-ReportingAdvanced-r14				ENUMERATED {different}				OPTIONAL
+}
+
+MIMO-CA-ParametersPerBoBCPerTM-v1470 ::=	SEQUENCE {
+	csi-ReportingAdvancedMaxPorts-r14		ENUMERATED {n8, n12, n16, n20, n24, n28}	OPTIONAL
+}
+
+MIMO-CA-ParametersPerBoBCPerTM-r15 ::=	SEQUENCE {
+	nonPrecoded-r13							MIMO-NonPrecodedCapabilities-r13	OPTIONAL,
+	beamformed-r13							MIMO-BeamformedCapabilityList-r13	OPTIONAL,
+	dmrs-Enhancements-r13					ENUMERATED {different}				OPTIONAL,
+	csi-ReportingNP-r14						ENUMERATED {different}				OPTIONAL,
+	csi-ReportingAdvanced-r14				ENUMERATED {different}				OPTIONAL
+}
+
+MIMO-NonPrecodedCapabilities-r13 ::=	SEQUENCE {
+	config1-r13								ENUMERATED {supported}			OPTIONAL,
+	config2-r13								ENUMERATED {supported}			OPTIONAL,
+	config3-r13								ENUMERATED {supported}			OPTIONAL,
+	config4-r13								ENUMERATED {supported}			OPTIONAL
+}
+
+MIMO-UE-BeamformedCapabilities-r13 ::=		SEQUENCE {
+	altCodebook-r13							ENUMERATED {supported}			OPTIONAL,
+	mimo-BeamformedCapabilities-r13			MIMO-BeamformedCapabilityList-r13
+}
+
+MIMO-BeamformedCapabilityList-r13 ::=		SEQUENCE (SIZE (1..maxCSI-Proc-r11)) OF MIMO-BeamformedCapabilities-r13
+
+MIMO-BeamformedCapabilities-r13 ::=		SEQUENCE {
+	k-Max-r13								INTEGER (1..8),
+	n-MaxList-r13							BIT STRING (SIZE (1..7))		OPTIONAL
+}
+
+MIMO-WeightedLayersCapabilities-r13 ::=		SEQUENCE {
+	relWeightTwoLayers-r13	ENUMERATED {v1, v1dot25, v1dot5, v1dot75, v2, v2dot5, v3, v4},
+	relWeightFourLayers-r13	ENUMERATED {v1, v1dot25, v1dot5, v1dot75, v2, v2dot5, v3, v4}	OPTIONAL,
+	relWeightEightLayers-r13	ENUMERATED {v1, v1dot25, v1dot5, v1dot75, v2, v2dot5, v3, v4}	OPTIONAL,
+	totalWeightedLayers-r13	INTEGER (2..128)
+}
+
+NonContiguousUL-RA-WithinCC-List-r10 ::= SEQUENCE (SIZE (1..maxBands)) OF NonContiguousUL-RA-WithinCC-r10
+
+NonContiguousUL-RA-WithinCC-r10 ::=		SEQUENCE {
+	nonContiguousUL-RA-WithinCC-Info-r10	ENUMERATED {supported}					OPTIONAL
+}
+
+RF-Parameters ::=					SEQUENCE {
+	supportedBandListEUTRA				SupportedBandListEUTRA
+}
+
+RF-Parameters-v9e0 ::=					SEQUENCE {
+	supportedBandListEUTRA-v9e0				SupportedBandListEUTRA-v9e0				OPTIONAL
+}
+
+RF-Parameters-v1020 ::=				SEQUENCE {
+	supportedBandCombination-r10			SupportedBandCombination-r10
+}
+
+RF-Parameters-v1060 ::=				SEQUENCE {
+	supportedBandCombinationExt-r10			SupportedBandCombinationExt-r10
+}
+
+RF-Parameters-v1090 ::=					SEQUENCE {
+	supportedBandCombination-v1090			SupportedBandCombination-v1090			OPTIONAL
+}
+
+RF-Parameters-v10f0 ::=					SEQUENCE {
+	modifiedMPR-Behavior-r10					BIT STRING (SIZE (32))				OPTIONAL
+}
+
+RF-Parameters-v10i0 ::=					SEQUENCE {
+	supportedBandCombination-v10i0			SupportedBandCombination-v10i0			OPTIONAL
+}
+
+RF-Parameters-v10j0 ::=					SEQUENCE {
+	multiNS-Pmax-r10						ENUMERATED {supported}					OPTIONAL
+}
+
+RF-Parameters-v1130 ::=				SEQUENCE {
+	supportedBandCombination-v1130			SupportedBandCombination-v1130			OPTIONAL
+}
+
+RF-Parameters-v1180 ::=				SEQUENCE {
+	freqBandRetrieval-r11					ENUMERATED {supported}			OPTIONAL,
+	requestedBands-r11						SEQUENCE (SIZE (1.. maxBands)) OF FreqBandIndicator-r11						OPTIONAL,
+	supportedBandCombinationAdd-r11			SupportedBandCombinationAdd-r11		OPTIONAL
+}
+
+RF-Parameters-v11d0 ::=					SEQUENCE {
+	supportedBandCombinationAdd-v11d0		SupportedBandCombinationAdd-v11d0		OPTIONAL
+}
+
+RF-Parameters-v1250 ::=				SEQUENCE {
+	supportedBandListEUTRA-v1250				SupportedBandListEUTRA-v1250			OPTIONAL,
+	supportedBandCombination-v1250			SupportedBandCombination-v1250			OPTIONAL,
+	supportedBandCombinationAdd-v1250		SupportedBandCombinationAdd-v1250		OPTIONAL,
+	freqBandPriorityAdjustment-r12			ENUMERATED {supported}					OPTIONAL
+}
+
+RF-Parameters-v1270 ::=				SEQUENCE {
+	supportedBandCombination-v1270			SupportedBandCombination-v1270			OPTIONAL,
+	supportedBandCombinationAdd-v1270		SupportedBandCombinationAdd-v1270		OPTIONAL
+}
+
+RF-Parameters-v1310 ::=				SEQUENCE {
+	eNB-RequestedParameters-r13			SEQUENCE {
+		reducedIntNonContCombRequested-r13	ENUMERATED {true}						OPTIONAL,
+		requestedCCsDL-r13					INTEGER (2..32)							OPTIONAL,
+		requestedCCsUL-r13					INTEGER (2..32)							OPTIONAL,
+		skipFallbackCombRequested-r13		ENUMERATED {true}						OPTIONAL
+	}																				OPTIONAL,
+	maximumCCsRetrieval-r13					ENUMERATED {supported}					OPTIONAL,
+	skipFallbackCombinations-r13			ENUMERATED {supported}					OPTIONAL,
+	reducedIntNonContComb-r13				ENUMERATED {supported}					OPTIONAL,
+	supportedBandListEUTRA-v1310			SupportedBandListEUTRA-v1310			OPTIONAL,
+	supportedBandCombinationReduced-r13		SupportedBandCombinationReduced-r13		OPTIONAL
+}
+
+RF-Parameters-v1320 ::=				SEQUENCE {
+	supportedBandListEUTRA-v1320			SupportedBandListEUTRA-v1320			OPTIONAL,
+	supportedBandCombination-v1320			SupportedBandCombination-v1320			OPTIONAL,
+	supportedBandCombinationAdd-v1320		SupportedBandCombinationAdd-v1320		OPTIONAL,
+	supportedBandCombinationReduced-v1320	SupportedBandCombinationReduced-v1320	OPTIONAL
+}
+
+RF-Parameters-v1380 ::=				SEQUENCE {
+	supportedBandCombination-v1380			SupportedBandCombination-v1380			OPTIONAL,
+	supportedBandCombinationAdd-v1380		SupportedBandCombinationAdd-v1380		OPTIONAL,
+	supportedBandCombinationReduced-v1380	SupportedBandCombinationReduced-v1380	OPTIONAL
+}
+
+RF-Parameters-v1390 ::=				SEQUENCE {
+	supportedBandCombination-v1390			SupportedBandCombination-v1390			OPTIONAL,
+	supportedBandCombinationAdd-v1390		SupportedBandCombinationAdd-v1390		OPTIONAL,
+	supportedBandCombinationReduced-v1390	SupportedBandCombinationReduced-v1390	OPTIONAL
+}
+
+RF-Parameters-v12b0 ::=				SEQUENCE {
+	maxLayersMIMO-Indication-r12			ENUMERATED {supported}					OPTIONAL
+}
+
+RF-Parameters-v1430 ::=				SEQUENCE {
+	supportedBandCombination-v1430			SupportedBandCombination-v1430			OPTIONAL,
+	supportedBandCombinationAdd-v1430		SupportedBandCombinationAdd-v1430		OPTIONAL,
+	supportedBandCombinationReduced-v1430	SupportedBandCombinationReduced-v1430	OPTIONAL,
+	eNB-RequestedParameters-v1430			SEQUENCE {
+		requestedDiffFallbackCombList-r14		BandCombinationList-r14
+	}																				OPTIONAL,
+	diffFallbackCombReport-r14				ENUMERATED {supported}					OPTIONAL
+}
+
+RF-Parameters-v1450 ::=				SEQUENCE {
+	supportedBandCombination-v1450			SupportedBandCombination-v1450			OPTIONAL,
+	supportedBandCombinationAdd-v1450		SupportedBandCombinationAdd-v1450		OPTIONAL,
+	supportedBandCombinationReduced-v1450	SupportedBandCombinationReduced-v1450	OPTIONAL
+}
+
+RF-Parameters-v1470 ::=				SEQUENCE {
+	supportedBandCombination-v1470			SupportedBandCombination-v1470			OPTIONAL,
+	supportedBandCombinationAdd-v1470		SupportedBandCombinationAdd-v1470		OPTIONAL,
+	supportedBandCombinationReduced-v1470	SupportedBandCombinationReduced-v1470	OPTIONAL
+}
+
+RF-Parameters-v14b0 ::=				SEQUENCE {
+	supportedBandCombination-v14b0			SupportedBandCombination-v14b0			OPTIONAL,
+	supportedBandCombinationAdd-v14b0		SupportedBandCombinationAdd-v14b0		OPTIONAL,
+	supportedBandCombinationReduced-v14b0	SupportedBandCombinationReduced-v14b0	OPTIONAL
+}
+
+RF-Parameters-v1530 ::=				SEQUENCE {
+	sTTI-SPT-Supported-r15					ENUMERATED {supported}					OPTIONAL,
+	supportedBandCombination-v1530			SupportedBandCombination-v1530			OPTIONAL,
+	supportedBandCombinationAdd-v1530		SupportedBandCombinationAdd-v1530		OPTIONAL,
+	supportedBandCombinationReduced-v1530	SupportedBandCombinationReduced-v1530	OPTIONAL,
+	powerClass-14dBm-r15					ENUMERATED {supported}					OPTIONAL
+}
+
+RF-Parameters-v1570 ::=			SEQUENCE {
+	dl-1024QAM-ScalingFactor-r15			ENUMERATED {v1, v1dot2, v1dot25},
+	dl-1024QAM-TotalWeightedLayers-r15		INTEGER (0..10)
+}
+
+RF-Parameters-v1610 ::=				SEQUENCE {
+	supportedBandCombination-v1610			SupportedBandCombination-v1610			OPTIONAL,
+	supportedBandCombinationAdd-v1610		SupportedBandCombinationAdd-v1610		OPTIONAL,
+	supportedBandCombinationReduced-v1610	SupportedBandCombinationReduced-v1610	OPTIONAL
+}
+
+RF-Parameters-v1630 ::=				SEQUENCE {
+	supportedBandCombination-v1630			SupportedBandCombination-v1630			OPTIONAL,
+	supportedBandCombinationAdd-v1630		SupportedBandCombinationAdd-v1630		OPTIONAL,
+	supportedBandCombinationReduced-v1630	SupportedBandCombinationReduced-v1630	OPTIONAL
+}
+
+SkipSubframeProcessing-r15 ::=		SEQUENCE {
+	skipProcessingDL-Slot-r15			INTEGER (0..3)					OPTIONAL,
+	skipProcessingDL-SubSlot-r15		INTEGER (0..3)					OPTIONAL,
+	skipProcessingUL-Slot-r15			INTEGER (0..3)					OPTIONAL,
+	skipProcessingUL-SubSlot-r15		INTEGER (0..3)					OPTIONAL
+}
+
+SPT-Parameters-r15 ::=				SEQUENCE {
+	frameStructureType-SPT-r15			BIT STRING (SIZE (3))			OPTIONAL,
+	maxNumberCCs-SPT-r15				INTEGER (1..32)					OPTIONAL
+}
+
+STTI-SPT-BandParameters-r15 ::= SEQUENCE {
+	dl-1024QAM-Slot-r15						ENUMERATED {supported}			OPTIONAL,
+	dl-1024QAM-SubslotTA-1-r15				ENUMERATED {supported}			OPTIONAL,
+	dl-1024QAM-SubslotTA-2-r15				ENUMERATED {supported}			OPTIONAL,
+	simultaneousTx-differentTx-duration-r15	ENUMERATED {supported}			OPTIONAL,
+	sTTI-CA-MIMO-ParametersDL-r15			CA-MIMO-ParametersDL-r15		OPTIONAL,
+	sTTI-CA-MIMO-ParametersUL-r15			CA-MIMO-ParametersUL-r15,
+	sTTI-FD-MIMO-Coexistence				ENUMERATED {supported}			OPTIONAL,
+	sTTI-MIMO-CA-ParametersPerBoBCs-r15		MIMO-CA-ParametersPerBoBC-r13	OPTIONAL,
+	sTTI-MIMO-CA-ParametersPerBoBCs-v1530	MIMO-CA-ParametersPerBoBC-v1430	OPTIONAL,
+	sTTI-SupportedCombinations-r15			STTI-SupportedCombinations-r15	OPTIONAL,
+	sTTI-SupportedCSI-Proc-r15				ENUMERATED {n1, n3, n4}			OPTIONAL,
+	ul-256QAM-Slot-r15						ENUMERATED {supported}			OPTIONAL,
+	ul-256QAM-Subslot-r15					ENUMERATED {supported}			OPTIONAL,
+	...
+}
+
+STTI-SupportedCombinations-r15 ::=	SEQUENCE {
+	combination-22-r15					DL-UL-CCs-r15					OPTIONAL,
+	combination-77-r15					DL-UL-CCs-r15					OPTIONAL,
+	combination-27-r15					DL-UL-CCs-r15					OPTIONAL,
+	combination-22-27-r15				SEQUENCE (SIZE (1..2)) OF DL-UL-CCs-r15		OPTIONAL,
+	combination-77-22-r15				SEQUENCE (SIZE (1..2)) OF DL-UL-CCs-r15		OPTIONAL,
+	combination-77-27-r15				SEQUENCE (SIZE (1..2)) OF DL-UL-CCs-r15		OPTIONAL
+}
+
+DL-UL-CCs-r15 ::= SEQUENCE {
+	maxNumberDL-CCs-r15				INTEGER (1..32)						OPTIONAL,
+	maxNumberUL-CCs-r15				INTEGER (1..32)						OPTIONAL
+}
+
+SupportedBandCombination-r10 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-r10
+
+SupportedBandCombinationExt-r10 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParametersExt-r10
+
+SupportedBandCombination-v1090 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1090
+
+SupportedBandCombination-v10i0 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v10i0
+
+SupportedBandCombination-v1130 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1130
+
+SupportedBandCombination-v1250 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1250
+
+SupportedBandCombination-v1270 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1270
+
+SupportedBandCombination-v1320 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1320
+
+SupportedBandCombination-v1380 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1380
+
+SupportedBandCombination-v1390 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1390
+
+SupportedBandCombination-v1430 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1430
+
+SupportedBandCombination-v1450 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1450
+
+SupportedBandCombination-v1470 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1470
+
+SupportedBandCombination-v14b0 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v14b0
+
+SupportedBandCombination-v1530 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1530
+
+SupportedBandCombination-v1610 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1610
+
+SupportedBandCombination-v1630 ::= SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandCombinationParameters-v1630
+
+SupportedBandCombinationAdd-r11 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-r11
+
+SupportedBandCombinationAdd-v11d0 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v10i0
+
+SupportedBandCombinationAdd-v1250 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1250
+
+SupportedBandCombinationAdd-v1270 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1270
+
+SupportedBandCombinationAdd-v1320 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1320
+
+SupportedBandCombinationAdd-v1380 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1380
+
+SupportedBandCombinationAdd-v1390 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1390
+
+SupportedBandCombinationAdd-v1430 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1430
+
+SupportedBandCombinationAdd-v1450 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1450
+
+SupportedBandCombinationAdd-v1470 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1470
+
+SupportedBandCombinationAdd-v14b0 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v14b0
+
+SupportedBandCombinationAdd-v1530 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1530
+
+SupportedBandCombinationAdd-v1610 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1610
+
+SupportedBandCombinationAdd-v1630 ::= SEQUENCE (SIZE (1..maxBandComb-r11)) OF BandCombinationParameters-v1630
+
+SupportedBandCombinationReduced-r13 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-r13
+
+SupportedBandCombinationReduced-v1320 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1320
+
+SupportedBandCombinationReduced-v1380 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1380
+
+SupportedBandCombinationReduced-v1390 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1390
+
+SupportedBandCombinationReduced-v1430 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1430
+
+SupportedBandCombinationReduced-v1450 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1450
+
+SupportedBandCombinationReduced-v1470 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1470
+
+SupportedBandCombinationReduced-v14b0 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v14b0
+
+SupportedBandCombinationReduced-v1530 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1530
+
+SupportedBandCombinationReduced-v1610 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1610
+
+SupportedBandCombinationReduced-v1630 ::=	SEQUENCE (SIZE (1..maxBandComb-r13)) OF BandCombinationParameters-v1630
+
+BandCombinationParameters-r10 ::= SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF BandParameters-r10
+
+BandCombinationParametersExt-r10 ::= SEQUENCE {
+	supportedBandwidthCombinationSet-r10	SupportedBandwidthCombinationSet-r10	OPTIONAL
+}
+
+BandCombinationParameters-v1090 ::= SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF BandParameters-v1090
+
+BandCombinationParameters-v10i0::= SEQUENCE {
+	bandParameterList-v10i0			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v10i0	OPTIONAL
+}
+
+BandCombinationParameters-v1130 ::=	SEQUENCE {
+	multipleTimingAdvance-r11		ENUMERATED {supported}					OPTIONAL,
+	simultaneousRx-Tx-r11			ENUMERATED {supported}					OPTIONAL,
+	bandParameterList-r11			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF BandParameters-v1130	OPTIONAL,
+	...
+}
+
+BandCombinationParameters-r11 ::=	SEQUENCE {
+	bandParameterList-r11			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-r11,
+	supportedBandwidthCombinationSet-r11	SupportedBandwidthCombinationSet-r10	OPTIONAL,
+	multipleTimingAdvance-r11		ENUMERATED {supported}					OPTIONAL,
+	simultaneousRx-Tx-r11			ENUMERATED {supported}					OPTIONAL,
+	bandInfoEUTRA-r11				BandInfoEUTRA,
+	...
+}
+
+BandCombinationParameters-v1250::= SEQUENCE {
+	dc-Support-r12					SEQUENCE {
+		asynchronous-r12				ENUMERATED {supported}			OPTIONAL,
+		supportedCellGrouping-r12		CHOICE {
+				threeEntries-r12				BIT STRING (SIZE(3)),
+				fourEntries-r12					BIT STRING (SIZE(7)),
+				fiveEntries-r12					BIT STRING (SIZE(15))
+		}																OPTIONAL
+	}																	OPTIONAL,
+	supportedNAICS-2CRS-AP-r12		BIT STRING (SIZE (1..maxNAICS-Entries-r12))		OPTIONAL,
+	commSupportedBandsPerBC-r12				BIT STRING (SIZE (1.. maxBands))		OPTIONAL,
+	...
+}
+
+BandCombinationParameters-v1270 ::= SEQUENCE {
+	bandParameterList-v1270			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v1270		OPTIONAL
+}
+
+BandCombinationParameters-r13 ::=	SEQUENCE {
+	differentFallbackSupported-r13	ENUMERATED {true}				OPTIONAL,
+	bandParameterList-r13			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF BandParameters-r13,
+	supportedBandwidthCombinationSet-r13	SupportedBandwidthCombinationSet-r10	OPTIONAL,
+	multipleTimingAdvance-r13		ENUMERATED {supported}				OPTIONAL,
+	simultaneousRx-Tx-r13			ENUMERATED {supported}				OPTIONAL,
+	bandInfoEUTRA-r13				BandInfoEUTRA,
+	dc-Support-r13					SEQUENCE {
+		asynchronous-r13			ENUMERATED {supported}				OPTIONAL,
+		supportedCellGrouping-r13		CHOICE {
+				threeEntries-r13				BIT STRING (SIZE(3)),
+				fourEntries-r13					BIT STRING (SIZE(7)),
+				fiveEntries-r13					BIT STRING (SIZE(15))
+		}																OPTIONAL
+	}																	OPTIONAL,
+	supportedNAICS-2CRS-AP-r13		BIT STRING (SIZE (1..maxNAICS-Entries-r12))	OPTIONAL,
+	commSupportedBandsPerBC-r13		BIT STRING (SIZE (1.. maxBands))		OPTIONAL
+}
+
+BandCombinationParameters-v1320 ::= SEQUENCE {
+	bandParameterList-v1320			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v1320		OPTIONAL,
+	additionalRx-Tx-PerformanceReq-r13		ENUMERATED {supported}					OPTIONAL
+}
+
+BandCombinationParameters-v1380 ::= SEQUENCE {
+	bandParameterList-v1380		SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v1380		OPTIONAL
+}
+
+BandCombinationParameters-v1390 ::= SEQUENCE {
+	ue-CA-PowerClass-N-r13			ENUMERATED {class2}				OPTIONAL
+}
+
+BandCombinationParameters-v1430 ::= SEQUENCE {
+	bandParameterList-v1430			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v1430		OPTIONAL,
+	v2x-SupportedTxBandCombListPerBC-r14			BIT STRING (SIZE (1.. maxBandComb-r13))		OPTIONAL,
+	v2x-SupportedRxBandCombListPerBC-r14			BIT STRING (SIZE (1.. maxBandComb-r13))		OPTIONAL
+}
+
+BandCombinationParameters-v1450 ::= SEQUENCE {
+	bandParameterList-v1450			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v1450		OPTIONAL
+}
+
+BandCombinationParameters-v1470 ::= SEQUENCE {
+	bandParameterList-v1470			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v1470		OPTIONAL,
+	srs-MaxSimultaneousCCs-r14	INTEGER (1..31)				OPTIONAL
+}
+
+BandCombinationParameters-v14b0 ::= SEQUENCE {
+	bandParameterList-v14b0			SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			BandParameters-v14b0		OPTIONAL
+}
+
+BandCombinationParameters-v1530 ::= SEQUENCE {
+	bandParameterList-v1530		SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF							BandParameters-v1530		OPTIONAL,
+	spt-Parameters-r15				SPT-Parameters-r15				OPTIONAL
+}
+
+-- If an additional band combination parameter is defined, which is supported for MR-DC,
+--  it shall be defined in the IE CA-ParametersEUTRA in TS 38.331 [82].
+
+BandCombinationParameters-v1610 ::= SEQUENCE {
+	measGapInfoNR					MeasGapInfoNR					OPTIONAL,
+	bandParameterList-v1610 		SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF 							BandParameters-v1610		OPTIONAL,
+	interFreqDAPS-r16						SEQUENCE {
+		interFreqAsyncDAPS-r16					ENUMERATED {supported}		OPTIONAL,
+		interFreqMultiUL-TransmissionDAPS-r16	ENUMERATED {supported}		OPTIONAL
+	}																		OPTIONAL
+}
+
+BandCombinationParameters-v1630 ::= SEQUENCE {
+	v2x-SupportedTxBandCombListPerBC-v1630		BIT STRING (SIZE (1..maxBandCombSidelinkNR-r16))		OPTIONAL,
+	v2x-SupportedRxBandCombListPerBC-v1630		BIT STRING (SIZE (1..maxBandCombSidelinkNR-r16))		OPTIONAL,
+	scalingFactorTxSidelink-r16					SEQUENCE (SIZE (1..maxBandCombSidelinkNR-r16)) OF ScalingFactorSidelink-r16		OPTIONAL,
+	scalingFactorRxSidelink-r16					SEQUENCE (SIZE (1..maxBandCombSidelinkNR-r16)) OF ScalingFactorSidelink-r16		OPTIONAL,
+	interBandPowerSharingSyncDAPS-r16			ENUMERATED {supported}	OPTIONAL,
+	interBandPowerSharingAsyncDAPS-r16			ENUMERATED {supported}	OPTIONAL
+}
+
+ScalingFactorSidelink-r16 ::=						ENUMERATED {f0p4, f0p75, f0p8, f1}
+
+SupportedBandwidthCombinationSet-r10 ::=	BIT STRING (SIZE (1..maxBandwidthCombSet-r10))
+
+BandParameters-r10 ::= SEQUENCE {
+	bandEUTRA-r10					FreqBandIndicator,
+	bandParametersUL-r10			BandParametersUL-r10					OPTIONAL,
+	bandParametersDL-r10			BandParametersDL-r10					OPTIONAL
+}
+
+BandParameters-v1090 ::= SEQUENCE {
+	bandEUTRA-v1090					FreqBandIndicator-v9e0					OPTIONAL,
+	...
+}
+
+BandParameters-v10i0::= SEQUENCE {
+	bandParametersDL-v10i0		SEQUENCE (SIZE (1..maxBandwidthClass-r10)) OF CA-MIMO-ParametersDL-v10i0
+}
+
+BandParameters-v1130 ::= SEQUENCE {
+	supportedCSI-Proc-r11			ENUMERATED {n1, n3, n4}
+}
+
+BandParameters-r11 ::= SEQUENCE {
+	bandEUTRA-r11					FreqBandIndicator-r11,
+	bandParametersUL-r11			BandParametersUL-r10					OPTIONAL,
+	bandParametersDL-r11			BandParametersDL-r10					OPTIONAL,
+	supportedCSI-Proc-r11			ENUMERATED {n1, n3, n4}					OPTIONAL
+}
+
+BandParameters-v1270 ::= SEQUENCE {
+	bandParametersDL-v1270			SEQUENCE (SIZE (1..maxBandwidthClass-r10)) OF CA-MIMO-ParametersDL-v1270
+}
+
+BandParameters-r13 ::= SEQUENCE {
+	bandEUTRA-r13					FreqBandIndicator-r11,
+	bandParametersUL-r13				BandParametersUL-r13				OPTIONAL,
+	bandParametersDL-r13				BandParametersDL-r13				OPTIONAL,
+	supportedCSI-Proc-r13			ENUMERATED {n1, n3, n4}			OPTIONAL
+}
+
+BandParameters-v1320 ::= SEQUENCE {
+	bandParametersDL-v1320			MIMO-CA-ParametersPerBoBC-r13
+}
+
+BandParameters-v1380 ::=	SEQUENCE {
+	txAntennaSwitchDL-r13			INTEGER (1..32)					OPTIONAL,
+	txAntennaSwitchUL-r13			INTEGER (1..32)					OPTIONAL
+}
+
+BandParameters-v1430 ::= SEQUENCE {
+	bandParametersDL-v1430			MIMO-CA-ParametersPerBoBC-v1430	OPTIONAL,
+	ul-256QAM-r14						ENUMERATED {supported}		OPTIONAL,
+	ul-256QAM-perCC-InfoList-r14		SEQUENCE (SIZE (2..maxServCell-r13)) OF UL-256QAM-perCC-Info-r14		OPTIONAL,
+	srs-CapabilityPerBandPairList-r14		SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+			SRS-CapabilityPerBandPair-r14	OPTIONAL
+}
+
+BandParameters-v1450 ::= SEQUENCE {
+	must-CapabilityPerBand-r14		MUST-Parameters-r14		OPTIONAL
+}
+
+BandParameters-v1470 ::= SEQUENCE {
+	bandParametersDL-v1470			MIMO-CA-ParametersPerBoBC-v1470	OPTIONAL
+}
+
+BandParameters-v14b0 ::= SEQUENCE {
+	srs-CapabilityPerBandPairList-v14b0		SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF		SRS-CapabilityPerBandPair-v14b0		OPTIONAL
+}
+
+BandParameters-v1530 ::=	SEQUENCE {
+	ue-TxAntennaSelection-SRS-1T4R-r15				ENUMERATED {supported}	OPTIONAL,
+	ue-TxAntennaSelection-SRS-2T4R-2Pairs-r15		ENUMERATED {supported}	OPTIONAL,
+	ue-TxAntennaSelection-SRS-2T4R-3Pairs-r15		ENUMERATED {supported}	OPTIONAL,
+	dl-1024QAM-r15									ENUMERATED {supported}	OPTIONAL,
+	qcl-TypeC-Operation-r15							ENUMERATED {supported}	OPTIONAL,
+	qcl-CRI-BasedCSI-Reporting-r15					ENUMERATED {supported}	OPTIONAL,
+	stti-SPT-BandParameters-r15					STTI-SPT-BandParameters-r15	OPTIONAL
+}
+
+BandParameters-v1610 ::= 	SEQUENCE {
+	intraFreqDAPS-r16		SEQUENCE {
+		intraFreqAsyncDAPS-r16					ENUMERATED {supported}		OPTIONAL,
+		dummy									ENUMERATED {supported}		OPTIONAL,
+		intraFreqTwoTAGs-DAPS-r16				ENUMERATED {supported}		OPTIONAL
+	}																	OPTIONAL,
+	addSRS-FrequencyHopping-r16 ENUMERATED {supported}			OPTIONAL,
+	addSRS-AntennaSwitching-r16	SEQUENCE {
+		addSRS-1T2R-r16			ENUMERATED {supported}			OPTIONAL,
+		addSRS-1T4R-r16			ENUMERATED {supported}			OPTIONAL,
+		addSRS-2T4R-2pairs-r16	ENUMERATED {supported}			OPTIONAL,
+		addSRS-2T4R-3pairs-r16	ENUMERATED {supported}			OPTIONAL
+	}				OPTIONAL,
+	srs-CapabilityPerBandPairList-v1610		SEQUENCE (SIZE (1..maxSimultaneousBands-r10)) OF
+	SRS-CapabilityPerBandPair-v1610	OPTIONAL
+}
+
+V2X-BandParameters-r14 ::= SEQUENCE {
+	v2x-FreqBandEUTRA-r14			FreqBandIndicator-r11,
+	bandParametersTxSL-r14			BandParametersTxSL-r14				OPTIONAL,
+	bandParametersRxSL-r14			BandParametersRxSL-r14				OPTIONAL
+}
+
+V2X-BandParameters-v1530 ::= SEQUENCE {
+	v2x-EnhancedHighReception-r15			ENUMERATED {supported}		OPTIONAL
+}
+
+BandParametersTxSL-r14 ::= SEQUENCE {
+	v2x-BandwidthClassTxSL-r14		V2X-BandwidthClassSL-r14,
+	v2x-eNB-Scheduled-r14			ENUMERATED {supported}				OPTIONAL,
+	v2x-HighPower-r14				ENUMERATED {supported}				OPTIONAL
+}
+
+BandParametersRxSL-r14 ::= SEQUENCE {
+	v2x-BandwidthClassRxSL-r14		V2X-BandwidthClassSL-r14,
+	v2x-HighReception-r14			ENUMERATED {supported}				OPTIONAL
+}
+
+V2X-BandwidthClassSL-r14 ::= SEQUENCE (SIZE (1..maxBandwidthClass-r10)) OF V2X-BandwidthClass-r14
+
+UL-256QAM-perCC-Info-r14 ::= SEQUENCE {
+	ul-256QAM-perCC-r14			ENUMERATED {supported}				OPTIONAL
+}
+
+FeatureSetDL-r15 ::=	SEQUENCE {
+	mimo-CA-ParametersPerBoBC-r15	MIMO-CA-ParametersPerBoBC-r15			OPTIONAL,
+	featureSetPerCC-ListDL-r15	SEQUENCE (SIZE (1..maxServCell-r13)) OF FeatureSetDL-PerCC-Id-r15
+}
+
+FeatureSetDL-v1550 ::=	SEQUENCE {
+	dl-1024QAM-r15				ENUMERATED {supported}			OPTIONAL
+}
+
+FeatureSetDL-PerCC-r15 ::=	SEQUENCE {
+	fourLayerTM3-TM4-r15						ENUMERATED {supported}				OPTIONAL,
+	supportedMIMO-CapabilityDL-MRDC-r15		MIMO-CapabilityDL-r10					OPTIONAL,
+	supportedCSI-Proc-r15						ENUMERATED {n1, n3, n4}				OPTIONAL
+}
+
+FeatureSetUL-r15 ::=	SEQUENCE {
+	featureSetPerCC-ListUL-r15	SEQUENCE (SIZE(1..maxServCell-r13)) OF FeatureSetUL-PerCC-Id-r15
+}
+
+FeatureSetUL-PerCC-r15 ::=	SEQUENCE {
+	supportedMIMO-CapabilityUL-r15		MIMO-CapabilityUL-r10				OPTIONAL,
+	ul-256QAM-r15						ENUMERATED {supported}				OPTIONAL
+}
+
+FeatureSetDL-PerCC-Id-r15 ::=	INTEGER (0..maxPerCC-FeatureSets-r15)
+
+FeatureSetUL-PerCC-Id-r15 ::=	INTEGER (0..maxPerCC-FeatureSets-r15)
+
+BandParametersUL-r10 ::= SEQUENCE (SIZE (1..maxBandwidthClass-r10)) OF CA-MIMO-ParametersUL-r10
+
+BandParametersUL-r13 ::= CA-MIMO-ParametersUL-r10
+
+CA-MIMO-ParametersUL-r10 ::= SEQUENCE {
+	ca-BandwidthClassUL-r10				CA-BandwidthClass-r10,
+	supportedMIMO-CapabilityUL-r10		MIMO-CapabilityUL-r10				OPTIONAL
+}
+
+CA-MIMO-ParametersUL-r15 ::= SEQUENCE {
+	supportedMIMO-CapabilityUL-r15		MIMO-CapabilityUL-r10				OPTIONAL
+}
+
+BandParametersDL-r10 ::= SEQUENCE (SIZE (1..maxBandwidthClass-r10)) OF CA-MIMO-ParametersDL-r10
+
+BandParametersDL-r13 ::= CA-MIMO-ParametersDL-r13
+
+CA-MIMO-ParametersDL-r10 ::= SEQUENCE {
+	ca-BandwidthClassDL-r10				CA-BandwidthClass-r10,
+	supportedMIMO-CapabilityDL-r10		MIMO-CapabilityDL-r10				OPTIONAL
+}
+
+CA-MIMO-ParametersDL-v10i0 ::= SEQUENCE {
+	fourLayerTM3-TM4-r10				ENUMERATED {supported}				OPTIONAL
+}
+
+CA-MIMO-ParametersDL-v1270 ::= SEQUENCE {
+	intraBandContiguousCC-InfoList-r12			SEQUENCE (SIZE (1..maxServCell-r10)) OF IntraBandContiguousCC-Info-r12
+}
+
+CA-MIMO-ParametersDL-r13 ::= SEQUENCE {
+	ca-BandwidthClassDL-r13					CA-BandwidthClass-r10,
+	supportedMIMO-CapabilityDL-r13			MIMO-CapabilityDL-r10				OPTIONAL,
+	fourLayerTM3-TM4-r13						ENUMERATED {supported}				OPTIONAL,
+	intraBandContiguousCC-InfoList-r13		SEQUENCE (SIZE (1..maxServCell-r13)) OF IntraBandContiguousCC-Info-r12
+}
+
+CA-MIMO-ParametersDL-r15 ::= SEQUENCE {
+	supportedMIMO-CapabilityDL-r15			MIMO-CapabilityDL-r10				OPTIONAL,
+	fourLayerTM3-TM4-r15					ENUMERATED {supported}				OPTIONAL,
+	intraBandContiguousCC-InfoList-r15		SEQUENCE (SIZE (1..maxServCell-r13)) OF
+	IntraBandContiguousCC-Info-r12				OPTIONAL
+}
+
+IntraBandContiguousCC-Info-r12 ::= SEQUENCE {
+	fourLayerTM3-TM4-perCC-r12			ENUMERATED {supported}				OPTIONAL,
+	supportedMIMO-CapabilityDL-r12		MIMO-CapabilityDL-r10				OPTIONAL,
+	supportedCSI-Proc-r12				ENUMERATED {n1, n3, n4}				OPTIONAL
+}
+
+CA-BandwidthClass-r10 ::= ENUMERATED {a, b, c, d, e, f, ...}
+
+V2X-BandwidthClass-r14 ::= ENUMERATED {a, b, c, d, e, f, ..., c1-v1530}
+
+MIMO-CapabilityUL-r10 ::= ENUMERATED {twoLayers, fourLayers}
+
+MIMO-CapabilityDL-r10 ::= ENUMERATED {twoLayers, fourLayers, eightLayers}
+
+MUST-Parameters-r14 ::= SEQUENCE {
+	must-TM234-UpTo2Tx-r14						ENUMERATED {supported}		OPTIONAL,
+	must-TM89-UpToOneInterferingLayer-r14		ENUMERATED {supported}		OPTIONAL,
+	must-TM10-UpToOneInterferingLayer-r14		ENUMERATED {supported}		OPTIONAL,
+	must-TM89-UpToThreeInterferingLayers-r14	ENUMERATED {supported}		OPTIONAL,
+	must-TM10-UpToThreeInterferingLayers-r14	ENUMERATED {supported}		OPTIONAL
+}
+
+SupportedBandListEUTRA ::=			SEQUENCE (SIZE (1..maxBands)) OF SupportedBandEUTRA
+
+SupportedBandListEUTRA-v9e0::=			SEQUENCE (SIZE (1..maxBands)) OF SupportedBandEUTRA-v9e0
+
+SupportedBandListEUTRA-v1250 ::=		SEQUENCE (SIZE (1..maxBands)) OF SupportedBandEUTRA-v1250
+
+SupportedBandListEUTRA-v1310 ::=		SEQUENCE (SIZE (1..maxBands)) OF SupportedBandEUTRA-v1310
+
+SupportedBandListEUTRA-v1320 ::=		SEQUENCE (SIZE (1..maxBands)) OF SupportedBandEUTRA-v1320
+
+SupportedBandEUTRA ::=				SEQUENCE {
+	bandEUTRA							FreqBandIndicator,
+	halfDuplex							BOOLEAN
+}
+
+SupportedBandEUTRA-v9e0 ::=		SEQUENCE {
+	bandEUTRA-v9e0						FreqBandIndicator-v9e0		OPTIONAL
+}
+
+SupportedBandEUTRA-v1250 ::=		SEQUENCE {
+	dl-256QAM-r12						ENUMERATED {supported}		OPTIONAL,
+	ul-64QAM-r12						ENUMERATED {supported}		OPTIONAL
+}
+
+SupportedBandEUTRA-v1310 ::=		SEQUENCE {
+	ue-PowerClass-5-r13			ENUMERATED {supported}		OPTIONAL
+}
+SupportedBandEUTRA-v1320 ::=		SEQUENCE {
+	intraFreq-CE-NeedForGaps-r13				ENUMERATED {supported}				OPTIONAL,
+	ue-PowerClass-N-r13			ENUMERATED {class1, class2, class4}		OPTIONAL
+}
+
+MeasParameters ::=					SEQUENCE {
+	bandListEUTRA						BandListEUTRA
+}
+
+MeasParameters-v1020 ::=			SEQUENCE {
+	bandCombinationListEUTRA-r10			BandCombinationListEUTRA-r10
+}
+
+MeasParameters-v1130 ::=			SEQUENCE {
+	rsrqMeasWideband-r11			ENUMERATED {supported}					OPTIONAL
+}
+
+MeasParameters-v11a0 ::=			SEQUENCE {
+	benefitsFromInterruption-r11			ENUMERATED {true}				OPTIONAL
+}
+
+MeasParameters-v1250 ::=			SEQUENCE {	
+	timerT312-r12						ENUMERATED {supported}		OPTIONAL,
+	alternativeTimeToTrigger-r12		ENUMERATED {supported}		OPTIONAL,
+	incMonEUTRA-r12						ENUMERATED {supported}		OPTIONAL,
+	incMonUTRA-r12						ENUMERATED {supported}		OPTIONAL,
+	extendedMaxMeasId-r12				ENUMERATED {supported}		OPTIONAL,
+	extendedRSRQ-LowerRange-r12			ENUMERATED {supported}		OPTIONAL,
+	rsrq-OnAllSymbols-r12				ENUMERATED {supported}		OPTIONAL,
+	crs-DiscoverySignalsMeas-r12		ENUMERATED {supported}		OPTIONAL,
+	csi-RS-DiscoverySignalsMeas-r12		ENUMERATED {supported}		OPTIONAL
+}
+
+MeasParameters-v1310 ::=			SEQUENCE {
+	rs-SINR-Meas-r13						ENUMERATED {supported}		OPTIONAL,
+	whiteCellList-r13						ENUMERATED {supported}		OPTIONAL,
+	extendedMaxObjectId-r13					ENUMERATED {supported}		OPTIONAL,
+	ul-PDCP-Delay-r13						ENUMERATED {supported}		OPTIONAL,
+	extendedFreqPriorities-r13				ENUMERATED {supported}		OPTIONAL,
+	multiBandInfoReport-r13					ENUMERATED {supported}		OPTIONAL,
+	rssi-AndChannelOccupancyReporting-r13	ENUMERATED {supported}		OPTIONAL
+}
+
+MeasParameters-v1430 ::=			SEQUENCE {
+	ceMeasurements-r14						ENUMERATED {supported}		OPTIONAL,
+	ncsg-r14								ENUMERATED {supported}				OPTIONAL,
+	shortMeasurementGap-r14					ENUMERATED {supported}				OPTIONAL,
+	perServingCellMeasurementGap-r14		ENUMERATED {supported}				OPTIONAL,
+	nonUniformGap-r14						ENUMERATED {supported}				OPTIONAL
+}
+
+MeasParameters-v1520 ::=			SEQUENCE {
+	measGapPatterns-r15					BIT STRING (SIZE (8))		OPTIONAL
+}
+
+MeasParameters-v1530 ::=			SEQUENCE {
+	qoe-MeasReport-r15					ENUMERATED {supported}		OPTIONAL,
+	qoe-MTSI-MeasReport-r15				ENUMERATED {supported}		OPTIONAL,
+	ca-IdleModeMeasurements-r15				ENUMERATED {supported}		OPTIONAL,
+	ca-IdleModeValidityArea-r15				ENUMERATED {supported}		OPTIONAL,
+	heightMeas-r15							ENUMERATED {supported}			OPTIONAL,
+	multipleCellsMeasExtension-r15			ENUMERATED {supported}			OPTIONAL
+}
+
+MeasParameters-v1610 ::=	SEQUENCE {
+	bandInfoNR-v1610					SEQUENCE (SIZE (1..maxBands)) OF MeasGapInfoNR	OPTIONAL,
+	altFreqPriority-r16					ENUMERATED {supported}							OPTIONAL,
+	ce-DL-ChannelQualityReporting-r16	ENUMERATED {supported}							OPTIONAL,
+	ce-MeasRSS-Dedicated-r16			ENUMERATED {supported}							OPTIONAL,
+	eutra-IdleInactiveMeasurements-r16			ENUMERATED {supported}		OPTIONAL,
+	nr-IdleInactiveMeasFR1-r16			ENUMERATED {supported}		OPTIONAL,
+	nr-IdleInactiveMeasFR2-r16			ENUMERATED {supported}		OPTIONAL,
+	idleInactiveValidityAreaList-r16		ENUMERATED {supported}		OPTIONAL,
+	measGapPatterns-NRonly-r16			ENUMERATED {supported}		OPTIONAL,
+	measGapPatterns-NRonly-ENDC-r16		ENUMERATED {supported}		OPTIONAL
+}
+
+MeasParameters-v1630 ::=	SEQUENCE {
+	nr-IdleInactiveBeamMeasFR1-r16		ENUMERATED {supported}		OPTIONAL,
+	nr-IdleInactiveBeamMeasFR2-r16		ENUMERATED {supported}		OPTIONAL,
+	ce-MeasRSS-DedicatedSameRBs-r16		ENUMERATED {supported}		OPTIONAL
+}
+
+MeasGapInfoNR ::= SEQUENCE {
+	interRAT-BandListNR-EN-DC		InterRAT-BandListNR					OPTIONAL,
+	interRAT-BandListNR-SA		InterRAT-BandListNR					OPTIONAL
+}
+
+BandListEUTRA ::=					SEQUENCE (SIZE (1..maxBands)) OF BandInfoEUTRA
+
+BandCombinationListEUTRA-r10 ::=	SEQUENCE (SIZE (1..maxBandComb-r10)) OF BandInfoEUTRA
+
+BandInfoEUTRA ::=					SEQUENCE {
+	interFreqBandList					InterFreqBandList,
+	interRAT-BandList					InterRAT-BandList		OPTIONAL
+}
+
+InterFreqBandList ::=				SEQUENCE (SIZE (1..maxBands)) OF InterFreqBandInfo
+
+InterFreqBandInfo ::=				SEQUENCE {
+	interFreqNeedForGaps				BOOLEAN
+}
+
+InterRAT-BandList ::=				SEQUENCE (SIZE (1..maxBands)) OF InterRAT-BandInfo
+
+InterRAT-BandListNR ::=				SEQUENCE (SIZE (1..maxBandsNR-r15)) OF InterRAT-BandInfoNR
+
+InterRAT-BandInfo ::=				SEQUENCE {
+	interRAT-NeedForGaps				BOOLEAN
+}
+
+InterRAT-BandInfoNR ::=			SEQUENCE {
+	interRAT-NeedForGapsNR				BOOLEAN
+}
+
+IRAT-ParametersNR-r15 ::=		SEQUENCE {
+	en-DC-r15							ENUMERATED {supported}						OPTIONAL,
+	eventB2-r15						ENUMERATED {supported}						OPTIONAL,
+	supportedBandListEN-DC-r15		SupportedBandListNR-r15						OPTIONAL
+}
+
+IRAT-ParametersNR-v1540 ::=		SEQUENCE {
+	eutra-5GC-HO-ToNR-FDD-FR1-r15		ENUMERATED {supported}				OPTIONAL,
+	eutra-5GC-HO-ToNR-TDD-FR1-r15		ENUMERATED {supported}				OPTIONAL,
+	eutra-5GC-HO-ToNR-FDD-FR2-r15		ENUMERATED {supported}				OPTIONAL,
+	eutra-5GC-HO-ToNR-TDD-FR2-r15		ENUMERATED {supported}				OPTIONAL,
+	eutra-EPC-HO-ToNR-FDD-FR1-r15		ENUMERATED {supported}				OPTIONAL,
+	eutra-EPC-HO-ToNR-TDD-FR1-r15		ENUMERATED {supported}				OPTIONAL,
+	eutra-EPC-HO-ToNR-FDD-FR2-r15		ENUMERATED {supported}				OPTIONAL,
+	eutra-EPC-HO-ToNR-TDD-FR2-r15		ENUMERATED {supported}				OPTIONAL,
+	ims-VoiceOverNR-FR1-r15				ENUMERATED {supported}				OPTIONAL,
+	ims-VoiceOverNR-FR2-r15				ENUMERATED {supported}				OPTIONAL,
+	sa-NR-r15								ENUMERATED {supported}				OPTIONAL,
+	supportedBandListNR-SA-r15			SupportedBandListNR-r15				OPTIONAL
+}
+
+IRAT-ParametersNR-v1560 ::=		SEQUENCE {
+	ng-EN-DC-r15							ENUMERATED {supported}				OPTIONAL
+}
+
+IRAT-ParametersNR-v1570 ::=		SEQUENCE {
+	ss-SINR-Meas-NR-FR1-r15				ENUMERATED {supported}				OPTIONAL,
+	ss-SINR-Meas-NR-FR2-r15				ENUMERATED {supported}				OPTIONAL
+}
+
+IRAT-ParametersNR-v1610 ::=		SEQUENCE {
+	nr-HO-ToEN-DC-r16					ENUMERATED {supported}				OPTIONAL,
+	ce-EUTRA-5GC-HO-ToNR-FDD-FR1-r16	ENUMERATED {supported}				OPTIONAL,
+	ce-EUTRA-5GC-HO-ToNR-TDD-FR1-r16	ENUMERATED {supported}				OPTIONAL,
+	ce-EUTRA-5GC-HO-ToNR-FDD-FR2-r16	ENUMERATED {supported}				OPTIONAL,
+	ce-EUTRA-5GC-HO-ToNR-TDD-FR2-r16	ENUMERATED {supported}				OPTIONAL
+}
+
+EUTRA-5GC-Parameters-r15 ::=		SEQUENCE {
+	eutra-5GC-r15								ENUMERATED {supported}			OPTIONAL,
+	eutra-EPC-HO-EUTRA-5GC-r15				ENUMERATED {supported}			OPTIONAL,
+	ho-EUTRA-5GC-FDD-TDD-r15					ENUMERATED {supported}			OPTIONAL,
+	ho-InterfreqEUTRA-5GC-r15					ENUMERATED {supported}			OPTIONAL,
+	ims-VoiceOverMCG-BearerEUTRA-5GC-r15	ENUMERATED {supported}			OPTIONAL,
+	inactiveState-r15							ENUMERATED {supported}			OPTIONAL,
+	reflectiveQoS-r15							ENUMERATED {supported}			OPTIONAL
+}
+
+EUTRA-5GC-Parameters-v1610 ::=	SEQUENCE {
+	ce-InactiveState-r16			ENUMERATED {supported}			OPTIONAL,
+	ce-EUTRA-5GC-r16				ENUMERATED {supported}			OPTIONAL
+}
+
+PDCP-ParametersNR-r15 ::=		SEQUENCE {
+	rohc-Profiles-r15					ROHC-ProfileSupportList-r15,
+	rohc-ContextMaxSessions-r15			ENUMERATED {
+											cs2, cs4, cs8, cs12, cs16, cs24, cs32,
+											cs48, cs64, cs128, cs256, cs512, cs1024,
+											cs16384, spare2, spare1}			DEFAULT cs16,
+	rohc-ProfilesUL-Only-r15				SEQUENCE {
+		profile0x0006-r15						BOOLEAN
+	},
+	rohc-ContextContinue-r15			ENUMERATED {supported}				OPTIONAL,
+	outOfOrderDelivery-r15				ENUMERATED {supported}				OPTIONAL,
+	sn-SizeLo-r15						ENUMERATED {supported}				OPTIONAL,
+	ims-VoiceOverNR-PDCP-MCG-Bearer-r15	ENUMERATED {supported}				OPTIONAL,
+	ims-VoiceOverNR-PDCP-SCG-Bearer-r15	ENUMERATED {supported}				OPTIONAL
+}
+
+PDCP-ParametersNR-v1560 ::=		SEQUENCE {
+	ims-VoNR-PDCP-SCG-NGENDC-r15			ENUMERATED {supported}				OPTIONAL
+}
+
+ROHC-ProfileSupportList-r15 ::=	SEQUENCE {
+	profile0x0001-r15					BOOLEAN,
+	profile0x0002-r15					BOOLEAN,
+	profile0x0003-r15					BOOLEAN,
+	profile0x0004-r15					BOOLEAN,
+	profile0x0006-r15					BOOLEAN,
+	profile0x0101-r15					BOOLEAN,
+	profile0x0102-r15					BOOLEAN,
+	profile0x0103-r15					BOOLEAN,
+	profile0x0104-r15					BOOLEAN
+}
+
+SupportedBandListNR-r15 ::=		SEQUENCE (SIZE (1..maxBandsNR-r15)) OF SupportedBandNR-r15
+
+SupportedBandNR-r15 ::=			SEQUENCE {
+	bandNR-r15							FreqBandIndicatorNR-r15
+}
+
+IRAT-ParametersUTRA-FDD ::=		SEQUENCE {
+	supportedBandListUTRA-FDD			SupportedBandListUTRA-FDD
+}
+
+IRAT-ParametersUTRA-v920 ::=		SEQUENCE {
+	e-RedirectionUTRA-r9				ENUMERATED {supported}
+}
+
+IRAT-ParametersUTRA-v9c0 ::=		SEQUENCE {
+	voiceOverPS-HS-UTRA-FDD-r9						ENUMERATED {supported}		OPTIONAL,
+	voiceOverPS-HS-UTRA-TDD128-r9					ENUMERATED {supported}		OPTIONAL,
+	srvcc-FromUTRA-FDD-ToUTRA-FDD-r9				ENUMERATED {supported}		OPTIONAL,
+	srvcc-FromUTRA-FDD-ToGERAN-r9					ENUMERATED {supported}		OPTIONAL,
+	srvcc-FromUTRA-TDD128-ToUTRA-TDD128-r9			ENUMERATED {supported}		OPTIONAL,
+	srvcc-FromUTRA-TDD128-ToGERAN-r9				ENUMERATED {supported}		OPTIONAL
+}
+
+IRAT-ParametersUTRA-v9h0 ::=		SEQUENCE {
+	mfbi-UTRA-r9						ENUMERATED {supported}
+}
+
+SupportedBandListUTRA-FDD ::=		SEQUENCE (SIZE (1..maxBands)) OF SupportedBandUTRA-FDD
+
+SupportedBandUTRA-FDD ::=			ENUMERATED {
+										bandI, bandII, bandIII, bandIV, bandV, bandVI,
+										bandVII, bandVIII, bandIX, bandX, bandXI,
+										bandXII, bandXIII, bandXIV, bandXV, bandXVI, ...,
+										bandXVII-8a0, bandXVIII-8a0, bandXIX-8a0, bandXX-8a0,
+										bandXXI-8a0, bandXXII-8a0, bandXXIII-8a0, bandXXIV-8a0,
+										bandXXV-8a0, bandXXVI-8a0, bandXXVII-8a0, bandXXVIII-8a0,
+										bandXXIX-8a0, bandXXX-8a0, bandXXXI-8a0, bandXXXII-8a0}
+
+IRAT-ParametersUTRA-TDD128 ::=		SEQUENCE {
+	supportedBandListUTRA-TDD128		SupportedBandListUTRA-TDD128
+}
+
+SupportedBandListUTRA-TDD128 ::=	SEQUENCE (SIZE (1..maxBands)) OF SupportedBandUTRA-TDD128
+
+SupportedBandUTRA-TDD128 ::=		ENUMERATED {
+										a, b, c, d, e, f, g, h, i, j, k, l, m, n,
+										o, p, ...}
+
+IRAT-ParametersUTRA-TDD384 ::=		SEQUENCE {
+	supportedBandListUTRA-TDD384		SupportedBandListUTRA-TDD384
+}
+
+SupportedBandListUTRA-TDD384 ::=	SEQUENCE (SIZE (1..maxBands)) OF SupportedBandUTRA-TDD384
+
+SupportedBandUTRA-TDD384 ::=		ENUMERATED {
+											a, b, c, d, e, f, g, h, i, j, k, l, m, n,
+											o, p, ...}
+
+IRAT-ParametersUTRA-TDD768 ::=		SEQUENCE {
+	supportedBandListUTRA-TDD768		SupportedBandListUTRA-TDD768
+}
+
+SupportedBandListUTRA-TDD768 ::=	SEQUENCE (SIZE (1..maxBands)) OF SupportedBandUTRA-TDD768
+
+SupportedBandUTRA-TDD768 ::=		ENUMERATED {
+										a, b, c, d, e, f, g, h, i, j, k, l, m, n,
+										o, p, ...}
+
+IRAT-ParametersUTRA-TDD-v1020 ::=		SEQUENCE {
+	e-RedirectionUTRA-TDD-r10				ENUMERATED {supported}
+}
+
+IRAT-ParametersGERAN ::=			SEQUENCE {
+	supportedBandListGERAN				SupportedBandListGERAN,
+	interRAT-PS-HO-ToGERAN				BOOLEAN
+}
+
+IRAT-ParametersGERAN-v920 ::=		SEQUENCE {
+	dtm-r9								ENUMERATED {supported}			OPTIONAL,
+	e-RedirectionGERAN-r9				ENUMERATED {supported}			OPTIONAL
+}
+
+SupportedBandListGERAN ::=			SEQUENCE (SIZE (1..maxBands)) OF SupportedBandGERAN
+
+SupportedBandGERAN ::=				ENUMERATED {
+										gsm450, gsm480, gsm710, gsm750, gsm810, gsm850,
+										gsm900P, gsm900E, gsm900R, gsm1800, gsm1900,
+										spare5, spare4, spare3, spare2, spare1, ...}
+
+IRAT-ParametersCDMA2000-HRPD ::=	SEQUENCE {
+	supportedBandListHRPD				SupportedBandListHRPD,
+	tx-ConfigHRPD						ENUMERATED {single, dual},
+	rx-ConfigHRPD						ENUMERATED {single, dual}
+}
+
+SupportedBandListHRPD ::=			SEQUENCE (SIZE (1..maxCDMA-BandClass)) OF BandclassCDMA2000
+
+IRAT-ParametersCDMA2000-1XRTT ::=	SEQUENCE {
+	supportedBandList1XRTT				SupportedBandList1XRTT,
+	tx-Config1XRTT						ENUMERATED {single, dual},
+	rx-Config1XRTT						ENUMERATED {single, dual}
+}
+
+IRAT-ParametersCDMA2000-1XRTT-v920 ::=	SEQUENCE {
+	e-CSFB-1XRTT-r9						ENUMERATED {supported},
+	e-CSFB-ConcPS-Mob1XRTT-r9			ENUMERATED {supported}			OPTIONAL
+}
+
+IRAT-ParametersCDMA2000-1XRTT-v1020 ::=	SEQUENCE {
+	e-CSFB-dual-1XRTT-r10				ENUMERATED {supported}
+}
+
+IRAT-ParametersCDMA2000-v1130 ::=		SEQUENCE {
+	cdma2000-NW-Sharing-r11					ENUMERATED {supported}		OPTIONAL
+}
+
+SupportedBandList1XRTT ::=			SEQUENCE (SIZE (1..maxCDMA-BandClass)) OF BandclassCDMA2000
+
+IRAT-ParametersWLAN-r13 ::=		SEQUENCE {
+	supportedBandListWLAN-r13		SEQUENCE (SIZE (1..maxWLAN-Bands-r13)) OF WLAN-BandIndicator-r13					OPTIONAL
+}
+
+CSG-ProximityIndicationParameters-r9 ::=	SEQUENCE {
+	intraFreqProximityIndication-r9		ENUMERATED {supported}			OPTIONAL,
+	interFreqProximityIndication-r9		ENUMERATED {supported}			OPTIONAL,
+	utran-ProximityIndication-r9		ENUMERATED {supported}			OPTIONAL
+}
+
+NeighCellSI-AcquisitionParameters-r9 ::=	SEQUENCE {
+	intraFreqSI-AcquisitionForHO-r9		ENUMERATED {supported}			OPTIONAL,
+	interFreqSI-AcquisitionForHO-r9		ENUMERATED {supported}			OPTIONAL,
+	utran-SI-AcquisitionForHO-r9		ENUMERATED {supported}			OPTIONAL
+}
+
+NeighCellSI-AcquisitionParameters-v1530 ::=	SEQUENCE {
+	reportCGI-NR-EN-DC-r15					ENUMERATED {supported}			OPTIONAL,
+	reportCGI-NR-NoEN-DC-r15				ENUMERATED {supported}			OPTIONAL
+}
+
+NeighCellSI-AcquisitionParameters-v1550 ::=	SEQUENCE {
+	eutra-CGI-Reporting-ENDC-r15				ENUMERATED {supported}			OPTIONAL,
+	utra-GERAN-CGI-Reporting-ENDC-r15			ENUMERATED {supported}			OPTIONAL
+}
+
+NeighCellSI-AcquisitionParameters-v15a0 ::=	SEQUENCE {
+	eutra-CGI-Reporting-NEDC-r15				ENUMERATED {supported}			OPTIONAL
+}
+
+NeighCellSI-AcquisitionParameters-v1610 ::=	SEQUENCE {
+	eutra-SI-AcquisitionForHO-ENDC-r16			ENUMERATED {supported}			OPTIONAL,
+	nr-AutonomousGaps-ENDC-FR1-r16				ENUMERATED {supported}			OPTIONAL,
+	nr-AutonomousGaps-ENDC-FR2-r16				ENUMERATED {supported}			OPTIONAL,
+	nr-AutonomousGaps-FR1-r16					ENUMERATED {supported}			OPTIONAL,
+	nr-AutonomousGaps-FR2-r16					ENUMERATED {supported}			OPTIONAL
+}
+
+SON-Parameters-r9 ::=				SEQUENCE {
+	rach-Report-r9						ENUMERATED {supported}			OPTIONAL
+}
+
+PUR-Parameters-r16 ::=				SEQUENCE {
+	pur-CP-5GC-CE-ModeA-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-CP-5GC-CE-ModeB-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-UP-5GC-CE-ModeA-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-UP-5GC-CE-ModeB-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-CP-EPC-CE-ModeA-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-CP-EPC-CE-ModeB-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-UP-EPC-CE-ModeA-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-UP-EPC-CE-ModeB-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-CP-L1Ack-r16					ENUMERATED {supported}			OPTIONAL,
+	pur-FrequencyHopping-r16			ENUMERATED {supported}			OPTIONAL,
+	pur-PUSCH-NB-MaxTBS-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-RSRP-Validation-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-SubPRB-CE-ModeA-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-SubPRB-CE-ModeB-r16				ENUMERATED {supported}			OPTIONAL
+}
+
+UE-BasedNetwPerfMeasParameters-r10 ::=	SEQUENCE {
+	loggedMeasurementsIdle-r10				ENUMERATED {supported}		OPTIONAL,
+	standaloneGNSS-Location-r10				ENUMERATED {supported}		OPTIONAL
+}
+
+UE-BasedNetwPerfMeasParameters-v1250 ::=	SEQUENCE {
+	loggedMBSFNMeasurements-r12				ENUMERATED {supported}
+}
+
+UE-BasedNetwPerfMeasParameters-v1430 ::=	SEQUENCE {
+	locationReport-r14						ENUMERATED {supported}		OPTIONAL
+}
+
+UE-BasedNetwPerfMeasParameters-v1530 ::=	SEQUENCE {
+	loggedMeasBT-r15						ENUMERATED {supported}		OPTIONAL,
+	loggedMeasWLAN-r15						ENUMERATED {supported}		OPTIONAL,
+	immMeasBT-r15							ENUMERATED {supported}		OPTIONAL,
+	immMeasWLAN-r15							ENUMERATED {supported}		OPTIONAL
+}
+
+UE-BasedNetwPerfMeasParameters-v1610 ::=	SEQUENCE {
+	ul-PDCP-AvgDelay-r16						ENUMERATED {supported}		OPTIONAL
+}
+
+OTDOA-PositioningCapabilities-r10 ::=	SEQUENCE {
+	otdoa-UE-Assisted-r10					ENUMERATED {supported},
+	interFreqRSTD-Measurement-r10			ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-r11 ::=				SEQUENCE {
+	inDeviceCoexInd-r11						ENUMERATED {supported}		OPTIONAL,
+	powerPrefInd-r11						ENUMERATED {supported}		OPTIONAL,
+	ue-Rx-TxTimeDiffMeasurements-r11		ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-v11d0 ::=				SEQUENCE {
+	inDeviceCoexInd-UL-CA-r11				ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-v1360 ::=	SEQUENCE {
+	inDeviceCoexInd-HardwareSharingInd-r13		ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-v1430 ::=			SEQUENCE {
+	bwPrefInd-r14					ENUMERATED {supported}		OPTIONAL,
+	rlm-ReportSupport-r14			ENUMERATED {supported}		OPTIONAL
+}
+
+OtherParameters-v1450 ::=	SEQUENCE {
+	overheatingInd-r14				ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-v1460 ::=	SEQUENCE {
+	nonCSG-SI-Reporting-r14			ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-v1530 ::=			SEQUENCE {
+	assistInfoBitForLC-r15			ENUMERATED {supported}		OPTIONAL,
+	timeReferenceProvision-r15		ENUMERATED {supported}		OPTIONAL,
+	flightPathPlan-r15				ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-v1540 ::=			SEQUENCE {
+	inDeviceCoexInd-ENDC-r15		ENUMERATED {supported}		OPTIONAL
+}
+
+Other-Parameters-v1610 ::=		SEQUENCE {
+	resumeWithStoredMCG-SCells-r16	ENUMERATED {supported}		OPTIONAL,
+	resumeWithMCG-SCellConfig-r16	ENUMERATED {supported}		OPTIONAL,
+	resumeWithStoredSCG-r16			ENUMERATED {supported}		OPTIONAL,
+	resumeWithSCG-Config-r16		ENUMERATED {supported}		OPTIONAL,
+	mcgRLF-RecoveryViaSCG-r16		ENUMERATED {supported}		OPTIONAL,
+	overheatingIndForSCG-r16		ENUMERATED {supported}		OPTIONAL}
+
+MBMS-Parameters-r11 ::=				SEQUENCE {
+	mbms-SCell-r11							ENUMERATED {supported}		OPTIONAL,
+	mbms-NonServingCell-r11					ENUMERATED {supported}		OPTIONAL
+}
+
+MBMS-Parameters-v1250 ::=				SEQUENCE {
+	mbms-AsyncDC-r12						ENUMERATED {supported}		OPTIONAL
+}
+
+MBMS-Parameters-v1430 ::=				SEQUENCE {
+	fembmsDedicatedCell-r14				ENUMERATED {supported}		OPTIONAL,
+	fembmsMixedCell-r14					ENUMERATED {supported}		OPTIONAL,
+	subcarrierSpacingMBMS-khz7dot5-r14	ENUMERATED {supported}		OPTIONAL,
+	subcarrierSpacingMBMS-khz1dot25-r14	ENUMERATED {supported}		OPTIONAL
+}
+
+MBMS-Parameters-v1470 ::=		SEQUENCE {
+	mbms-MaxBW-r14					CHOICE {
+		implicitValue					NULL,
+		explicitValue					INTEGER(2..20)
+	},
+	mbms-ScalingFactor1dot25-r14		ENUMERATED {n3, n6, n9, n12}	OPTIONAL,
+	mbms-ScalingFactor7dot5-r14		ENUMERATED {n1, n2, n3, n4}		OPTIONAL
+}
+
+MBMS-Parameters-v1610 ::=		SEQUENCE {
+	mbms-ScalingFactor2dot5-r16		ENUMERATED {n2, n4, n6, n8}			OPTIONAL,
+	mbms-ScalingFactor0dot37-r16	ENUMERATED {n12, n16, n20, n24}		OPTIONAL,
+	mbms-SupportedBandInfoList-r16	SEQUENCE (SIZE (1..maxBands)) OF MBMS-SupportedBandInfo-r16
+}
+
+MBMS-SupportedBandInfo-r16 ::=		SEQUENCE {
+	subcarrierSpacingMBMS-khz2dot5-r16	ENUMERATED {supported}		OPTIONAL,
+	subcarrierSpacingMBMS-khz0dot37-r16	SEQUENCE {
+		timeSeparationSlot2-r16			ENUMERATED {supported}			OPTIONAL,
+		timeSeparationSlot4-r16			ENUMERATED {supported}			OPTIONAL
+	}	OPTIONAL
+}
+
+FeMBMS-Unicast-Parameters-r14 ::=		SEQUENCE {
+	unicast-fembmsMixedSCell-r14			ENUMERATED {supported}		OPTIONAL,
+	emptyUnicastRegion-r14					ENUMERATED {supported}		OPTIONAL
+}
+
+SCPTM-Parameters-r13 ::=				SEQUENCE {
+	scptm-ParallelReception-r13					ENUMERATED {supported}		OPTIONAL,
+	scptm-SCell-r13								ENUMERATED {supported}		OPTIONAL,
+	scptm-NonServingCell-r13					ENUMERATED {supported}		OPTIONAL,
+	scptm-AsyncDC-r13							ENUMERATED {supported}		OPTIONAL
+}
+
+CE-Parameters-r13 ::=		SEQUENCE {
+	ce-ModeA-r13						ENUMERATED {supported}				OPTIONAL,
+	ce-ModeB-r13						ENUMERATED {supported}				OPTIONAL
+}
+
+CE-Parameters-v1320 ::=		SEQUENCE {
+	intraFreqA3-CE-ModeA-r13				ENUMERATED {supported}				OPTIONAL,
+	intraFreqA3-CE-ModeB-r13				ENUMERATED {supported}				OPTIONAL,
+	intraFreqHO-CE-ModeA-r13				ENUMERATED {supported}				OPTIONAL,
+	intraFreqHO-CE-ModeB-r13				ENUMERATED {supported}				OPTIONAL
+}
+
+CE-Parameters-v1350 ::=		SEQUENCE {
+	unicastFrequencyHopping-r13				ENUMERATED {supported}				OPTIONAL
+}
+
+CE-Parameters-v1370 ::=		SEQUENCE {
+	tm9-CE-ModeA-r13						ENUMERATED {supported}			OPTIONAL,
+	tm9-CE-ModeB-r13						ENUMERATED {supported}			OPTIONAL
+}
+
+CE-Parameters-v1380 ::=		SEQUENCE {
+	tm6-CE-ModeA-r13						ENUMERATED {supported}			OPTIONAL
+}
+
+CE-Parameters-v1430 ::=		SEQUENCE {
+	ce-SwitchWithoutHO-r14					ENUMERATED {supported}				OPTIONAL
+}
+
+CE-MultiTB-Parameters-r16 ::=	SEQUENCE {
+	pdsch-MultiTB-CE-ModeA-r16			ENUMERATED {supported}			OPTIONAL,
+	pdsch-MultiTB-CE-ModeB-r16			ENUMERATED {supported}			OPTIONAL,
+	pusch-MultiTB-CE-ModeA-r16			ENUMERATED {supported}			OPTIONAL,
+	pusch-MultiTB-CE-ModeB-r16			ENUMERATED {supported}			OPTIONAL,
+	ce-MultiTB-64QAM-r16 				ENUMERATED {supported}			OPTIONAL,
+	ce-MultiTB-EarlyTermination-r16 	ENUMERATED {supported}			OPTIONAL,
+	ce-MultiTB-FrequencyHopping-r16		ENUMERATED {supported}			OPTIONAL,
+	ce-MultiTB-HARQ-AckBundling-r16		ENUMERATED {supported}			OPTIONAL,
+	ce-MultiTB-Interleaving-r16			ENUMERATED {supported}			OPTIONAL,
+	ce-MultiTB-SubPRB-r16 				ENUMERATED {supported}			OPTIONAL
+}
+
+CE-ResourceResvParameters-r16 ::=	SEQUENCE {
+	subframeResourceResvDL-CE-ModeA-r16 	ENUMERATED {supported}			OPTIONAL,
+	subframeResourceResvDL-CE-ModeB-r16 	ENUMERATED {supported}			OPTIONAL,
+	subframeResourceResvUL-CE-ModeA-r16 	ENUMERATED {supported}			OPTIONAL,
+	subframeResourceResvUL-CE-ModeB-r16 	ENUMERATED {supported}			OPTIONAL,
+	slotSymbolResourceResvDL-CE-ModeA-r16 	ENUMERATED {supported}			OPTIONAL,
+	slotSymbolResourceResvDL-CE-ModeB-r16 	ENUMERATED {supported}			OPTIONAL,
+	slotSymbolResourceResvUL-CE-ModeA-r16 	ENUMERATED {supported}			OPTIONAL,
+	slotSymbolResourceResvUL-CE-ModeB-r16 	ENUMERATED {supported}			OPTIONAL,
+	subcarrierPuncturingCE-ModeA-r16 		ENUMERATED {supported}			OPTIONAL,
+	subcarrierPuncturingCE-ModeB-r16 		ENUMERATED {supported}			OPTIONAL
+}
+
+LAA-Parameters-r13 ::=				SEQUENCE {
+	crossCarrierSchedulingLAA-DL-r13			ENUMERATED {supported}		OPTIONAL,
+	csi-RS-DRS-RRM-MeasurementsLAA-r13			ENUMERATED {supported}		OPTIONAL,
+	downlinkLAA-r13								ENUMERATED {supported}		OPTIONAL,
+	endingDwPTS-r13								ENUMERATED {supported}		OPTIONAL,
+	secondSlotStartingPosition-r13				ENUMERATED {supported}		OPTIONAL,
+	tm9-LAA-r13									ENUMERATED {supported}		OPTIONAL,
+	tm10-LAA-r13								ENUMERATED {supported}		OPTIONAL
+}
+
+LAA-Parameters-v1430 ::=				SEQUENCE {
+	crossCarrierSchedulingLAA-UL-r14			ENUMERATED {supported}		OPTIONAL,
+	uplinkLAA-r14								ENUMERATED {supported}		OPTIONAL,
+	twoStepSchedulingTimingInfo-r14				ENUMERATED {nPlus1, nPlus2, nPlus3}	OPTIONAL,
+	uss-BlindDecodingAdjustment-r14				ENUMERATED {supported}		OPTIONAL,
+	uss-BlindDecodingReduction-r14				ENUMERATED {supported}		OPTIONAL,
+	outOfSequenceGrantHandling-r14				ENUMERATED {supported}		OPTIONAL
+}
+
+LAA-Parameters-v1530 ::=				SEQUENCE {
+	aul-r15										ENUMERATED {supported}		OPTIONAL,
+	laa-PUSCH-Mode1-r15							ENUMERATED {supported}		OPTIONAL,
+	laa-PUSCH-Mode2-r15							ENUMERATED {supported}		OPTIONAL,
+	laa-PUSCH-Mode3-r15							ENUMERATED {supported}		OPTIONAL
+}
+
+WLAN-IW-Parameters-r12 ::=	SEQUENCE {
+	wlan-IW-RAN-Rules-r12					ENUMERATED {supported}		OPTIONAL,
+	wlan-IW-ANDSF-Policies-r12						ENUMERATED {supported}		OPTIONAL
+}
+
+LWA-Parameters-r13 ::=		SEQUENCE {
+	lwa-r13						ENUMERATED {supported}		OPTIONAL,
+	lwa-SplitBearer-r13			ENUMERATED {supported}		OPTIONAL,
+	wlan-MAC-Address-r13		OCTET STRING (SIZE (6))		OPTIONAL,
+	lwa-BufferSize-r13			ENUMERATED {supported}		OPTIONAL
+}
+
+LWA-Parameters-v1430 ::=		SEQUENCE {
+	lwa-HO-WithoutWT-Change-r14			ENUMERATED {supported}		OPTIONAL,
+	lwa-UL-r14							ENUMERATED {supported}		OPTIONAL,
+	wlan-PeriodicMeas-r14				ENUMERATED {supported}		OPTIONAL,
+	wlan-ReportAnyWLAN-r14				ENUMERATED {supported}		OPTIONAL,
+	wlan-SupportedDataRate-r14			INTEGER (1..2048)			OPTIONAL
+}
+
+LWA-Parameters-v1440 ::=		SEQUENCE {
+	lwa-RLC-UM-r14						ENUMERATED {supported}		OPTIONAL
+}
+
+WLAN-IW-Parameters-v1310 ::=	SEQUENCE {
+	rclwi-r13										ENUMERATED {supported}		OPTIONAL
+}
+
+LWIP-Parameters-r13 ::=		SEQUENCE {
+	lwip-r13					ENUMERATED {supported}				OPTIONAL
+}
+
+LWIP-Parameters-v1430 ::=		SEQUENCE {
+	lwip-Aggregation-DL-r14					ENUMERATED {supported}				OPTIONAL,
+	lwip-Aggregation-UL-r14					ENUMERATED {supported}				OPTIONAL
+}
+
+NAICS-Capability-List-r12 ::= SEQUENCE (SIZE (1..maxNAICS-Entries-r12)) OF NAICS-Capability-Entry-r12
+
+
+NAICS-Capability-Entry-r12	::=	SEQUENCE {
+	numberOfNAICS-CapableCC-r12				INTEGER(1..5),
+	numberOfAggregatedPRB-r12				ENUMERATED {
+												n50, n75, n100, n125, n150, n175,
+												n200, n225, n250, n275, n300, n350,
+												n400, n450, n500, spare},
+	...
+}
+
+SL-Parameters-r12 ::=				SEQUENCE {
+	commSimultaneousTx-r12					ENUMERATED {supported}		OPTIONAL,
+	commSupportedBands-r12					FreqBandIndicatorListEUTRA-r12	OPTIONAL,
+	discSupportedBands-r12					SupportedBandInfoList-r12	OPTIONAL,
+	discScheduledResourceAlloc-r12			ENUMERATED {supported}		OPTIONAL,
+	disc-UE-SelectedResourceAlloc-r12		ENUMERATED {supported}		OPTIONAL,
+	disc-SLSS-r12							ENUMERATED {supported}		OPTIONAL,
+	discSupportedProc-r12					ENUMERATED {n50, n400}		OPTIONAL
+}
+
+SL-Parameters-v1310 ::=				SEQUENCE {
+	discSysInfoReporting-r13					ENUMERATED {supported}		OPTIONAL,
+	commMultipleTx-r13							ENUMERATED {supported}		OPTIONAL,
+	discInterFreqTx-r13							ENUMERATED {supported}		OPTIONAL,
+	discPeriodicSLSS-r13						ENUMERATED {supported}		OPTIONAL
+}
+
+SL-Parameters-v1430 ::=				SEQUENCE {
+	zoneBasedPoolSelection-r14				ENUMERATED {supported}				OPTIONAL,
+	ue-AutonomousWithFullSensing-r14		ENUMERATED {supported}				OPTIONAL,
+	ue-AutonomousWithPartialSensing-r14		ENUMERATED {supported}				OPTIONAL,
+	sl-CongestionControl-r14				ENUMERATED {supported}				OPTIONAL,
+	v2x-TxWithShortResvInterval-r14			ENUMERATED {supported}				OPTIONAL,
+	v2x-numberTxRxTiming-r14				INTEGER(1..16)						OPTIONAL,
+	v2x-nonAdjacentPSCCH-PSSCH-r14			ENUMERATED {supported}				OPTIONAL,
+	slss-TxRx-r14							ENUMERATED {supported}				OPTIONAL,
+	v2x-SupportedBandCombinationList-r14	V2X-SupportedBandCombination-r14	OPTIONAL
+}
+
+SL-Parameters-v1530 ::=				SEQUENCE {
+	slss-SupportedTxFreq-r15				ENUMERATED {single, multiple}		OPTIONAL,
+	sl-64QAM-Tx-r15						ENUMERATED {supported}				OPTIONAL,
+	sl-TxDiversity-r15						ENUMERATED {supported}				OPTIONAL,
+	ue-CategorySL-r15						UE-CategorySL-r15					OPTIONAL,
+	v2x-SupportedBandCombinationList-v1530	V2X-SupportedBandCombination-v1530	OPTIONAL
+}
+
+SL-Parameters-v1540 ::=				SEQUENCE {
+	sl-64QAM-Rx-r15						ENUMERATED {supported}				OPTIONAL,
+	sl-RateMatchingTBSScaling-r15			ENUMERATED {supported}				OPTIONAL,
+	sl-LowT2min-r15							ENUMERATED {supported}				OPTIONAL,
+	v2x-SensingReportingMode3-r15			ENUMERATED {supported}				OPTIONAL
+}
+
+SL-Parameters-v1610 ::=		SEQUENCE {
+	sl-ParameterNR-r16			OCTET STRING								OPTIONAL,
+	dummy						V2X-SupportedBandCombinationEUTRA-NR-r16	OPTIONAL
+}
+
+SL-Parameters-v1630 ::=					SEQUENCE {
+	v2x-SupportedBandCombinationListEUTRA-NR-r16	V2X-SupportedBandCombinationEUTRA-NR-v1630	OPTIONAL
+}
+
+UE-CategorySL-r15 ::=			SEQUENCE {
+	ue-CategorySL-C-TX-r15				INTEGER(1..5),
+	ue-CategorySL-C-RX-r15				INTEGER(1..4)
+}
+
+V2X-SupportedBandCombination-r14 ::=		SEQUENCE (SIZE (1..maxBandComb-r13)) OF V2X-BandCombinationParameters-r14
+
+V2X-SupportedBandCombination-v1530	::=		SEQUENCE (SIZE (1..maxBandComb-r13)) OF V2X-BandCombinationParameters-v1530
+
+V2X-BandCombinationParameters-r14 ::=	SEQUENCE (SIZE (1.. maxSimultaneousBands-r10)) OF V2X-BandParameters-r14
+
+V2X-BandCombinationParameters-v1530 ::=	SEQUENCE (SIZE (1.. maxSimultaneousBands-r10)) OF V2X-BandParameters-v1530
+
+V2X-SupportedBandCombinationEUTRA-NR-r16	::=	SEQUENCE (SIZE (1..maxBandCombSidelinkNR-r16)) OF V2X-BandParametersEUTRA-NR-r16
+
+V2X-SupportedBandCombinationEUTRA-NR-v1630	::=	SEQUENCE (SIZE (1..maxBandCombSidelinkNR-r16)) OF V2X-BandCombinationParametersEUTRA-NR-v1630
+
+V2X-BandCombinationParametersEUTRA-NR-v1630 ::=	SEQUENCE {
+	bandListSidelinkEUTRA-NR-r16					SEQUENCE (SIZE (1.. maxSimultaneousBands-r10)) OF V2X-BandParametersEUTRA-NR-r16,
+	bandListSidelinkEUTRA-NR-v1630					SEQUENCE (SIZE (1.. maxSimultaneousBands-r10)) OF V2X-BandParametersEUTRA-NR-v1630
+}
+
+V2X-BandParametersEUTRA-NR-r16 ::=	CHOICE {
+	eutra									SEQUENCE {
+		v2x-BandParameters1-r16				V2X-BandParameters-r14		OPTIONAL,
+		v2x-BandParameters2-r16				V2X-BandParameters-v1530		OPTIONAL
+	},
+	nr										SEQUENCE {
+		v2x-BandParametersNR-r16					OCTET STRING				OPTIONAL
+	}
+}
+
+V2X-BandParametersEUTRA-NR-v1630 ::=	CHOICE {
+	eutra									NULL,
+	nr										SEQUENCE {
+ 	tx-Sidelink-r16							ENUMERATED {supported}	OPTIONAL,
+		rx-Sidelink-r16							ENUMERATED {supported}	OPTIONAL
+	}
+}
+
+SupportedBandInfoList-r12 ::=		SEQUENCE (SIZE (1..maxBands)) OF SupportedBandInfo-r12
+
+SupportedBandInfo-r12 ::=			SEQUENCE {
+	support-r12								ENUMERATED {supported}	OPTIONAL
+}
+
+FreqBandIndicatorListEUTRA-r12 ::=		SEQUENCE (SIZE (1..maxBands)) OF FreqBandIndicator-r11
+
+MMTEL-Parameters-r14 ::=			SEQUENCE {
+	delayBudgetReporting-r14					ENUMERATED {supported}		OPTIONAL,
+	pusch-Enhancements-r14						ENUMERATED {supported}		OPTIONAL,
+	recommendedBitRate-r14						ENUMERATED {supported}		OPTIONAL,
+	recommendedBitRateQuery-r14					ENUMERATED {supported}		OPTIONAL
+}
+
+MMTEL-Parameters-v1610 ::=				SEQUENCE {
+	recommendedBitRateMultiplier-r16			ENUMERATED {supported}			OPTIONAL
+}
+
+SRS-CapabilityPerBandPair-r14 ::= SEQUENCE {
+	retuningInfo				SEQUENCE {
+		rf-RetuningTimeDL-r14			ENUMERATED {n0, n0dot5, n1, n1dot5, n2, n2dot5, n3,
+													n3dot5, n4, n4dot5, n5, n5dot5, n6, n6dot5,
+													n7, spare1}		OPTIONAL,
+		rf-RetuningTimeUL-r14			ENUMERATED {n0, n0dot5, n1, n1dot5, n2, n2dot5, n3,
+													n3dot5, n4, n4dot5, n5, n5dot5, n6, n6dot5,
+													n7, spare1}		OPTIONAL
+	}
+}
+
+SRS-CapabilityPerBandPair-v14b0 ::= SEQUENCE {
+	srs-FlexibleTiming-r14				ENUMERATED {supported}		OPTIONAL,
+	srs-HARQ-ReferenceConfig-r14			ENUMERATED {supported}		OPTIONAL
+}
+
+SRS-CapabilityPerBandPair-v1610::= SEQUENCE {
+	addSRS-CarrierSwitching-r16				ENUMERATED {supported}		OPTIONAL
+}
+
+HighSpeedEnhParameters-r14 ::= SEQUENCE {
+	measurementEnhancements-r14		ENUMERATED {supported}		OPTIONAL,
+	demodulationEnhancements-r14	ENUMERATED {supported}		OPTIONAL,
+	prach-Enhancements-r14			ENUMERATED {supported}		OPTIONAL
+}
+
+HighSpeedEnhParameters-v1610 ::= SEQUENCE {
+	measurementEnhancementsSCell-r16	ENUMERATED {supported}		OPTIONAL,
+	measurementEnhancements2-r16		ENUMERATED {supported}		OPTIONAL,
+	demodulationEnhancements2-r16	ENUMERATED {supported}		OPTIONAL,
+	interRAT-enhancementNR-r16		ENUMERATED {supported}		OPTIONAL
+}
+
+
+
+UE-RadioPagingInfo-r12 ::=				SEQUENCE {
+	ue-Category-v1250						INTEGER (0)			OPTIONAL,
+	...,
+	[[	ue-CategoryDL-v1310					ENUMERATED {m1}		OPTIONAL,
+		ce-ModeA-r13						ENUMERATED {true}	OPTIONAL,
+		ce-ModeB-r13						ENUMERATED {true}	OPTIONAL
+	]],
+	[[	wakeUpSignal-r15					ENUMERATED {true}	OPTIONAL,
+		wakeUpSignal-TDD-r15				ENUMERATED {true}	OPTIONAL,
+		wakeUpSignalMinGap-eDRX-r15			ENUMERATED {ms40, ms240, ms1000, ms2000}		OPTIONAL,
+		wakeUpSignalMinGap-eDRX-TDD-r15		ENUMERATED {ms40, ms240, ms1000, ms2000}		OPTIONAL
+	]],
+	[[	ue-CategoryDL-v1610					ENUMERATED {m2}		OPTIONAL,
+		groupWakeUpSignal-r16				ENUMERATED {true}	OPTIONAL,
+		groupWakeUpSignalTDD-r16			ENUMERATED {true}	OPTIONAL,
+		groupWakeUpSignalAlternation-r16	ENUMERATED {true}	OPTIONAL,
+		groupWakeUpSignalAlternationTDD-r16	ENUMERATED {true}	OPTIONAL
+	]]
+}
+
+
+
+UE-TimersAndConstants ::=			SEQUENCE {
+	t300								ENUMERATED {
+											ms100, ms200, ms300, ms400, ms600, ms1000, ms1500,
+											ms2000},
+	t301								ENUMERATED {
+											ms100, ms200, ms300, ms400, ms600, ms1000, ms1500,
+											ms2000},
+	t310								ENUMERATED {
+											ms0, ms50, ms100, ms200, ms500, ms1000, ms2000},
+	n310								ENUMERATED {
+											n1, n2, n3, n4, n6, n8, n10, n20},
+	t311								ENUMERATED {
+											ms1000, ms3000, ms5000, ms10000, ms15000,
+											ms20000, ms30000},
+	n311								ENUMERATED {
+											n1, n2, n3, n4, n5, n6, n8, n10},
+	...,
+	[[	t300-v1310						ENUMERATED {
+											ms2500, ms3000, ms3500, ms4000, ms5000, ms6000, ms8000,
+											ms10000}		OPTIONAL,	-- Need OR
+		t301-v1310						ENUMERATED {
+											ms2500, ms3000, ms3500, ms4000, ms5000, ms6000, ms8000,
+											ms10000}		OPTIONAL	-- Need OR
+	]],
+	[[	t310-v1330							ENUMERATED {ms4000, ms6000}	
+															OPTIONAL	-- Need OR
+	]],
+	[[	t300-r15						ENUMERATED {ms4000, ms6000, ms8000, ms10000, ms15000,
+											ms25000, ms40000, ms60000}	OPTIONAL		-- Cond EDTorPUR
+	]]
+}
+
+
+
+VisitedCellInfoList-r12 ::=	SEQUENCE (SIZE (1..maxCellHistory-r12)) OF VisitedCellInfo-r12
+
+VisitedCellInfo-r12 ::=				SEQUENCE {
+	visitedCellId-r12					CHOICE {
+		cellGlobalId-r12						CellGlobalIdEUTRA,
+		pci-arfcn-r12							SEQUENCE {
+			physCellId-r12							PhysCellId,
+			carrierFreq-r12							ARFCN-ValueEUTRA-r9
+		}
+	}																OPTIONAL,
+	timeSpent-r12						INTEGER (0..4095),
+	...
+}
+
+
+
+WLAN-OffloadConfig-r12 ::=				SEQUENCE {
+	thresholdRSRP-r12						SEQUENCE {
+		thresholdRSRP-Low-r12					RSRP-Range,
+		thresholdRSRP-High-r12					RSRP-Range
+	}																	OPTIONAL, -- Need OR
+	thresholdRSRQ-r12						SEQUENCE {
+		thresholdRSRQ-Low-r12					RSRQ-Range,
+		thresholdRSRQ-High-r12					RSRQ-Range
+	}																	OPTIONAL, -- Need OR
+	thresholdRSRQ-OnAllSymbolsWithWB-r12	SEQUENCE {
+		thresholdRSRQ-OnAllSymbolsWithWB-Low-r12			RSRQ-Range,
+		thresholdRSRQ-OnAllSymbolsWithWB-High-r12			RSRQ-Range
+	}																	OPTIONAL, -- Need OP
+	thresholdRSRQ-OnAllSymbols-r12			SEQUENCE {
+			thresholdRSRQ-OnAllSymbolsLow-r12					RSRQ-Range,
+			thresholdRSRQ-OnAllSymbolsHigh-r12					RSRQ-Range
+	}																	OPTIONAL, -- Need OP
+	thresholdRSRQ-WB-r12					SEQUENCE {
+		thresholdRSRQ-WB-Low-r12							RSRQ-Range,
+		thresholdRSRQ-WB-High-r12							RSRQ-Range
+	}																	OPTIONAL, -- Need OP
+
+	thresholdChannelUtilization-r12			SEQUENCE {
+		thresholdChannelUtilizationLow-r12		INTEGER (0..255),
+		thresholdChannelUtilizationHigh-r12		INTEGER (0..255)
+	}																	OPTIONAL, -- Need OR
+	thresholdBackhaul-Bandwidth-r12			SEQUENCE {
+		thresholdBackhaulDL-BandwidthLow-r12	WLAN-backhaulRate-r12,
+		thresholdBackhaulDL-BandwidthHigh-r12	WLAN-backhaulRate-r12,
+		thresholdBackhaulUL-BandwidthLow-r12	WLAN-backhaulRate-r12,
+		thresholdBackhaulUL-BandwidthHigh-r12	WLAN-backhaulRate-r12
+	}																	OPTIONAL, -- Need OR
+	thresholdWLAN-RSSI-r12						SEQUENCE {
+		thresholdWLAN-RSSI-Low-r12					INTEGER (0..255),
+		thresholdWLAN-RSSI-High-r12					INTEGER (0..255)
+	}																	OPTIONAL, -- Need OR
+	offloadPreferenceIndicator-r12			BIT STRING (SIZE (16))		OPTIONAL, -- Need OR
+	t-SteeringWLAN-r12						T-Reselection				OPTIONAL, -- Need OR
+	...
+}
+
+WLAN-backhaulRate-r12 ::=					ENUMERATED
+										{r0, r4, r8, r16, r32, r64, r128, r256, r512,
+										r1024, r2048, r4096, r8192, r16384, r32768, r65536, r131072,
+										r262144, r524288, r1048576, r2097152, r4194304, r8388608,
+										r16777216, r33554432, r67108864, r134217728, r268435456,
+										r536870912, r1073741824, r2147483648, r4294967296}
+
+
+
+MBMS-NotificationConfig-r9 ::=				SEQUENCE {
+	notificationRepetitionCoeff-r9		ENUMERATED {n2, n4},
+	notificationOffset-r9				INTEGER (0..10),
+	notificationSF-Index-r9				INTEGER (1..6)
+}
+
+MBMS-NotificationConfig-v1430 ::=				SEQUENCE {
+	notificationSF-Index-v1430				INTEGER (7..10)
+}
+
+
+
+MBMS-ServiceList-r13 ::=			SEQUENCE (SIZE (0..maxMBMS-ServiceListPerUE-r13)) OF MBMS-ServiceInfo-r13
+
+MBMS-ServiceInfo-r13 ::=				SEQUENCE	{
+	tmgi-r13							TMGI-r9
+}
+
+
+
+MBSFN-AreaId-r12 ::=					INTEGER (0..255)
+
+
+
+MBSFN-AreaInfoList-r9 ::=			SEQUENCE (SIZE(1..maxMBSFN-Area)) OF MBSFN-AreaInfo-r9
+
+MBSFN-AreaInfo-r9 ::=				SEQUENCE {
+	mbsfn-AreaId-r9						MBSFN-AreaId-r12,
+	non-MBSFNregionLength				ENUMERATED {s1, s2},
+	notificationIndicator-r9			INTEGER (0..7),
+	mcch-Config-r9						SEQUENCE {
+		mcch-RepetitionPeriod-r9		ENUMERATED {rf32, rf64, rf128, rf256},
+		mcch-Offset-r9					INTEGER (0..10),
+		mcch-ModificationPeriod-r9		ENUMERATED {rf512, rf1024},
+		sf-AllocInfo-r9					BIT STRING (SIZE(6)),
+		signallingMCS-r9				ENUMERATED {n2, n7, n13, n19}
+	},
+	...,
+	[[	mcch-Config-r14				SEQUENCE {
+			mcch-RepetitionPeriod-v1430		ENUMERATED {rf1, rf2, rf4, rf8,
+										rf16 }		OPTIONAL,	-- Need OR
+			mcch-ModificationPeriod-v1430	ENUMERATED {rf1, rf2, rf4, rf8, rf16, rf32, rf64, rf128,
+											rf256, spare7}					OPTIONAL	-- Need OR
+		}																	OPTIONAL,	-- Need OR
+		subcarrierSpacingMBMS-r14		ENUMERATED {kHz7dot5, kHz1dot25}	OPTIONAL	-- Need OR
+	]]
+}
+
+MBSFN-AreaInfoList-r16 ::=		SEQUENCE (SIZE(1..maxMBSFN-Area)) OF MBSFN-AreaInfo-r16
+
+MBSFN-AreaInfo-r16 ::=				SEQUENCE {
+	mbsfn-AreaId-r16					MBSFN-AreaId-r12,
+	notificationIndicator-r16			INTEGER (0..7),
+	mcch-Config-r16						SEQUENCE {
+		mcch-RepetitionPeriod-r16			ENUMERATED {rf1, rf2, rf4, rf8, rf16, rf32, rf64,
+														rf128, rf256, spare7, spare6, spare5,
+														spare4, spare3, spare2, spare1},
+		mcch-ModificationPeriod-r16			ENUMERATED {rf1, rf2, rf4, rf8, rf16, rf32, rf64, rf128,
+														rf256, rf512, rf1024, spare5, spare4,
+														spare3,spare2, spare1},
+		mcch-Offset-r16					INTEGER (0..10),
+		sf-AllocInfo-r16				BIT STRING (SIZE(10)),
+		signallingMCS-r16				ENUMERATED {n2, n7, n13, n19}
+	},
+	subcarrierSpacingMBMS-r16		ENUMERATED {kHz7dot5, kHz2dot5, kHz1dot25, kHz0dot37,
+										spare4, spare3, spare2, spare1},
+	timeSeparation-r16				ENUMERATED {sl2, sl4} OPTIONAL,	-- Need OR
+	...
+}
+
+
+
+MBSFN-SubframeConfig ::=			SEQUENCE {
+	radioframeAllocationPeriod			ENUMERATED {n1, n2, n4, n8, n16, n32},
+	radioframeAllocationOffset			INTEGER (0..7),
+	subframeAllocation					CHOICE {
+		oneFrame							BIT STRING (SIZE(6)),
+		fourFrames							BIT STRING (SIZE(24))
+	}
+}
+
+MBSFN-SubframeConfig-v1430 ::=		SEQUENCE {
+	subframeAllocation-v1430				CHOICE {
+		oneFrame-v1430						BIT STRING (SIZE(2)),
+		fourFrames-v1430					BIT STRING (SIZE(8))
+	}
+}
+
+MBSFN-SubframeConfig-v1610 ::=		SEQUENCE {
+	subframeAllocation-v1610				CHOICE {
+		oneFrame-v1610						BIT STRING (SIZE(2)),
+		fourFrames-v1610					BIT STRING (SIZE(8))
+	}
+}
+
+
+
+PMCH-InfoList-r9 ::=				SEQUENCE (SIZE (0..maxPMCH-PerMBSFN)) OF PMCH-Info-r9
+
+PMCH-InfoListExt-r12 ::=			SEQUENCE (SIZE (0..maxPMCH-PerMBSFN)) OF PMCH-InfoExt-r12
+
+PMCH-Info-r9 ::=					SEQUENCE {
+	pmch-Config-r9						PMCH-Config-r9,
+	mbms-SessionInfoList-r9			MBMS-SessionInfoList-r9,
+	...
+}
+
+PMCH-InfoExt-r12 ::=				SEQUENCE {
+	pmch-Config-r12						PMCH-Config-r12,
+	mbms-SessionInfoList-r12			MBMS-SessionInfoList-r9,
+	...
+}
+
+MBMS-SessionInfoList-r9 ::=		SEQUENCE (SIZE (0..maxSessionPerPMCH)) OF MBMS-SessionInfo-r9
+
+MBMS-SessionInfo-r9 ::=			SEQUENCE {
+	tmgi-r9								TMGI-r9,
+	sessionId-r9						OCTET STRING (SIZE (1))		OPTIONAL,	-- Need OR
+	logicalChannelIdentity-r9			INTEGER (0..maxSessionPerPMCH-1),
+	...
+}
+
+PMCH-Config-r9 ::=					SEQUENCE {
+	sf-AllocEnd-r9						INTEGER (0..1535),
+	dataMCS-r9							INTEGER (0..28),
+	mch-SchedulingPeriod-r9			ENUMERATED {
+										rf8, rf16, rf32, rf64, rf128, rf256, rf512, rf1024},
+	...
+}
+
+PMCH-Config-r12 ::=					SEQUENCE {
+	sf-AllocEnd-r12						INTEGER (0..1535),
+	dataMCS-r12							CHOICE {
+		normal-r12							INTEGER (0..28),
+		higerOrder-r12						INTEGER (0..27)
+	},
+	mch-SchedulingPeriod-r12		ENUMERATED {
+										rf4, rf8, rf16, rf32, rf64, rf128, rf256, rf512, rf1024},
+	...,
+	[[	mch-SchedulingPeriod-v1430		ENUMERATED {rf1, rf2}			OPTIONAL	-- Need OR
+	]]
+}
+
+TMGI-r9 ::=						SEQUENCE {
+	plmn-Id-r9							CHOICE {
+		plmn-Index-r9						INTEGER (1..maxPLMN-r11),
+		explicitValue-r9					PLMN-Identity
+	},
+	serviceId-r9						OCTET STRING (SIZE (3))
+}
+
+
+
+SC-MTCH-InfoList-r13 ::=			SEQUENCE (SIZE (0..maxSC-MTCH-r13)) OF SC-MTCH-Info-r13
+
+SC-MTCH-Info-r13 ::=				SEQUENCE	{
+	mbmsSessionInfo-r13						MBMSSessionInfo-r13,
+	g-RNTI-r13								BIT STRING(SIZE(16)),
+	sc-mtch-schedulingInfo-r13				SC-MTCH-SchedulingInfo-r13			OPTIONAL,	-- Need OP
+	sc-mtch-neighbourCell-r13				BIT STRING (SIZE(maxNeighCell-SCPTM-r13))	OPTIONAL,	-- Need OP
+	...,
+	[[	p-a-r13								ENUMERATED {
+												dB-6, dB-4dot77, dB-3, dB-1dot77,
+												dB0, dB1, dB2, dB3}		OPTIONAL	-- Need ON
+	]]
+}
+
+MBMSSessionInfo-r13 ::=				SEQUENCE	{
+	tmgi-r13								TMGI-r9,
+	sessionId-r13							OCTET STRING (SIZE (1))		OPTIONAL	-- Need OR
+}
+
+SC-MTCH-SchedulingInfo-r13::=		SEQUENCE	{
+	onDurationTimerSCPTM-r13				ENUMERATED {
+												psf1, psf2, psf3, psf4, psf5, psf6,
+												psf8, psf10, psf20, psf30, psf40,
+												psf50, psf60, psf80, psf100,
+												psf200},
+	drx-InactivityTimerSCPTM-r13			ENUMERATED {
+												psf0, psf1, psf2, psf4, psf8,
+												psf10, psf20, psf40,
+												psf80, psf160, ps320,
+												psf640, psf960,
+												psf1280, psf1920, psf2560},
+	schedulingPeriodStartOffsetSCPTM-r13	CHOICE {
+		sf10									INTEGER(0..9),
+		sf20									INTEGER(0..19),
+		sf32									INTEGER(0..31),
+		sf40									INTEGER(0..39),
+		sf64									INTEGER(0..63),
+		sf80									INTEGER(0..79),
+		sf128									INTEGER(0..127),
+		sf160									INTEGER(0..159),
+		sf256									INTEGER(0..255),
+		sf320									INTEGER(0..319),
+		sf512									INTEGER(0..511),
+		sf640									INTEGER(0..639),
+		sf1024									INTEGER(0..1023),
+		sf2048									INTEGER(0..2048),
+		sf4096									INTEGER(0..4096),
+		sf8192									INTEGER(0..8192)
+	},
+	...
+}
+
+
+
+SC-MTCH-InfoList-BR-r14 ::=		SEQUENCE (SIZE (0..maxSC-MTCH-BR-r14)) OF SC-MTCH-Info-BR-r14
+
+SC-MTCH-Info-BR-r14 ::=			SEQUENCE	{
+	sc-mtch-CarrierFreq-r14					ARFCN-ValueEUTRA-r9,
+	mbmsSessionInfo-r14						MBMSSessionInfo-r13,
+	g-RNTI-r14								BIT STRING(SIZE(16)),
+	sc-mtch-schedulingInfo-r14			SC-MTCH-SchedulingInfo-BR-r14				OPTIONAL,	-- Need OP
+	sc-mtch-neighbourCell-r14				BIT STRING (SIZE(maxNeighCell-SCPTM-r13))	OPTIONAL,	-- Need OP
+	mpdcch-Narrowband-SC-MTCH-r14				INTEGER (1.. maxAvailNarrowBands-r13),
+	mpdcch-NumRepetition-SC-MTCH-r14			ENUMERATED {r1, r2, r4, r8, r16,
+															r32, r64, r128, r256},
+	mpdcch-StartSF-SC-MTCH-r14		CHOICE {
+			fdd-r14								ENUMERATED {v1, v1dot5, v2, v2dot5, v4,
+																v5, v8, v10},
+			tdd-r14								ENUMERATED {v1, v2, v4, v5, v8, v10,
+																v20}
+	},
+	mpdcch-PDSCH-HoppingConfig-SC-MTCH-r14		ENUMERATED {on, off},
+	mpdcch-PDSCH-CEmodeConfig-SC-MTCH-r14		ENUMERATED {ce-ModeA, ce-ModeB},
+	mpdcch-PDSCH-MaxBandwidth-SC-MTCH-r14		ENUMERATED {bw1dot4, bw5},
+	mpdcch-Offset-SC-MTCH-r14					ENUMERATED {zero, oneEighth, oneQuarter,
+															threeEighth, oneHalf, fiveEighth,
+															threeQuarter, sevenEighth},
+
+	p-a-r14										ENUMERATED { dB-6, dB-4dot77, dB-3,
+															dB-1dot77, dB0, dB1, dB2,
+															dB3}				OPTIONAL,--	Need OR
+	...
+}
+
+SC-MTCH-SchedulingInfo-BR-r14::=	SEQUENCE	{
+	onDurationTimerSCPTM-r14				ENUMERATED {
+												psf300, psf400, psf500, psf600,
+												psf800, psf1000, psf1200, psf1600},
+	drx-InactivityTimerSCPTM-r14			ENUMERATED {
+												psf0, psf1, psf2, psf4, psf8, psf16,
+												psf32, psf64, psf128, psf256, ps512,
+												psf1024, psf2048, psf4096, psf8192, psf16384},
+	schedulingPeriodStartOffsetSCPTM-r14	CHOICE {
+		sf10									INTEGER(0..9),
+		sf20									INTEGER(0..19),
+		sf32									INTEGER(0..31),
+		sf40									INTEGER(0..39),
+		sf64									INTEGER(0..63),
+		sf80									INTEGER(0..79),
+		sf128									INTEGER(0..127),
+		sf160									INTEGER(0..159),
+		sf256									INTEGER(0..255),
+		sf320									INTEGER(0..319),
+		sf512									INTEGER(0..511),
+		sf640									INTEGER(0..639),
+		sf1024									INTEGER(0..1023),
+		sf2048									INTEGER(0..2047),
+		sf4096									INTEGER(0..4095),
+		sf8192									INTEGER(0..8191)
+	},
+	...
+}
+
+
+
+SCPTM-NeighbourCellList-r13 ::=		SEQUENCE (SIZE (1..maxNeighCell-SCPTM-r13)) OF PCI-ARFCN-r13
+
+PCI-ARFCN-r13 ::=					SEQUENCE {
+		physCellId-r13						PhysCellId,
+		carrierFreq-r13						ARFCN-ValueEUTRA-r9		OPTIONAL
+}
+
+
+
+SL-AnchorCarrierFreqList-V2X-r14 ::= SEQUENCE (SIZE (1..maxFreqV2X-r14)) OF ARFCN-ValueEUTRA-r9
+
+
+
+SL-CBR-CommonTxConfigList-r14 ::=	SEQUENCE {
+	cbr-RangeCommonConfigList-r14	SEQUENCE (SIZE (1..maxSL-V2X-CBRConfig-r14)) OF SL-CBR-Levels-Config-r14,
+	sl-CBR-PSSCH-TxConfigList-r14	SEQUENCE (SIZE (1..maxSL-V2X-TxConfig-r14)) OF SL-CBR-PSSCH-TxConfig-r14
+}
+
+SL-CBR-Levels-Config-r14 ::=		SEQUENCE (SIZE (1..maxCBR-Level-r14)) OF SL-CBR-r14
+
+
+SL-CBR-PSSCH-TxConfig-r14 ::=		SEQUENCE {
+	cr-Limit-r14					INTEGER(0..10000),
+	tx-Parameters-r14				SL-PSSCH-TxParameters-r14
+}
+
+SL-CBR-r14 ::=						INTEGER(0..100)
+
+
+
+SL-CBR-PPPP-TxConfigList-r14 ::=	SEQUENCE (SIZE (1..8)) OF SL-PPPP-TxConfigIndex-r14
+
+SL-PPPP-TxConfigIndex-r14 ::=		SEQUENCE {
+	priorityThreshold-r14			SL-Priority-r13,
+	defaultTxConfigIndex-r14		INTEGER(0..maxCBR-Level-1-r14),
+	cbr-ConfigIndex-r14				INTEGER(0..maxSL-V2X-CBRConfig-1-r14),
+	tx-ConfigIndexList-r14			SEQUENCE (SIZE (1..maxCBR-Level-r14)) OF Tx-ConfigIndex-r14
+}
+
+Tx-ConfigIndex-r14 ::=				INTEGER(0..maxSL-V2X-TxConfig-1-r14)
+
+SL-CBR-PPPP-TxConfigList-v1530 ::=	SEQUENCE (SIZE (1..8)) OF SL-PPPP-TxConfigIndex-v1530
+
+SL-PPPP-TxConfigIndex-v1530 ::=		SEQUENCE {
+	mcs-PSSCH-RangeList-r15				SEQUENCE (SIZE (1..maxCBR-Level-r14)) OF MCS-PSSCH-Range-r15						OPTIONAL		--Need OR
+}
+
+MCS-PSSCH-Range-r15 ::=		SEQUENCE{
+	minMCS-PSSCH-r15			INTEGER (0..31),
+	maxMCS-PSSCH-r15			INTEGER (0..31)
+}
+
+SL-CBR-PPPP-TxConfigList-r15 ::=	SEQUENCE (SIZE (1..8)) OF SL-PPPP-TxConfigIndex-r15
+
+SL-PPPP-TxConfigIndex-r15 ::=		SEQUENCE {
+	priorityThreshold-r15			SL-Priority-r13,
+	defaultTxConfigIndex-r15		INTEGER(0..maxCBR-Level-1-r14),
+	cbr-ConfigIndex-r15				INTEGER(0..maxSL-V2X-CBRConfig-1-r14),
+	tx-ConfigIndexList-r15			SEQUENCE (SIZE (1..maxCBR-Level-r14)) OF Tx-ConfigIndex-r14,
+	mcs-PSSCH-RangeList-r15				SEQUENCE (SIZE (1..maxCBR-Level-r14)) OF MCS-PSSCH-Range-r15
+}
+
+
+
+SL-CommConfig-r12 ::=				SEQUENCE	{
+	commTxResources-r12					CHOICE {
+		release								NULL,
+		setup								CHOICE {
+			scheduled-r12					SEQUENCE {
+				sl-RNTI-r12						C-RNTI,
+				mac-MainConfig-r12				MAC-MainConfigSL-r12,
+				sc-CommTxConfig-r12				SL-CommResourcePool-r12,
+				mcs-r12							INTEGER (0..28)				OPTIONAL	-- Need OP
+			},
+			ue-Selected-r12					SEQUENCE {
+				-- Pool for normal usage
+				commTxPoolNormalDedicated-r12	SEQUENCE {
+					poolToReleaseList-r12			SL-TxPoolToReleaseList-r12 OPTIONAL,	-- Need ON
+					poolToAddModList-r12			SL-CommTxPoolToAddModList-r12 OPTIONAL	-- Need ON
+				}
+			}
+		}
+	}																		OPTIONAL,	-- Need ON
+	...,
+	[[	commTxResources-v1310				CHOICE {
+			release								NULL,
+			setup								CHOICE {
+				scheduled-v1310						SEQUENCE {
+					logicalChGroupInfoList-r13			LogicalChGroupInfoList-r13,
+					multipleTx-r13						BOOLEAN
+				},
+				ue-Selected-v1310					SEQUENCE {
+					commTxPoolNormalDedicatedExt-r13	SEQUENCE {
+						poolToReleaseListExt-r13			SL-TxPoolToReleaseListExt-r13 OPTIONAL,	-- Need ON
+						poolToAddModListExt-r13				SL-CommTxPoolToAddModListExt-r13	OPTIONAL	-- Need ON
+					}
+				}
+			}
+		}																OPTIONAL,	-- Need ON
+		commTxAllowRelayDedicated-r13		BOOLEAN			OPTIONAL	-- Need ON
+	]]
+}
+
+LogicalChGroupInfoList-r13 ::=		SEQUENCE (SIZE (1..maxLCG-r13)) OF SL-PriorityList-r13
+
+SL-CommTxPoolToAddModList-r12 ::=		SEQUENCE (SIZE (1..maxSL-TxPool-r12)) OF SL-CommTxPoolToAddMod-r12
+
+SL-CommTxPoolToAddModListExt-r13 ::=	SEQUENCE (SIZE (1..maxSL-TxPool-v1310)) OF SL-CommTxPoolToAddModExt-r13
+
+SL-CommTxPoolToAddMod-r12 ::=		SEQUENCE	{
+	poolIdentity-r12					SL-TxPoolIdentity-r12,
+	pool-r12							SL-CommResourcePool-r12
+}
+
+SL-CommTxPoolToAddModExt-r13 ::=		SEQUENCE	{
+	poolIdentity-v1310					SL-TxPoolIdentity-v1310,
+	pool-r13							SL-CommResourcePool-r12
+}
+
+MAC-MainConfigSL-r12 ::=		SEQUENCE	{
+	periodic-BSR-TimerSL					PeriodicBSR-Timer-r12		OPTIONAL,	-- Need ON
+	retx-BSR-TimerSL						RetxBSR-Timer-r12
+}
+
+
+
+SL-CommTxPoolList-r12 ::=		SEQUENCE (SIZE (1..maxSL-TxPool-r12)) OF SL-CommResourcePool-r12
+
+SL-CommTxPoolListExt-r13 ::=	SEQUENCE (SIZE (1..maxSL-TxPool-v1310)) OF SL-CommResourcePool-r12
+
+SL-CommTxPoolListV2X-r14 ::=		SEQUENCE (SIZE (1..maxSL-V2X-TxPool-r14)) OF SL-CommResourcePoolV2X-r14
+
+SL-CommRxPoolList-r12 ::=		SEQUENCE (SIZE (1..maxSL-RxPool-r12)) OF SL-CommResourcePool-r12
+
+SL-CommRxPoolListV2X-r14 ::=		SEQUENCE (SIZE (1..maxSL-V2X-RxPool-r14)) OF SL-CommResourcePoolV2X-r14
+
+SL-CommResourcePool-r12 ::=		SEQUENCE {
+	sc-CP-Len-r12						SL-CP-Len-r12,
+	sc-Period-r12						SL-PeriodComm-r12,
+	sc-TF-ResourceConfig-r12			SL-TF-ResourceConfig-r12,
+	data-CP-Len-r12						SL-CP-Len-r12,
+	dataHoppingConfig-r12				SL-HoppingConfigComm-r12,
+	ue-SelectedResourceConfig-r12			SEQUENCE {
+		data-TF-ResourceConfig-r12				SL-TF-ResourceConfig-r12,
+		trpt-Subset-r12						SL-TRPT-Subset-r12	OPTIONAL	-- Need OP
+	}																OPTIONAL,	-- Need OR
+	rxParametersNCell-r12				SEQUENCE {
+		tdd-Config-r12					TDD-Config					OPTIONAL,	-- Need OP
+		syncConfigIndex-r12			INTEGER (0..15)
+	}																OPTIONAL,	-- Need OR
+	txParameters-r12					SEQUENCE {
+		sc-TxParameters-r12				SL-TxParameters-r12,
+		dataTxParameters-r12			SL-TxParameters-r12
+	}																OPTIONAL,	-- Cond Tx
+	...,
+	[[	priorityList-r13				SL-PriorityList-r13			OPTIONAL	-- Cond Tx
+	]]
+
+}
+
+SL-CommResourcePoolV2X-r14 ::=		SEQUENCE {
+	sl-OffsetIndicator-r14				SL-OffsetIndicator-r12		OPTIONAL,	-- Need OR
+	sl-Subframe-r14						SubframeBitmapSL-r14,
+	adjacencyPSCCH-PSSCH-r14			BOOLEAN,
+	sizeSubchannel-r14					ENUMERATED {
+										n4, n5, n6, n8, n9, n10, n12, n15, n16, n18, n20, n25, n30,
+										n48, n50, n72, n75, n96, n100, spare13, spare12, spare11,
+										spare10, spare9, spare8, spare7, spare6, spare5, spare4,
+										spare3, spare2, spare1},
+	numSubchannel-r14					ENUMERATED {n1, n3, n5, n8, n10, n15, n20, spare1},
+	startRB-Subchannel-r14				INTEGER (0..99),
+	startRB-PSCCH-Pool-r14				INTEGER (0..99)				OPTIONAL,	-- Need OR
+	rxParametersNCell-r14				SEQUENCE {
+		tdd-Config-r14					TDD-Config					OPTIONAL,	-- Need OP
+		syncConfigIndex-r14				INTEGER (0..15)
+	}																OPTIONAL,	-- Need OR
+	dataTxParameters-r14				SL-TxParameters-r12			OPTIONAL,	-- Cond Tx
+	zoneID-r14							INTEGER (0..7)				OPTIONAL,	-- Need OR
+	threshS-RSSI-CBR-r14					INTEGER (0..45)				OPTIONAL,	-- Need OR
+	poolReportId-r14					SL-V2X-TxPoolReportIdentity-r14		OPTIONAL,	-- Need OR
+	cbr-pssch-TxConfigList-r14			SL-CBR-PPPP-TxConfigList-r14	OPTIONAL,	-- Need OR
+	resourceSelectionConfigP2X-r14		SL-P2X-ResourceSelectionConfig-r14	OPTIONAL,	-- Cond P2X
+	syncAllowed-r14						SL-SyncAllowed-r14				OPTIONAL,	-- Need OR
+	restrictResourceReservationPeriod-r14	SL-RestrictResourceReservationPeriodList-r14	OPTIONAL,	-- Need OR
+	...,
+	[[	sl-MinT2ValueList-r15		SL-MinT2ValueList-r15		OPTIONAL,	-- Need OR
+		cbr-pssch-TxConfigList-v1530	SL-CBR-PPPP-TxConfigList-v1530	OPTIONAL	-- Need OR
+	]]
+}
+
+SL-TRPT-Subset-r12 ::=			BIT STRING (SIZE (3..5))
+
+SL-V2X-TxPoolReportIdentity-r14::=		INTEGER (1..maxSL-PoolToMeasure-r14)
+
+SL-MinT2ValueList-r15 ::=	SEQUENCE (SIZE (1..maxSL-Prio-r13)) OF SL-MinT2Value-r15
+
+SL-MinT2Value-r15 ::=			SEQUENCE {
+	priorityList-r15					SL-PriorityList-r13,
+	minT2Value-r15						INTEGER (10..20)
+}
+
+
+
+SL-CommTxPoolSensingConfig-r14 ::=		SEQUENCE {
+	pssch-TxConfigList-r14					SL-PSSCH-TxConfigList-r14,
+	thresPSSCH-RSRP-List-r14				SL-ThresPSSCH-RSRP-List-r14,
+	restrictResourceReservationPeriod-r14	SL-RestrictResourceReservationPeriodList-r14	OPTIONAL,	-- Need OR
+	probResourceKeep-r14				ENUMERATED {v0, v0dot2, v0dot4, v0dot6, v0dot8,
+													spare3,spare2, spare1},
+	p2x-SensingConfig-r14					SEQUENCE {
+		minNumCandidateSF-r14				INTEGER (1..13),
+		gapCandidateSensing-r14				BIT STRING (SIZE (10))
+	}		OPTIONAL,	-- Need OR
+	sl-ReselectAfter-r14				ENUMERATED {n1, n2, n3, n4, n5, n6, n7, n8, n9,
+												spare7, spare6, spare5, spare4, spare3, spare2,
+												spare1}				OPTIONAL		-- Need OR
+}
+
+
+
+SL-CP-Len-r12 ::=				ENUMERATED {normal, extended}
+
+
+
+SL-DiscConfig-r12 ::=					SEQUENCE {
+	discTxResources-r12						CHOICE {
+		release								NULL,
+		setup								CHOICE {
+			scheduled-r12					SEQUENCE {
+				discTxConfig-r12					SL-DiscResourcePool-r12	OPTIONAL, -- Need ON
+				discTF-IndexList-r12				SL-TF-IndexPairList-r12	OPTIONAL, -- Need ON
+				discHoppingConfig-r12				SL-HoppingConfigDisc-r12
+														OPTIONAL	-- Need ON
+			},
+			ue-Selected-r12					SEQUENCE {
+				discTxPoolDedicated-r12			SEQUENCE {
+					poolToReleaseList-r12			SL-TxPoolToReleaseList-r12 OPTIONAL,	-- Need ON
+					poolToAddModList-r12			SL-DiscTxPoolToAddModList-r12 OPTIONAL	-- Need ON
+				}													OPTIONAL	-- Need ON
+			}
+		}
+	}																OPTIONAL,	-- Need ON
+	...,
+	[[	discTF-IndexList-v1260				CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				discTF-IndexList-r12b				SL-TF-IndexPairList-r12b
+			}
+		}															OPTIONAL	-- Need ON
+	]],
+	[[	discTxResourcesPS-r13			CHOICE {
+			release								NULL,
+			setup								CHOICE {
+				scheduled-r13						SL-DiscTxConfigScheduled-r13,
+				ue-Selected-r13						SEQUENCE {
+					discTxPoolPS-Dedicated-r13			SL-DiscTxPoolDedicated-r13
+				}
+			}
+		}															OPTIONAL,	-- Need ON
+		discTxInterFreqInfo-r13			CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				discTxCarrierFreq-r13				ARFCN-ValueEUTRA-r9			OPTIONAL,	-- Need OR
+				discTxRefCarrierDedicated-r13		SL-DiscTxRefCarrierDedicated-r13	OPTIONAL,	-- Need OR
+				discTxInfoInterFreqListAdd-r13			SL-DiscTxInfoInterFreqListAdd-r13	OPTIONAL	-- Need ON
+			}
+		}															OPTIONAL,	-- Need ON
+		gapRequestsAllowedDedicated-r13		BOOLEAN			OPTIONAL,	-- Need ON
+		discRxGapConfig-r13					CHOICE {
+			release								NULL,
+			setup								SL-GapConfig-r13
+		}															OPTIONAL,	-- Need ON
+		discTxGapConfig-r13					CHOICE {
+			release								NULL,
+			setup								SL-GapConfig-r13
+		}															OPTIONAL,	-- Need ON
+		discSysInfoToReportConfig-r13		CHOICE {
+			release								NULL,
+			setup								SL-DiscSysInfoToReportFreqList-r13
+		}															OPTIONAL	-- Need ON
+	]]
+}
+
+SL-DiscSysInfoToReportFreqList-r13 ::= SEQUENCE (SIZE (1..maxFreq)) OF ARFCN-ValueEUTRA-r9
+
+SL-DiscTxInfoInterFreqListAdd-r13 ::=	SEQUENCE {
+	discTxFreqToAddModList-r13				SEQUENCE (SIZE (1..maxFreq)) OF SL-DiscTxResourceInfoPerFreq-r13	OPTIONAL,	-- Need ON
+	discTxFreqToReleaseList-r13				SEQUENCE (SIZE (1..maxFreq)) OF ARFCN-ValueEUTRA-r9	OPTIONAL,	-- Need ON
+	...
+}
+
+SL-DiscTxResourceInfoPerFreq-r13 ::=	SEQUENCE	{
+	discTxCarrierFreq-r13					ARFCN-ValueEUTRA-r9,
+	discTxResources-r13						SL-DiscTxResource-r13	OPTIONAL,	-- Need OR
+	discTxResourcesPS-r13					SL-DiscTxResource-r13	OPTIONAL,	-- Need OR
+	discTxRefCarrierDedicated-r13			SL-DiscTxRefCarrierDedicated-r13	OPTIONAL,	-- Need OR
+	discCellSelectionInfo-r13					CellSelectionInfoNFreq-r13			OPTIONAL,	-- Need OR
+	...
+}
+
+SL-DiscTxResource-r13 ::=				CHOICE {
+	release								NULL,
+	setup								CHOICE {
+		scheduled-r13					SL-DiscTxConfigScheduled-r13,
+		ue-Selected-r13					SL-DiscTxPoolDedicated-r13
+	}
+}
+
+SL-DiscTxPoolToAddModList-r12 ::=		SEQUENCE (SIZE (1..maxSL-TxPool-r12)) OF SL-DiscTxPoolToAddMod-r12
+
+SL-DiscTxPoolToAddMod-r12 ::=		SEQUENCE	{
+	poolIdentity-r12					SL-TxPoolIdentity-r12,
+	pool-r12							SL-DiscResourcePool-r12
+}
+
+SL-DiscTxConfigScheduled-r13 ::=			SEQUENCE {
+	discTxConfig-r13					SL-DiscResourcePool-r12	OPTIONAL, -- Need ON
+	discTF-IndexList-r13				SL-TF-IndexPairList-r12b	OPTIONAL, -- Need ON
+	discHoppingConfig-r13				SL-HoppingConfigDisc-r12	OPTIONAL,-- Need ON
+	...
+}
+
+SL-DiscTxPoolDedicated-r13 ::=			SEQUENCE {
+	poolToReleaseList-r13			SL-TxPoolToReleaseList-r12 OPTIONAL,	-- Need ON
+	poolToAddModList-r13			SL-DiscTxPoolToAddModList-r12 OPTIONAL	-- Need ON
+}
+
+SL-TF-IndexPairList-r12 ::=		SEQUENCE (SIZE (1..maxSL-TF-IndexPair-r12)) OF SL-TF-IndexPair-r12
+
+SL-TF-IndexPair-r12 ::=		SEQUENCE	{
+	discSF-Index-r12					INTEGER (1.. 200)		OPTIONAL,	-- Need ON
+	discPRB-Index-r12					INTEGER (1.. 50)		OPTIONAL	-- Need ON
+}
+
+SL-TF-IndexPairList-r12b ::=		SEQUENCE (SIZE (1..maxSL-TF-IndexPair-r12)) OF SL-TF-IndexPair-r12b
+
+SL-TF-IndexPair-r12b ::=		SEQUENCE	{
+	discSF-Index-r12b					INTEGER (0..209)		OPTIONAL,	-- Need ON
+	discPRB-Index-r12b					INTEGER (0..49)			OPTIONAL	-- Need ON
+}
+
+SL-DiscTxRefCarrierDedicated-r13 ::=	CHOICE {
+	pCell								NULL,
+	sCell								SCellIndex-r10
+}
+
+
+
+SL-DiscTxPoolList-r12 ::=		SEQUENCE (SIZE (1..maxSL-TxPool-r12)) OF SL-DiscResourcePool-r12
+
+SL-DiscRxPoolList-r12 ::=		SEQUENCE (SIZE (1..maxSL-RxPool-r12)) OF SL-DiscResourcePool-r12
+
+SL-DiscResourcePool-r12 ::=		SEQUENCE	{
+	cp-Len-r12						SL-CP-Len-r12,
+	discPeriod-r12				ENUMERATED {rf32, rf64, rf128,
+											rf256, rf512, rf1024, rf16-v1310, spare},
+	numRetx-r12					INTEGER (0..3),
+	numRepetition-r12				INTEGER (1..50),
+	tf-ResourceConfig-r12			SL-TF-ResourceConfig-r12,
+	txParameters-r12				SEQUENCE {
+		txParametersGeneral-r12		SL-TxParameters-r12,
+		ue-SelectedResourceConfig-r12	SEQUENCE {
+			poolSelection-r12				CHOICE {
+				rsrpBased-r12					SL-PoolSelectionConfig-r12,
+				random-r12						NULL
+			},
+			txProbability-r12			ENUMERATED {p25, p50, p75, p100}
+		}															OPTIONAL	-- Need OR
+	}																OPTIONAL,	-- Cond Tx
+	rxParameters-r12				SEQUENCE {
+		tdd-Config-r12					TDD-Config					OPTIONAL,	-- Need OR
+		syncConfigIndex-r12			INTEGER (0..15)
+	}																OPTIONAL,	-- Need OR
+	...,
+	[[	discPeriod-v1310				CHOICE {
+			release								NULL,
+			setup								ENUMERATED {rf4, rf6, rf7, rf8,
+													rf12, rf14, rf24, rf28}
+			}														OPTIONAL,	-- Need ON
+		rxParamsAddNeighFreq-r13		CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+				physCellId-r13					PhysCellIdList-r13
+			}
+		}															OPTIONAL,	-- Need ON
+		txParamsAddNeighFreq-r13		CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+				physCellId-r13					PhysCellIdList-r13,
+				p-Max							P-Max					OPTIONAL,	-- Need OP
+				tdd-Config-r13					TDD-Config				OPTIONAL,	-- Cond TDD-OR
+				tdd-Config-v1130				TDD-Config-v1130		OPTIONAL,	-- Cond TDD-OR
+				freqInfo							SEQUENCE {
+					ul-CarrierFreq						ARFCN-ValueEUTRA	OPTIONAL,	-- Need OP
+					ul-Bandwidth						ENUMERATED {n6, n15, n25, n50, n75, n100}
+																			OPTIONAL,	-- Need OP
+				additionalSpectrumEmission			AdditionalSpectrumEmission
+				},
+				referenceSignalPower				INTEGER (-60..50),
+				syncConfigIndex-r13				INTEGER (0..15)			OPTIONAL	-- Need OR
+			}
+		}															OPTIONAL	-- Need ON
+	]],
+	[[	txParamsAddNeighFreq-v1370		CHOICE {
+			release							NULL,
+			setup							SEQUENCE {
+				freqInfo-v1370					SEQUENCE {
+					additionalSpectrumEmission-v1370		AdditionalSpectrumEmission-v10l0
+				}
+			}
+		}															OPTIONAL	-- Need ON
+	]]
+}
+
+PhysCellIdList-r13	::=		SEQUENCE (SIZE (1.. maxSL-DiscCells-r13)) OF PhysCellId
+
+SL-PoolSelectionConfig-r12 ::=		SEQUENCE {
+	threshLow-r12							RSRP-RangeSL2-r12,
+	threshHigh-r12							RSRP-RangeSL2-r12
+}
+
+
+
+SL-DiscSysInfoReport-r13 ::=	SEQUENCE {
+	plmn-IdentityList-r13			PLMN-IdentityList			OPTIONAL,
+	cellIdentity-13					CellIdentity				OPTIONAL,
+	carrierFreqInfo-13				ARFCN-ValueEUTRA-r9			OPTIONAL,
+	discRxResources-r13				SL-DiscRxPoolList-r12		OPTIONAL,
+	discTxPoolCommon-r13			SL-DiscTxPoolList-r12		OPTIONAL,
+	discTxPowerInfo-r13				SL-DiscTxPowerInfoList-r12	OPTIONAL,
+	discSyncConfig-r13				SL-SyncConfigNFreq-r13		OPTIONAL,
+	discCellSelectionInfo-r13		SEQUENCE {
+		q-RxLevMin-r13					Q-RxLevMin,
+		q-RxLevMinOffset-r13			INTEGER (1..8)			OPTIONAL
+	}															OPTIONAL,
+	cellReselectionInfo-r13			SEQUENCE {
+		q-Hyst-r13						ENUMERATED {
+												dB0, dB1, dB2, dB3, dB4, dB5, dB6, dB8, dB10,
+												dB12, dB14, dB16, dB18, dB20, dB22, dB24},
+		q-RxLevMin-r13					Q-RxLevMin,
+		t-ReselectionEUTRA-r13			T-Reselection
+	}															OPTIONAL,
+	tdd-Config-r13					TDD-Config					OPTIONAL,
+	freqInfo-r13					SEQUENCE {
+		ul-CarrierFreq-r13				ARFCN-ValueEUTRA				OPTIONAL,	
+		ul-Bandwidth-r13				ENUMERATED {n6, n15, n25, n50, n75, n100}
+																		OPTIONAL,	
+		additionalSpectrumEmission-r13	AdditionalSpectrumEmission		OPTIONAL
+	}																OPTIONAL,
+	p-Max-r13						P-Max	OPTIONAL,
+	referenceSignalPower-r13		INTEGER (-60..50)	OPTIONAL,
+	...,
+	[[
+	freqInfo-v1370					SEQUENCE {
+		additionalSpectrumEmission-v1370	AdditionalSpectrumEmission-v10l0
+	}																OPTIONAL
+	]]
+}
+
+
+
+SL-DiscTxPowerInfoList-r12 ::=	SEQUENCE (SIZE (maxSL-DiscPowerClass-r12)) OF SL-DiscTxPowerInfo-r12
+
+SL-DiscTxPowerInfo-r12 ::=				SEQUENCE	{
+	discMaxTxPower-r12							P-Max,
+	...
+}
+
+
+
+SL-GapConfig-r13 ::=				SEQUENCE {
+	gapPatternList-r13				SL-GapPatternList-r13
+}
+
+SL-GapPatternList-r13 ::=	SEQUENCE (SIZE (1..maxSL-GP-r13)) OF SL-GapPattern-r13
+
+SL-GapPattern-r13 ::=				SEQUENCE {
+	gapPeriod-r13						ENUMERATED {sf40, sf60, sf70, sf80, sf120, sf140, sf160,
+											sf240, sf280, sf320, sf640, sf1280, sf2560, sf5120,
+											sf10240},
+	gapOffset-r12						SL-OffsetIndicator-r12,
+	gapSubframeBitmap-r13				BIT STRING (SIZE (1..10240)),
+	...
+}
+
+
+
+SL-GapRequest-r13 ::=				SEQUENCE (SIZE (1..maxFreq)) OF SL-GapFreqInfo-r13
+
+SL-GapFreqInfo-r13 ::=				SEQUENCE {
+	carrierFreq-r13					ARFCN-ValueEUTRA-r9					OPTIONAL,
+	gapPatternList-r13				SL-GapPatternList-r13
+}
+
+
+
+SL-HoppingConfigComm-r12 ::=		SEQUENCE	{
+	hoppingParameter-r12				INTEGER (0..504),
+	numSubbands-r12						ENUMERATED {ns1, ns2, ns4},
+	rb-Offset-r12						INTEGER (0..110)
+}
+
+SL-HoppingConfigDisc-r12 ::=	SEQUENCE	{
+	a-r12									INTEGER (1..200),
+	b-r12									INTEGER (1..10),
+	c-r12									ENUMERATED {n1, n5}
+}
+
+
+
+SL-InterFreqInfoListV2X-r14 ::=	SEQUENCE (SIZE (0..maxFreqV2X-1-r14)) OF SL-InterFreqInfoV2X-r14
+
+SL-InterFreqInfoV2X-r14 ::=		SEQUENCE {
+	plmn-IdentityList-r14				PLMN-IdentityList			OPTIONAL,		-- Need OP
+	v2x-CommCarrierFreq-r14			ARFCN-ValueEUTRA-r9,
+	sl-MaxTxPower-r14					P-Max				OPTIONAL,		-- Need OR
+	sl-Bandwidth-r14					ENUMERATED {n6, n15, n25, n50, n75, n100}	OPTIONAL,	-- Need OR
+	v2x-SchedulingPool-r14				SL-CommResourcePoolV2X-r14				OPTIONAL,	-- Need OR
+	v2x-UE-ConfigList-r14		SL-V2X-UE-ConfigList-r14	OPTIONAL,	-- Need OR
+	...,
+	[[	additionalSpectrumEmissionV2X-r14		CHOICE {
+			additionalSpectrumEmission-r14			AdditionalSpectrumEmission,
+			additionalSpectrumEmission-v1440		AdditionalSpectrumEmission-v10l0
+		}				OPTIONAL		-- Need ON
+	]],
+	[[	v2x-FreqSelectionConfigList-r15	SL-V2X-FreqSelectionConfigList-r15	OPTIONAL	--Need OR
+	]]
+}
+
+
+
+SL-NR-AnchorCarrierFreqList-r16 ::= SEQUENCE (SIZE (1..maxFreqSL-NR-r16)) OF ARFCN-ValueNR-r15
+
+
+
+SL-V2X-UE-ConfigList-r14 ::=	SEQUENCE (SIZE (1.. maxCellIntra)) OF SL-V2X-InterFreqUE-Config-r14
+
+SL-V2X-InterFreqUE-Config-r14 ::=		SEQUENCE {
+	physCellIdList-r14					PhysCellIdList-r13					OPTIONAL,	-- Need OR
+	typeTxSync-r14						SL-TypeTxSync-r14					OPTIONAL,	-- Need OR
+	v2x-SyncConfig-r14					SL-SyncConfigListNFreqV2X-r14		OPTIONAL,	-- Need OR
+	v2x-CommRxPool-r14					SL-CommRxPoolListV2X-r14				OPTIONAL,	-- Need OR
+	v2x-CommTxPoolNormal-r14				SL-CommTxPoolListV2X-r14				OPTIONAL,	-- Need OR
+	p2x-CommTxPoolNormal-r14				SL-CommTxPoolListV2X-r14				OPTIONAL,	-- Need OR
+	v2x-CommTxPoolExceptional-r14		SL-CommResourcePoolV2X-r14			OPTIONAL,	-- Need OR
+	v2x-ResourceSelectionConfig-r14		SL-CommTxPoolSensingConfig-r14		OPTIONAL,	-- Need OR
+	zoneConfig-r14						SL-ZoneConfig-r14					OPTIONAL,	-- Need OR
+	offsetDFN-r14						INTEGER (0..1000)					OPTIONAL,	-- Need OR
+	...
+}
+
+
+
+SL-OffsetIndicator-r12 ::=			CHOICE {
+	small-r12								INTEGER (0..319),
+	large-r12								INTEGER (0..10239)
+}
+
+SL-OffsetIndicatorSync-r12 ::=			INTEGER (0..39)
+
+SL-OffsetIndicatorSync-v1430 ::=		INTEGER (40..159)
+
+SL-OffsetIndicatorSync-r14 ::=			INTEGER (0..159)
+
+
+
+SL-P2X-ResourceSelectionConfig-r14 ::=			SEQUENCE {
+	partialSensing-r14				ENUMERATED {true}				OPTIONAL,	-- Need OR
+	randomSelection-r14				ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+
+
+SL-PeriodComm-r12 ::=					ENUMERATED {sf40, sf60, sf70, sf80, sf120, sf140,
+												sf160, sf240, sf280, sf320, spare6, spare5,
+												spare4, spare3, spare2, spare}
+
+
+
+SL-PriorityList-r13 ::=		SEQUENCE (SIZE (1..maxSL-Prio-r13)) OF SL-Priority-r13
+
+SL-Priority-r13 ::=			INTEGER (1..8)
+
+
+
+SL-PSSCH-TxConfigList-r14 ::=	SEQUENCE (SIZE (1..maxPSSCH-TxConfig-r14)) OF SL-PSSCH-TxConfig-r14
+
+SL-PSSCH-TxConfig-r14 ::=		SEQUENCE {
+	typeTxSync-r14				SL-TypeTxSync-r14		OPTIONAL,	-- Need OR
+	thresUE-Speed-r14			ENUMERATED {kmph60, kmph80, kmph100, kmph120,
+								kmph140, kmph160, kmph180, kmph200},
+	parametersAboveThres-r14	SL-PSSCH-TxParameters-r14,
+	parametersBelowThres-r14	SL-PSSCH-TxParameters-r14,
+	...,
+	[[	parametersAboveThres-v1530	SL-PSSCH-TxParameters-v1530		OPTIONAL,	-- Need OR
+		parametersBelowThres-v1530	SL-PSSCH-TxParameters-v1530		OPTIONAL	-- Need OR
+	]]
+}
+
+SL-PSSCH-TxParameters-r14 ::=		SEQUENCE {
+	minMCS-PSSCH-r14			INTEGER (0..31),
+	maxMCS-PSSCH-r14			INTEGER (0..31),
+	minSubChannel-NumberPSSCH-r14		INTEGER (1..20),
+	maxSubchannel-NumberPSSCH-r14		INTEGER (1..20),
+	allowedRetxNumberPSSCH-r14	ENUMERATED {n0, n1, both, spare1},
+	maxTxPower-r14				SL-TxPower-r14				OPTIONAL			-- Cond CBR
+}
+
+SL-PSSCH-TxParameters-v1530 ::=		SEQUENCE {
+	minMCS-PSSCH-r15			INTEGER (0..31),
+	maxMCS-PSSCH-r15			INTEGER (0..31)
+}
+
+
+
+SL-ReliabilityList-r15 ::=		SEQUENCE (SIZE (1..maxSL-Reliability-r15)) OF SL-Reliability-r15
+
+SL-Reliability-r15 ::=			INTEGER (1..8)
+
+
+
+SL-RestrictResourceReservationPeriodList-r14 ::=	SEQUENCE (SIZE (1..maxReservationPeriod-r14)) OF SL-RestrictResourceReservationPeriod-r14
+
+SL-RestrictResourceReservationPeriod-r14 ::=		ENUMERATED {v0dot2, v0dot5, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, spare4,spare3, spare2, spare1}
+
+
+
+SLSSID-r12 ::=					INTEGER (0..167)
+
+
+
+SL-SyncAllowed-r14 ::=		SEQUENCE {
+	gnss-Sync-r14						ENUMERATED {true}				OPTIONAL,	-- Need OR
+	enb-Sync-r14						ENUMERATED {true}				OPTIONAL,	-- Need OR
+	ue-Sync-r14							ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+
+
+SL-SyncConfigList-r12 ::=		SEQUENCE (SIZE (1..maxSL-SyncConfig-r12)) OF SL-SyncConfig-r12
+
+SL-SyncConfigListV2X-r14 ::=	SEQUENCE (SIZE (1.. maxSL-V2X-SyncConfig-r14)) OF SL-SyncConfig-r12
+
+SL-SyncConfig-r12 ::=					SEQUENCE {
+	syncCP-Len-r12							SL-CP-Len-r12,
+	syncOffsetIndicator-r12				SL-OffsetIndicatorSync-r12,
+	slssid-r12								SLSSID-r12,
+	txParameters-r12							SEQUENCE {
+		syncTxParameters-r12					SL-TxParameters-r12,
+		syncTxThreshIC-r12						RSRP-RangeSL-r12,
+		syncInfoReserved-r12						BIT STRING (SIZE (19))	OPTIONAL	-- Need OR
+	}																	OPTIONAL,	-- Need OR
+	rxParamsNCell-r12						SEQUENCE {
+		physCellId-r12							PhysCellId,
+		discSyncWindow-r12				ENUMERATED {w1, w2}
+	}																	OPTIONAL,	-- Need OR
+	...,
+	[[	syncTxPeriodic-r13					ENUMERATED {true}			OPTIONAL	-- Need OR
+	]],
+	[[	syncOffsetIndicator-v1430		SL-OffsetIndicatorSync-v1430	OPTIONAL,	-- Need OR
+		gnss-Sync-r14					ENUMERATED {true}				OPTIONAL	-- Need OR
+	]],
+	[[	syncOffsetIndicator2-r14		SL-OffsetIndicatorSync-r14	OPTIONAL,	-- Need OR
+		syncOffsetIndicator3-r14		SL-OffsetIndicatorSync-r14	OPTIONAL	-- Need OR
+	]],
+	[[	slss-TxDisabled-r15				ENUMERATED {true}				OPTIONAL	-- Need OR
+	]]
+}
+
+SL-SyncConfigListNFreq-r13 ::=		SEQUENCE (SIZE (1..maxSL-SyncConfig-r12)) OF SL-SyncConfigNFreq-r13
+
+SL-SyncConfigListNFreqV2X-r14 ::=		SEQUENCE (SIZE (1..maxSL-V2X-SyncConfig-r14)) OF SL-SyncConfigNFreq-r13
+
+SL-SyncConfigNFreq-r13 ::=			SEQUENCE {
+	asyncParameters-r13					SEQUENCE {
+		syncCP-Len-r13						SL-CP-Len-r12,
+		syncOffsetIndicator-r13				SL-OffsetIndicatorSync-r12,
+		slssid-r13							SLSSID-r12
+	}																OPTIONAL,	-- Need OR
+	txParameters-r13					SEQUENCE {
+		syncTxParameters-r13				SL-TxParameters-r12,
+		syncTxThreshIC-r13					RSRP-RangeSL-r12,
+		syncInfoReserved-r13					BIT STRING (SIZE (19))	OPTIONAL,	-- Need OR
+		syncTxPeriodic-r13					ENUMERATED {true}		OPTIONAL	-- Need OR
+	}																OPTIONAL,	-- Need OR
+	rxParameters-r13					SEQUENCE {
+		discSyncWindow-r13					ENUMERATED {w1, w2}
+	}																	OPTIONAL,	-- Need OR
+	...,
+	[[	syncOffsetIndicator-v1430		SL-OffsetIndicatorSync-v1430	OPTIONAL,	-- Need OR
+		gnss-Sync-r14					ENUMERATED {true}				OPTIONAL	-- Need OR
+	]],
+	[[	syncOffsetIndicator2-r14		SL-OffsetIndicatorSync-r14	OPTIONAL,	-- Need OR
+		syncOffsetIndicator3-r14		SL-OffsetIndicatorSync-r14	OPTIONAL	-- Need OR
+	]],
+	[[	slss-TxDisabled-r15				ENUMERATED {true}				OPTIONAL	-- Need OR
+	]]
+}
+
+
+
+SL-TF-ResourceConfig-r12 ::=		SEQUENCE	{
+	prb-Num-r12							INTEGER (1..100),
+	prb-Start-r12						INTEGER (0..99),
+	prb-End-r12							INTEGER (0..99),
+	offsetIndicator-r12					SL-OffsetIndicator-r12,
+	subframeBitmap-r12					SubframeBitmapSL-r12
+}
+
+SubframeBitmapSL-r12 ::=		CHOICE {
+	bs4-r12									BIT STRING (SIZE (4)),
+	bs8-r12									BIT STRING (SIZE (8)),
+	bs12-r12								BIT STRING (SIZE (12)),
+	bs16-r12								BIT STRING (SIZE (16)),
+	bs30-r12								BIT STRING (SIZE (30)),
+	bs40-r12								BIT STRING (SIZE (40)),
+	bs42-r12								BIT STRING (SIZE (42))
+}
+
+SubframeBitmapSL-r14 ::=		CHOICE {
+	bs10-r14								BIT STRING (SIZE (10)),
+	bs16-r14								BIT STRING (SIZE (16)),
+	bs20-r14								BIT STRING (SIZE (20)),
+	bs30-r14								BIT STRING (SIZE (30)),
+	bs40-r14								BIT STRING (SIZE (40)),
+	bs50-r14								BIT STRING (SIZE (50)),
+	bs60-r14								BIT STRING (SIZE (60)),
+	bs100-r14								BIT STRING (SIZE (100))
+}
+
+
+
+SL-TxPower-r14 ::=		CHOICE {
+	minusinfinity-r14				NULL,
+	txPower-r14						INTEGER (-41..31)
+}
+
+
+
+SL-TypeTxSync-r14 ::=		ENUMERATED {gnss, enb, ue}
+
+
+
+SL-ThresPSSCH-RSRP-List-r14 ::=	SEQUENCE (SIZE (64)) OF SL-ThresPSSCH-RSRP-r14
+
+SL-ThresPSSCH-RSRP-r14 ::=		INTEGER (0..66)
+
+
+
+SL-TxParameters-r12 ::=				SEQUENCE	{
+	alpha-r12								Alpha-r12,
+	p0-r12									P0-SL-r12
+}
+
+P0-SL-r12 ::=							INTEGER (-126..31)
+
+
+
+SL-TxPoolIdentity-r12 ::=			INTEGER (1.. maxSL-TxPool-r12)
+
+SL-TxPoolIdentity-v1310 ::=		INTEGER (maxSL-TxPool-r12Plus1-r13.. maxSL-TxPool-r13)
+
+SL-V2X-TxPoolIdentity-r14 ::=		INTEGER (1.. maxSL-V2X-TxPool-r14)
+
+
+
+SL-TxPoolToReleaseList-r12 ::=	SEQUENCE (SIZE (1..maxSL-TxPool-r12)) OF SL-TxPoolIdentity-r12
+
+SL-TxPoolToReleaseListExt-r13 ::=	SEQUENCE (SIZE (1..maxSL-TxPool-v1310)) OF SL-TxPoolIdentity-v1310
+
+
+
+SL-V2X-ConfigDedicated-r14 ::=				SEQUENCE	{
+	commTxResources-r14					CHOICE {
+		release								NULL,
+		setup								CHOICE {
+			scheduled-r14					SEQUENCE {
+				sl-V-RNTI-r14			C-RNTI,
+				mac-MainConfig-r14				MAC-MainConfigSL-r12,
+				v2x-SchedulingPool-r14			SL-CommResourcePoolV2X-r14	OPTIONAL,	-- Need ON
+				mcs-r14							INTEGER (0..31)				OPTIONAL,	-- Need OR
+				logicalChGroupInfoList-r14		LogicalChGroupInfoList-r13
+			},
+			ue-Selected-r14					SEQUENCE {
+				-- Pool for normal usage
+				v2x-CommTxPoolNormalDedicated-r14	SEQUENCE {
+					poolToReleaseList-r14	SL-TxPoolToReleaseListV2X-r14	OPTIONAL,	-- Need ON
+					poolToAddModList-r14		SL-TxPoolToAddModListV2X-r14		OPTIONAL,	-- Need ON
+					v2x-CommTxPoolSensingConfig-r14		SL-CommTxPoolSensingConfig-r14
+																			OPTIONAL	-- Need ON
+				}
+			}
+		}
+	}																		OPTIONAL,	-- Need ON
+	v2x-InterFreqInfoList-r14			SL-InterFreqInfoListV2X-r14			OPTIONAL,	-- Need ON
+	thresSL-TxPrioritization-r14			SL-Priority-r13						OPTIONAL,	-- Need OR
+	typeTxSync-r14						SL-TypeTxSync-r14					OPTIONAL,	-- Need OR
+	cbr-DedicatedTxConfigList-r14		SL-CBR-CommonTxConfigList-r14	OPTIONAL,	-- Need OR
+	...,
+	[[	commTxResources-v1530					CHOICE {
+			release								NULL,
+			setup								CHOICE {
+				scheduled-v1530					SEQUENCE {
+					logicalChGroupInfoList-v1530	LogicalChGroupInfoList-v1530	OPTIONAL,	-- Need OR
+					mcs-r15							INTEGER (0..31)			OPTIONAL	-- Need OR
+				},
+				ue-Selected-v1530				SEQUENCE {
+					v2x-FreqSelectionConfigList-r15	SL-V2X-FreqSelectionConfigList-r15	OPTIONAL	--Need OR
+				}
+			}
+		}																OPTIONAL,		-- Need ON
+		v2x-PacketDuplicationConfig-r15	SL-V2X-PacketDuplicationConfig-r15	OPTIONAL,	-- Need OR
+		syncFreqList-r15				SL-V2X-SyncFreqList-r15				OPTIONAL,	-- Need OR
+		slss-TxMultiFreq-r15			ENUMERATED {true}					OPTIONAL	-- Need OR
+	]],
+	[[
+		slss-TxDisabled-r15			ENUMERATED {true}					OPTIONAL	-- Need OR
+	]]
+}
+
+LogicalChGroupInfoList-v1530 ::=		SEQUENCE (SIZE (1..maxLCG-r13)) OF SL-ReliabilityList-r15
+
+SL-TxPoolToAddModListV2X-r14 ::=		SEQUENCE (SIZE (1.. maxSL-V2X-TxPool-r14)) OF SL-TxPoolToAddMod-r14
+
+SL-TxPoolToAddMod-r14 ::=		SEQUENCE	{
+	poolIdentity-r14					SL-V2X-TxPoolIdentity-r14,
+	pool-r14							SL-CommResourcePoolV2X-r14
+}
+
+SL-TxPoolToReleaseListV2X-r14 ::=	SEQUENCE (SIZE (1.. maxSL-V2X-TxPool-r14)) OF SL-V2X-TxPoolIdentity-r14
+
+
+
+SL-V2X-FreqSelectionConfigList-r15 ::=	SEQUENCE (SIZE (1..8)) OF SL-V2X-FreqSelectionConfig-r15
+
+SL-V2X-FreqSelectionConfig-r15 ::=				SEQUENCE {
+	priorityList-r15					SL-PriorityList-r13,
+	threshCBR-FreqReselection-r15		SL-CBR-r14			OPTIONAL,	-- Need OR
+	threshCBR-FreqKeeping-r15			SL-CBR-r14			OPTIONAL	-- Need OR
+}
+
+
+
+SL-V2X-PacketDuplicationConfig-r15 ::=	SEQUENCE {
+	threshSL-Reliability-r15		SL-Reliability-r15,
+	allowedCarrierFreqConfig-r15	SL-PPPR-Dest-CarrierFreqList-r15		OPTIONAL,	-- Need OR
+	...
+}
+
+SL-PPPR-Dest-CarrierFreqList-r15 ::=	SEQUENCE (SIZE (1..maxSL-Dest-r12)) OF SL-PPPR-Dest-CarrierFreq
+
+SL-PPPR-Dest-CarrierFreq ::=	SEQUENCE {
+	destinationInfoList-r15			SL-DestinationInfoList-r12		OPTIONAL,	-- Need OR
+	allowedCarrierFreqList-r15		SL-AllowedCarrierFreqList-r15			OPTIONAL	-- Need OR
+}
+
+SL-AllowedCarrierFreqList-r15 ::=	SEQUENCE {
+	allowedCarrierFreqSet1		SEQUENCE (SIZE (1..maxFreqV2X-r14)) OF ARFCN-ValueEUTRA-r9,
+	allowedCarrierFreqSet2		SEQUENCE (SIZE (1..maxFreqV2X-r14)) OF ARFCN-ValueEUTRA-r9
+}
+
+
+
+SL-V2X-SyncFreqList-r15 ::= SEQUENCE (SIZE (1..maxFreqV2X-r14)) OF ARFCN-ValueEUTRA-r9
+
+
+
+SL-ZoneConfig-r14 ::=		SEQUENCE {
+	zoneLength-r14	ENUMERATED { m5, m10, m20, m50, m100, m200, m500, spare1},
+	zoneWidth-r14	ENUMERATED { m5, m10, m20, m50, m100, m200, m500, spare1},
+	zoneIdLongiMod-r14	INTEGER (1..4),
+	zoneIdLatiMod-r14	INTEGER (1..4)
+}
+
+
+
+maxAccessCat-1-r15			INTEGER ::=	63	-- Maximum number of Access Categories - 1
+maxACDC-Cat-r13				INTEGER ::=	16	-- Maximum number of ACDC categories (per PLMN)
+maxAvailNarrowBands-r13		INTEGER ::=	16	-- Maximum number of narrowbands
+maxAvailNarrowBands-1-r16	INTEGER ::= 15	-- Maximum number of narrowbands minus one
+maxBandComb-r10				INTEGER ::=	128	-- Maximum number of band combinations.
+maxBandComb-r11				INTEGER ::=	256	-- Maximum number of additional band combinations.
+maxBandComb-r13				INTEGER ::=	384 -- Maximum number of band combinations in Rel-13
+maxBandCombSidelinkNR-r16	INTEGER ::=	512	-- Maximum number of NR sidelink band combinations
+maxBands					INTEGER ::= 64	-- Maximum number of bands listed in EUTRA UE caps
+maxBandsNR-r15				INTEGER ::= 1024	-- Maximum number of NR bands listed in EUTRA UE caps
+maxBandsENDC-r16			INTEGER ::= 10	-- Maximum number of NR bands from across all the PLMNs
+											-- sharing the serving cell in EN-DC for the forwarding
+											-- of upperLayerIndication.
+maxBandwidthClass-r10		INTEGER ::=	16	-- Maximum number of supported CA BW classes per band
+maxBandwidthCombSet-r10		INTEGER ::=	32	-- Maximum number of bandwidth combination sets per
+											-- supported band combination
+maxBarringInfoSet-r15		INTEGER ::= 8	-- Maximum number of UAC barring information sets
+maxBT-IdReport-r15			INTEGER ::= 32	-- Maximum number of Bluetooth IDs to report
+maxBT-Name-r15				INTEGER ::= 4	-- Maximum number of Bluetooth name
+maxCBR-Level-r14			INTEGER ::= 16	-- Maximum number of CBR levels
+maxCBR-Level-1-r14			INTEGER ::= 15
+maxCBR-Report-r14			INTEGER ::= 72	-- Maximum number of CBR results in a report
+maxCDMA-BandClass			INTEGER ::= 32	-- Maximum value of the CDMA band classes
+maxCE-Level-r13				INTEGER ::=	4	-- Maximum number of CE levels
+maxCellBlack				INTEGER ::= 16	-- Maximum number of blacklisted physical cell identity
+											-- ranges listed in SIB type 4 and 5
+maxCellHistory-r12			INTEGER ::= 16	-- Maximum number of visited EUTRA cells reported
+maxCellInfoGERAN-r9		INTEGER ::=	32	-- Maximum number of GERAN cells for which system in-
+											-- formation can be provided as redirection assistance
+maxCellInfoUTRA-r9			INTEGER ::=	16	-- Maximum number of UTRA cells for which system
+											-- information can be provided as redirection
+											-- assistance
+maxCellMeasIdle-r15			INTEGER ::= 8	-- Maximum number of neighbouring inter-frequency
+											-- cells per carrier measured in RRC_IDLE and RRC_INACTIVE
+maxCombIDC-r11				INTEGER ::= 128	-- Maximum number of reported UL CA or
+											-- MR-DC combinations
+maxCSI-IM-r11				INTEGER ::= 3	-- Maximum number of CSI-IM configurations
+											-- (per carrier frequency)
+maxCSI-IM-r12				INTEGER ::= 4	-- Maximum number of CSI-IM configurations
+											-- (per carrier frequency)
+minCSI-IM-r13				INTEGER ::= 5	-- Minimum number of CSI IM configurations from which
+											-- REL-13 extension is used
+maxCSI-IM-r13				INTEGER ::= 24	-- Maximum number of CSI-IM configurations
+											-- (per carrier frequency)
+maxCSI-IM-v1310				INTEGER ::= 20	-- Maximum number of additional CSI-IM configurations
+											-- (per carrier frequency)
+maxCSI-Proc-r11				INTEGER ::= 4	-- Maximum number of CSI processes (per carrier
+											-- frequency)
+maxCSI-RS-NZP-r11			INTEGER ::= 3	-- Maximum number of CSI RS resource
+											-- configurations using non-zero Tx power
+											-- (per carrier frequency)
+minCSI-RS-NZP-r13			INTEGER ::= 4	-- Minimum number of CSI RS resource from which
+											-- REL-13 extension is used
+maxCSI-RS-NZP-r13			INTEGER ::= 24	-- Maximum number of CSI RS resource
+											-- configurations using non-zero Tx power
+											-- (per carrier frequency)
+maxCSI-RS-NZP-v1310			INTEGER ::= 21	-- Maximum number of additional CSI RS resource
+											-- configurations using non-zero Tx power
+											-- (per carrier frequency)
+maxCSI-RS-ZP-r11			INTEGER ::= 4	-- Maximum number of CSI RS resource
+											-- configurations using zero Tx power(per carrier
+											-- frequency)
+maxCQI-ProcExt-r11			INTEGER ::= 3	-- Maximum number of additional periodic CQI
+											-- configurations (per carrier frequency)
+maxFreqUTRA-TDD-r10			INTEGER ::=	6	-- Maximum number of UTRA TDD carrier frequencies for
+											-- which system information can be provided as
+											-- redirection assistance
+maxCellInter				INTEGER ::= 16	-- Maximum number of neighbouring inter-frequency
+											-- cells listed in SIB type 5
+maxCellIntra				INTEGER ::= 16	-- Maximum number of neighbouring intra-frequency
+											-- cells listed in SIB type 4
+maxCellListGERAN			INTEGER ::= 3	-- Maximum number of lists of GERAN cells
+maxCellMeas					INTEGER ::= 32	-- Maximum number of entries in each of the
+											-- cell lists in a measurement object
+maxCellReport				INTEGER ::= 8	-- Maximum number of reported cells/CSI-RS resources
+maxCellSFTD				INTEGER ::= 3	-- Maximum number of cells for SFTD reporting
+maxCellWhiteNR-r16			INTEGER ::= 16	-- Maximum number of whitelisted NR cells in SIB24
+maxCondConfig-r16			INTEGER ::= 8	-- Maximum number of conditional configurations
+maxConfigSPS-r14			INTEGER ::= 8	-- Maximum number of simultaneous SPS configurations
+maxConfigSPS-r15			INTEGER ::= 6	-- Maximum number of simultaneous SPS configurations
+											-- configured with SPS C-RNTI
+maxCSI-RS-Meas-r12			INTEGER ::= 96	-- Maximum number of entries in the CSI-RS list
+											-- in a measurement object
+maxDRB						INTEGER ::= 11	-- Maximum number of Data Radio Bearers
+maxDRBExt-r15				INTEGER ::= 4	-- Maximum number of additional DRBs
+maxDRB-r15					INTEGER ::= 15	-- Highest value of extended maximum number of DRBs
+maxDS-Duration-r12			INTEGER ::= 5	-- Maximum number of subframes in a discovery signals
+											-- occasion
+maxDS-ZTP-CSI-RS-r12		INTEGER ::= 5	-- Maximum number of zero transmission power CSI-RS for
+											-- a serving cell concerning discovery signals
+maxEARFCN					INTEGER ::= 65535	-- Maximum value of EUTRA carrier frequency
+maxEARFCN-Plus1				INTEGER ::= 65536	-- Lowest value extended EARFCN range
+maxEARFCN2					INTEGER ::= 262143	-- Highest value extended EARFCN range
+maxEPDCCH-Set-r11			INTEGER ::= 2	-- Maximum number of EPDCCH sets
+maxFBI						INTEGER ::= 64	-- Maximum value of fequency band indicator
+maxFBI-NR-r15				INTEGER ::= 1024	-- Highest value FBI range for NR.
+maxFBI-Plus1				INTEGER ::= 65	-- Lowest value extended FBI range
+maxFBI2						INTEGER ::= 256	-- Highest value extended FBI range
+maxFeatureSets-r15			INTEGER ::= 256	-- Total number of feature sets (size of pool)
+maxPerCC-FeatureSets-r15	INTEGER ::= 32	-- Total number of CC-specific feature sets
+												-- (size of the pool)
+maxFreq						INTEGER ::= 8	-- Maximum number of carrier frequencies
+maxFreq-1-r16				INTEGER ::= 7	-- Maximum number of carrier frequencies
+maxFreqIDC-r11				INTEGER ::= 32	-- Maximum number of carrier frequencies that are
+											-- affected by the IDC problems
+maxFreqIdle-r15				INTEGER ::= 8	-- Maximum number of carrier frequencies for
+												-- IDLE mode measurements configured by eNB
+maxFreqMBMS-r11				INTEGER ::= 5	-- Maximum number of carrier frequencies for which an
+											-- MBMS capable UE may indicate an interest
+maxFreqNBIOT-r16			INTEGER ::= 8	-- Maximum number of NB-IoT carrier frequencies that can
+											-- be provided as assistance information for inter-RAT
+											-- cell selection
+maxFreqNR-r15				INTEGER ::= 5	-- Maximum number of NR carrier frequencies for
+											-- which a UE may provide measurement results upon
+											-- NR SCG failure
+maxFreqSL-NR-r16			INTEGER ::= 8	-- Maximum number of NR anchor carrier frequencies on
+											-- which configurations for V2X sidelink communication
+											-- are provided
+maxFreqV2X-r14				INTEGER ::= 8	-- Maximum number of carrier frequencies for which V2X
+											-- sidelink communication can be configured
+maxFreqV2X-1-r14			INTEGER ::= 7	-- Highest index of frequencies
+maxGERAN-SI					INTEGER ::= 10	-- Maximum number of GERAN SI blocks that can be
+											-- provided as part of NACC information
+maxGNFG						INTEGER ::= 16	-- Maximum number of GERAN neighbour freq groups
+maxGWUS-Groups-1-r16		INTEGER ::= 31	-- Maximum number of groups minus one for each
+											-- probability group
+maxGWUS-Resources-r16		INTEGER	::= 4	-- Maximum number of GWUS resources for each group
+maxGWUS-ProbThresholds-r16	INTEGER	::= 3	-- Maximum number of paging probability thresholds
+maxIdleMeasCarriers-r15		INTEGER ::= 3	-- Maximum number of neighbouring inter-
+											-- frequency carriers measured in RRC_IDLE and RRC_INACTIVE
+maxIdleMeasCarriersExt-r16		INTEGER ::= 5	--Additional number of neighbouring inter-
+											-- frequency carriers measured in RRC_IDLE and RRC_INACTIVE
+maxIdleMeasCarriers-r16		INTEGER ::= 8	-- Maximum number of neighbouring inter-
+												-- frequency/inter-RAT carriers measured in RRC_IDLE and RRC_INACTIVE
+maxLCG-r13					INTEGER ::= 4	-- Maximum number of logical channel groups
+maxLogMeasReport-r10		INTEGER ::= 520	-- Maximum number of logged measurement entries
+											-- that can be reported by the UE in one message
+maxMBSFN-Allocations		INTEGER ::= 8	-- Maximum number of MBSFN frame allocations with
+											-- different offset
+maxMBSFN-Area				INTEGER ::= 8
+maxMBSFN-Area-1				INTEGER ::= 7
+maxMBMS-ServiceListPerUE-r13	INTEGER ::= 15	-- Maximum number of services which the UE can
+										-- include in the MBMS interest indication
+maxMeasId					INTEGER ::= 32
+maxMeasId-Plus1				INTEGER ::= 33
+maxMeasId-r12				INTEGER ::= 64
+maxMultiBands				INTEGER ::= 8	-- Maximum number of additional frequency bands
+											-- that a cell belongs to
+maxMultiBandsNR-r15			INTEGER ::= 32	-- Maximum number of additional NR frequency bands
+											-- that a cell belongs to
+maxMultiBandsNR-1-r15		INTEGER ::= 31
+maxNS-Pmax-r10				INTEGER ::= 8	-- Maximum number of NS and P-Max values per band
+maxNAICS-Entries-r12		INTEGER ::= 8	-- Maximum number of supported NAICS combination(s)
+maxNeighCell-r12			INTEGER ::= 8	-- Maximum number of neighbouring cells in NAICS
+											-- configuration (per carrier frequency)
+maxNeighCell-SCPTM-r13		INTEGER ::= 8	-- Maximum number of SCPTM neighbour cells
+maxNrofPCI-PerSMTC-r16		INTEGER ::= 64  -- Maximum number of PCIs per SMTC
+maxNrofS-NSSAI-r15			INTEGER ::= 8	-- Maximum number of S-NSSAI
+maxObjectId					INTEGER ::= 32
+maxObjectId-Plus1-r13		INTEGER ::= 33
+maxObjectId-r13				INTEGER ::= 64
+maxP-a-PerNeighCell-r12		INTEGER ::= 3	-- Maximum number of power offsets for a neighbour cell
+											-- in NAICS configuration
+maxPageRec					INTEGER ::= 16	--
+maxPhysCellIdRange-r9		INTEGER ::= 4	-- Maximum number of physical cell identity ranges
+maxPLMN-r11					INTEGER ::=	6	-- Maximum number of PLMNs
+maxPLMN-1-r14				INTEGER ::=	5	-- Maximum number of PLMNs minus one
+maxPLMN-r15					INTEGER ::= 8	-- Maximum number of PLMNs for RNA configuration
+maxPLMN-NR-r15				INTEGER ::= 12	-- Maximum number of NR PLMNs
+maxPNOffset					INTEGER ::=	511	-- Maximum number of CDMA2000 PNOffsets
+maxPMCH-PerMBSFN			INTEGER ::= 15
+maxPSSCH-TxConfig-r14		INTEGER ::= 16	-- Maximum number of PSSCH TX configurations
+maxQuantSetsNR-r15			INTEGER ::= 2	-- Maximum number of NR quantity configuration sets
+maxQCI-r13					INTEGER ::= 6	-- Maximum number of QCIs
+maxRAT-Capabilities			INTEGER ::= 8	-- Maximum number of interworking RATs (incl EUTRA)
+maxRE-MapQCL-r11			INTEGER ::= 4	-- Maximum number of PDSCH RE Mapping configurations
+											-- (per carrier frequency)
+maxReportConfigId			INTEGER ::= 32
+maxReservationPeriod-r14	INTEGER ::= 16	-- Maximum number of resource reservation periodicities
+											-- for sidelink V2X communication
+maxRS-Index-r15				INTEGER ::= 64	-- Maximum number of RS indices
+maxRS-Index-1-r15			INTEGER ::= 63	-- Highest value of RS index as used to identify
+											-- RS index in RRM reports.
+maxRS-IndexCellQual-r15		INTEGER ::= 16	-- Maximum number of RS indices averaged to derive
+											-- cell quality for RRM.
+maxRS-IndexReport-r15		INTEGER ::= 32	-- Maximum number of RS indices for RRM.
+maxRSTD-Freq-r10			INTEGER ::= 3	-- Maximum number of frequency layers for RSTD
+											-- measurement
+maxSAI-MBMS-r11				INTEGER ::= 64	-- Maximum number of MBMS service area identities
+											-- broadcast per carrier frequency
+maxSCell-r10				INTEGER ::= 4	-- Maximum number of SCells
+maxSCell-r13				INTEGER ::= 31	-- Highest value of extended number range of SCells
+maxSCellGroups-r15			INTEGER ::= 4	-- Maximum number of SCell common parameter groups
+maxSC-MTCH-r13				INTEGER ::= 1023	-- Maximum number of SC-MTCHs in one cell
+maxSC-MTCH-BR-r14			INTEGER ::= 128	-- Maximum number of SC-MTCHs in one cell for feMTC
+maxSL-CommRxPoolNFreq-r13	INTEGER ::= 32	-- Maximum number of individual sidelink communication
+											-- Rx resource pools on neighbouring freq
+maxSL-CommRxPoolPreconf-v1310	INTEGER ::= 12	-- Maximum number of additional preconfigured
+												-- sidelink communication Rx resource pool entries
+maxSL-TxPool-r12Plus1-r13	INTEGER ::= 5	-- First additional individual sidelink
+												-- Tx resource pool
+maxSL-TxPool-v1310			INTEGER ::= 4	-- Maximum number of additional sidelink
+												-- Tx resource pool entries
+maxSL-TxPool-r13			INTEGER ::= 8	-- Maximum number of individual sidelink
+												-- Tx resource pools
+maxSL-CommTxPoolPreconf-v1310	INTEGER ::= 7	-- Maximum number of additional preconfigured
+												-- sidelink Tx resource pool entries
+maxSL-Dest-r12			INTEGER ::= 16			-- Maximum number of sidelink destinations
+maxSL-DiscCells-r13		INTEGER ::= 16			-- Maximum number of cells with similar sidelink
+												-- configurations
+maxSL-DiscPowerClass-r12	INTEGER ::= 3		-- Maximum number of sidelink power classes
+maxSL-DiscRxPoolPreconf-r13		INTEGER ::= 16	-- Maximum number of preconfigured sidelink
+												-- discovery Rx resource pool entries
+maxSL-DiscSysInfoReportFreq-r13	INTEGER ::= 8	-- Maximum number of frequencies to include in a
+												-- SidelinkUEInformation for SI reporting
+maxSL-DiscTxPoolPreconf-r13		INTEGER ::= 4	-- Maximum number of preconfigured sidelink
+												-- discovery Tx resource pool entries
+maxSL-GP-r13			INTEGER ::= 8	-- Maximum number of gap patterns that can be requested
+										-- for a frequency or assigned
+maxSL-PoolToMeasure-r14	INTEGER ::= 72	-- Maximum number of TX resource pools for CBR
+												-- measurement and report
+
+maxSL-Prio-r13			INTEGER ::= 8	-- Maximum number of entries in sidelink priority list
+maxSL-RxPool-r12			INTEGER ::= 16	-- Maximum number of individual sidelink Rx resource pools
+maxSL-Reliability-r15	INTEGER ::= 8	-- Maximum number of entries in sidelink reliability list
+maxSL-SyncConfig-r12		INTEGER ::= 16	-- Maximum number of sidelink Sync configurations
+maxSL-TF-IndexPair-r12	INTEGER ::= 64	-- Maximum number of sidelink Time Freq resource index
+											-- pairs
+maxSL-TxPool-r12			INTEGER ::= 4	-- Maximum number of individual sidelink Tx resource pools
+maxSL-V2X-RxPool-r14		INTEGER ::= 16	-- Maximum number of RX resource pools for
+												-- V2X sidelink communication
+maxSL-V2X-RxPoolPreconf-r14	INTEGER ::= 16		-- Maximum number of RX resource pools for
+												-- V2X sidelink communication
+maxSL-V2X-TxPool-r14		INTEGER ::= 8	-- Maximum number of TX resource pools for
+												-- V2X sidelink communication
+maxSL-V2X-TxPoolPreconf-r14	INTEGER ::= 8		-- Maximum number of TX resource pools for
+												-- V2X sidelink communication
+maxSL-V2X-SyncConfig-r14	INTEGER ::= 16	-- Maximum number of sidelink Sync configurations
+												-- for V2X sidelink communication
+maxSL-V2X-CBRConfig-r14		INTEGER ::= 4	-- Maximum number of CBR range configurations
+												-- for V2X sidelink communication congestion
+												-- control
+maxSL-V2X-CBRConfig-1-r14	INTEGER ::= 3
+maxSL-V2X-TxConfig-r14		INTEGER ::= 64	-- Maximum number of TX parameter configurations
+												-- for V2X sidelink communication congestion
+												-- control
+maxSL-V2X-TxConfig-1-r14	INTEGER ::= 63
+maxSL-V2X-CBRConfig2-r14		INTEGER ::= 8	-- Maximum number of CBR range configurations in
+												-- pre-configuration for V2X sidelink
+												-- communication congestion control
+maxSL-V2X-CBRConfig2-1-r14	INTEGER ::= 7
+maxSL-V2X-TxConfig2-r14		INTEGER ::= 128	-- Maximum number of TX parameter
+												-- configurations in pre-configuration for V2X
+												-- sidelink communication congestion control
+maxSL-V2X-TxConfig2-1-r14	INTEGER ::= 127
+maxSTAG-r11					INTEGER ::= 3	-- Maximum number of STAGs
+maxServCell-r10				INTEGER ::= 5	-- Maximum number of Serving cells
+maxServCell-r13				INTEGER ::= 32	-- Highest value of extended number range of Serving cells
+maxServCellNR-r15			INTEGER ::= 16	-- Maximum number of NR serving cells
+maxServiceCount			INTEGER ::= 16	-- Maximum number of MBMS services that can be included
+											-- in an MBMS counting request and response
+maxServiceCount-1			INTEGER ::= 15
+maxSessionPerPMCH			INTEGER ::= 29
+maxSessionPerPMCH-1			INTEGER ::= 28
+maxSIB						INTEGER ::= 32	-- Maximum number of SIBs
+maxSIB-1					INTEGER ::= 31
+maxSI-Message				INTEGER ::= 32	-- Maximum number of SI messages
+maxSimultaneousBands-r10	INTEGER ::= 64	-- Maximum number of simultaneously aggregated bands
+maxSubframePatternIDC-r11	INTEGER ::= 8	-- Maximum number of subframe reservation patterns
+											-- that the UE can simultaneously recommend to the
+											-- E-UTRAN for use.
+maxTrafficPattern-r14		INTEGER ::= 8	-- Maximum number of periodical traffic patterns
+											-- that the UE can simultaneously report to the
+											-- E-UTRAN.
+maxUTRA-FDD-Carrier			INTEGER ::= 16	-- Maximum number of UTRA FDD carrier frequencies
+maxUTRA-TDD-Carrier			INTEGER ::= 16	-- Maximum number of UTRA TDD carrier frequencies
+maxWayPoint-r15				INTEGER ::= 20	-- Maximum number of flight path information waypoints
+maxWLAN-Id-r12				INTEGER ::=	16	-- Maximum number of WLAN identifiers
+maxWLAN-Bands-r13			INTEGER ::= 8	-- Maximum number of WLAN bands
+maxWLAN-Id-r13				INTEGER ::= 32	-- Maximum number of WLAN identifiers
+maxWLAN-Channels-r13		INTEGER ::= 16	-- maximum number of WLAN channels used in
+											-- WLAN-CarrierInfo
+maxWLAN-CarrierInfo-r13	INTEGER ::= 8	-- Maximum number of WLAN Carrier Information
+maxWLAN-Id-Report-r14		INTEGER ::= 32	-- Maximum number of WLAN IDs to report
+maxWLAN-Name-r15			INTEGER ::= 4	-- Maximum number of WLAN name
+
+
+
+END
+
+
+
+PC5-RRC-Definitions DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+	TDD-ConfigSL-r12
+FROM EUTRA-RRC-Definitions;
+
+
+
+SBCCH-SL-BCH-Message ::= SEQUENCE {
+	message					SBCCH-SL-BCH-MessageType
+}
+
+SBCCH-SL-BCH-MessageType ::=						MasterInformationBlock-SL
+
+
+
+SBCCH-SL-BCH-Message-V2X-r14 ::= SEQUENCE {
+	message					SBCCH-SL-BCH-MessageType-V2X-r14
+}
+
+SBCCH-SL-BCH-MessageType-V2X-r14 ::=				MasterInformationBlock-SL-V2X-r14
+
+
+
+MasterInformationBlock-SL ::=		SEQUENCE {
+	sl-Bandwidth-r12					ENUMERATED {
+											n6, n15, n25, n50, n75, n100},
+	tdd-ConfigSL-r12					TDD-ConfigSL-r12,
+	directFrameNumber-r12				BIT STRING (SIZE (10)),
+	directSubframeNumber-r12			INTEGER (0..9),
+	inCoverage-r12						BOOLEAN,
+	reserved-r12						BIT STRING (SIZE (19))
+}
+
+
+
+
+MasterInformationBlock-SL-V2X-r14 ::=		SEQUENCE {
+	sl-Bandwidth-r14					ENUMERATED {
+											n6, n15, n25, n50, n75, n100},
+	tdd-ConfigSL-r14					TDD-ConfigSL-r12,
+	directFrameNumber-r14				BIT STRING (SIZE (10)),
+	directSubframeNumber-r14			INTEGER (0..9),
+	inCoverage-r14						BOOLEAN,
+	reserved-r14						BIT STRING (SIZE (27))
+}
+
+
+
+
+END
+
+
+
+NBIOT-RRC-Definitions DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+	RRCConnectionReestablishmentReject,
+	SecurityModeCommand,
+	SecurityModeComplete,
+	SecurityModeFailure,
+	AdditionalSpectrumEmission,
+	ARFCN-ValueEUTRA-r9,
+	CarrierFreqsGERAN,
+	CellGlobalIdEUTRA,
+	CellIdentity,
+	C-RNTI,
+	DedicatedInfoNAS,
+	DRB-Identity,
+	InitialUE-Identity,
+	IntraFreqBlackCellList,
+	IntraFreqNeighCellList,
+	I-RNTI-r15,
+	LocationInfo-r10,
+	maxAccessCat-1-r15,
+	maxBands,
+	maxCellBlack,
+	maxCellInter,
+	maxCellIntra,
+	maxFBI2,
+	maxFreq,
+	maxMultiBands,
+	maxNrofS-NSSAI-r15,
+	maxPageRec,
+	maxPLMN-r11,
+	maxSAI-MBMS-r11,
+	maxSIB,
+	maxSIB-1,
+	MBMS-SAI-r11,
+	MBMS-SAI-List-r11,
+	MBMSSessionInfo-r13,
+	NextHopChainingCount,
+	NG-5G-S-TMSI-r15,
+	PagingUE-Identity,
+	PLMN-Identity,
+	PLMN-IdentityList2,
+	P-Max,
+	PowerRampingParameters,
+	PreambleTransMax,
+	PhysCellId,
+	Q-OffsetRange,
+	Q-QualMin-r9,
+	Q-RxLevMin,
+	ReestabUE-Identity,
+	RegisteredAMF-r15,
+	RegisteredMME,
+	ReselectionThreshold,
+	ResumeIdentity-r13,
+	RRC-TransactionIdentifier,
+	RSRP-Range,
+	SetupRelease,
+	ShortMAC-I,
+	S-NSSAI-r15,
+	S-TMSI,
+	SystemInformationBlockType16-r11,
+	SystemInfoValueTagSI-r13,
+	T-Reordering,
+	TimeAlignmentTimer,
+	TimeSinceFailure-r11,
+	TMGI-r9,
+	TrackingAreaCode,
+	TrackingAreaCode-5GC-r15,
+	UAC-AC1-SelectAssistInfo-r15,
+	DataInactivityTimer-r14
+
+FROM EUTRA-RRC-Definitions;
+
+
+
+BCCH-BCH-Message-NB ::= SEQUENCE {
+	message					BCCH-BCH-MessageType-NB
+}
+
+
+BCCH-BCH-MessageType-NB::=	MasterInformationBlock-NB
+
+
+
+
+BCCH-BCH-Message-TDD-NB ::= SEQUENCE {
+	message					BCCH-BCH-MessageType-TDD-NB-r15
+}
+
+
+BCCH-BCH-MessageType-TDD-NB-r15 ::=	MasterInformationBlock-TDD-NB-r15
+
+
+
+BCCH-DL-SCH-Message-NB ::= SEQUENCE {
+	message					BCCH-DL-SCH-MessageType-NB
+}
+
+BCCH-DL-SCH-MessageType-NB ::= CHOICE {
+	c1						CHOICE {
+		systemInformation-r13				SystemInformation-NB,
+		systemInformationBlockType1-r13		SystemInformationBlockType1-NB
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+PCCH-Message-NB ::= SEQUENCE {
+	message					PCCH-MessageType-NB
+}
+
+PCCH-MessageType-NB ::= CHOICE {
+	c1						CHOICE {
+		paging-r13							Paging-NB
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+DL-CCCH-Message-NB ::= SEQUENCE {
+	message					DL-CCCH-MessageType-NB
+}
+
+DL-CCCH-MessageType-NB ::= CHOICE {
+	c1						CHOICE {
+		rrcConnectionReestablishment-r13		RRCConnectionReestablishment-NB,
+		rrcConnectionReestablishmentReject-r13	RRCConnectionReestablishmentReject,
+		rrcConnectionReject-r13					RRCConnectionReject-NB,
+		rrcConnectionSetup-r13					RRCConnectionSetup-NB,
+		rrcEarlyDataComplete-r15				RRCEarlyDataComplete-NB-r15,
+		spare3 NULL, spare2 NULL, spare1 NULL
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+DL-DCCH-Message-NB ::= SEQUENCE {
+	message					DL-DCCH-MessageType-NB
+}
+
+DL-DCCH-MessageType-NB ::= CHOICE {
+	c1						CHOICE {
+		dlInformationTransfer-r13				DLInformationTransfer-NB,
+		rrcConnectionReconfiguration-r13		RRCConnectionReconfiguration-NB,
+		rrcConnectionRelease-r13				RRCConnectionRelease-NB,
+		securityModeCommand-r13					SecurityModeCommand,
+		ueCapabilityEnquiry-r13					UECapabilityEnquiry-NB,
+		rrcConnectionResume-r13					RRCConnectionResume-NB,
+		ueInformationRequest-r16				UEInformationRequest-NB-r16,
+		spare1 NULL
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+
+UL-CCCH-Message-NB ::= SEQUENCE {
+	message					UL-CCCH-MessageType-NB
+}
+
+UL-CCCH-MessageType-NB ::= CHOICE {
+	c1						CHOICE {
+		rrcConnectionReestablishmentRequest-r13	RRCConnectionReestablishmentRequest-NB,
+		rrcConnectionRequest-r13				RRCConnectionRequest-NB,
+		rrcConnectionResumeRequest-r13			RRCConnectionResumeRequest-NB,
+		rrcEarlyDataRequest-r15				RRCEarlyDataRequest-NB-r15
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+SC-MCCH-Message-NB ::= SEQUENCE {
+	message					SC-MCCH-MessageType-NB
+}
+
+
+SC-MCCH-MessageType-NB ::= CHOICE {
+	c1						CHOICE {
+		scptmConfiguration-r14						SCPTMConfiguration-NB-r14
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+UL-DCCH-Message-NB ::= SEQUENCE {
+	message					UL-DCCH-MessageType-NB
+}
+
+UL-DCCH-MessageType-NB ::= CHOICE {
+	c1						CHOICE {
+		rrcConnectionReconfigurationComplete-r13	RRCConnectionReconfigurationComplete-NB,
+		rrcConnectionReestablishmentComplete-r13	RRCConnectionReestablishmentComplete-NB,
+		rrcConnectionSetupComplete-r13				RRCConnectionSetupComplete-NB,
+		securityModeComplete-r13					SecurityModeComplete,
+		securityModeFailure-r13						SecurityModeFailure,
+		ueCapabilityInformation-r13					UECapabilityInformation-NB,
+		ulInformationTransfer-r13					ULInformationTransfer-NB,
+		rrcConnectionResumeComplete-r13				RRCConnectionResumeComplete-NB,
+		ueInformationResponse-r16					UEInformationResponse-NB-r16,
+		purConfigurationRequest-r16					PURConfigurationRequest-NB-r16,
+		spare6 NULL, spare5 NULL, spare4 NULL,
+		spare3 NULL, spare2 NULL, spare1 NULL
+	},
+	messageClassExtension	SEQUENCE {}
+}
+
+
+
+DLInformationTransfer-NB ::=	SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			dlInformationTransfer-r13		DLInformationTransfer-NB-r13-IEs,
+			spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+DLInformationTransfer-NB-r13-IEs ::=	SEQUENCE {
+	dedicatedInfoNAS-r13					DedicatedInfoNAS,
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}						OPTIONAL
+}
+
+
+
+MasterInformationBlock-NB ::=	SEQUENCE {
+	systemFrameNumber-MSB-r13		BIT STRING (SIZE (4)),
+	hyperSFN-LSB-r13				BIT STRING (SIZE (2)),
+	schedulingInfoSIB1-r13			INTEGER (0..15),
+	systemInfoValueTag-r13			INTEGER (0..31),
+	ab-Enabled-r13					BOOLEAN,
+	operationModeInfo-r13			CHOICE {
+		inband-SamePCI-r13				Inband-SamePCI-NB-r13,
+		inband-DifferentPCI-r13			Inband-DifferentPCI-NB-r13,
+		guardband-r13					Guardband-NB-r13,
+		standalone-r13					Standalone-NB-r13
+	},
+	additionalTransmissionSIB1-r15	BOOLEAN,
+	ab-Enabled-5GC-r16				BOOLEAN,
+	spare							BIT STRING (SIZE (9))
+}
+
+Guardband-NB-r13 ::=			SEQUENCE {
+	rasterOffset-r13				ChannelRasterOffset-NB-r13,
+	spare							BIT STRING (SIZE (3))
+}
+
+Inband-SamePCI-NB-r13 ::=		SEQUENCE {
+	eutra-CRS-SequenceInfo-r13		INTEGER (0..31)
+}
+
+Inband-DifferentPCI-NB-r13 ::=	SEQUENCE {
+	eutra-NumCRS-Ports-r13			ENUMERATED {same, four},
+	rasterOffset-r13				ChannelRasterOffset-NB-r13,
+	spare							BIT STRING (SIZE (2))
+}
+
+Standalone-NB-r13 ::=			SEQUENCE {
+	spare							BIT STRING (SIZE (5))
+}
+
+
+
+MasterInformationBlock-TDD-NB-r15 ::=	SEQUENCE {
+	systemFrameNumber-MSB-r15				BIT STRING (SIZE (4)),
+	hyperSFN-LSB-r15						BIT STRING (SIZE (2)),
+	schedulingInfoSIB1-r15					INTEGER (0..15),
+	systemInfoValueTag-r15					INTEGER (0..31),
+	ab-Enabled-r15							BOOLEAN,
+	operationModeInfo-r15				CHOICE {
+		inband-SamePCI-r15					Inband-SamePCI-TDD-NB-r15,
+		inband-DifferentPCI-r15				Inband-DifferentPCI-TDD-NB-r15,
+		guardband-r15						GuardbandTDD-NB-r15,
+		standalone-r15						StandaloneTDD-NB-r15
+	},
+	sib1-CarrierInfo-r15					ENUMERATED {anchor, non-anchor},
+	ab-Enabled-5GC-r16						BOOLEAN,
+	spare									BIT STRING (SIZE (8))
+}
+
+GuardbandTDD-NB-r15 ::=				SEQUENCE {
+	rasterOffset-r15					ChannelRasterOffset-NB-r13,
+	sib-GuardbandInfo-r15				CHOICE {
+		sib-GuardbandAnchor-r15				SIB-GuardbandAnchorTDD-NB-r15,
+		sib-GuardbandGuardband-r15			SIB-GuardbandGuardbandTDD-NB-r15,
+		sib-GuardbandInbandSamePCI-r15		SIB-GuardbandInbandSamePCI-TDD-NB-r15,
+		sib-GuardbandinbandDiffPCI-r15		SIB-GuardbandInbandDiffPCI-TDD-NB-r15
+	},	
+	eutra-Bandwitdh-r15					ENUMERATED {bw5or10, bw15or20}
+}
+
+Inband-SamePCI-TDD-NB-r15 ::=		SEQUENCE {
+	eutra-CRS-SequenceInfo-r15			INTEGER (0..31),
+	sib-InbandLocation-r15				ENUMERATED {lower, higher}
+}
+
+Inband-DifferentPCI-TDD-NB-r15 ::=		SEQUENCE {
+	eutra-NumCRS-Ports-r15					ENUMERATED {same, four},
+	rasterOffset-r15						ChannelRasterOffset-NB-r13,
+	sib-InbandLocation-r15					ENUMERATED {lower, higher},
+	spare									BIT STRING (SIZE (2))
+}
+
+StandaloneTDD-NB-r15 ::=				SEQUENCE {
+	sib-StandaloneLocation-r15				ENUMERATED {lower, higher},
+	spare									BIT STRING (SIZE (5))
+}
+
+SIB-GuardbandAnchorTDD-NB-r15 ::=		SEQUENCE {
+	spare									BIT STRING (SIZE (1))
+}
+
+SIB-GuardbandGuardbandTDD-NB-r15 ::=	SEQUENCE {
+	sib-GuardbandGuardbandLocation-r15		ENUMERATED {same, opposite}
+}
+
+SIB-GuardbandInbandSamePCI-TDD-NB-r15 ::= SEQUENCE {
+	spare									BIT STRING (SIZE (1))
+}
+
+SIB-GuardbandInbandDiffPCI-TDD-NB-r15 ::= SEQUENCE {
+	sib-EUTRA-NumCRS-Ports-r15				ENUMERATED {same, four}
+}
+
+
+
+Paging-NB ::=						SEQUENCE {
+	pagingRecordList-r13				PagingRecordList-NB-r13		OPTIONAL,	-- Need ON
+	systemInfoModification-r13			ENUMERATED {true}				OPTIONAL,	-- Need ON
+	systemInfoModification-eDRX-r13		ENUMERATED {true}				OPTIONAL,	-- Need ON
+	nonCriticalExtension				Paging-NB-v1610-IEs				OPTIONAL
+}
+
+Paging-NB-v1610-IEs	::=				SEQUENCE {
+	pagingRecordList-v1610				PagingRecordList-NB-v1610		OPTIONAL,	-- Need ON
+	nonCriticalExtension 				SEQUENCE {}						OPTIONAL
+}
+
+PagingRecordList-NB-r13 ::=			SEQUENCE (SIZE (1..maxPageRec)) OF PagingRecord-NB-r13
+
+PagingRecordList-NB-v1610 ::=		SEQUENCE (SIZE (1..maxPageRec)) OF PagingRecord-NB-v1610
+
+PagingRecord-NB-r13 ::=				SEQUENCE {
+	ue-Identity-r13						PagingUE-Identity,
+	...
+}
+
+PagingRecord-NB-v1610 ::=			SEQUENCE {
+	mt-EDT-r16							ENUMERATED {true}			OPTIONAL	-- Need ON
+}
+
+
+
+PURConfigurationRequest-NB-r16 ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		purConfigurationRequest-r16			PURConfigurationRequest-NB-r16-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+PURConfigurationRequest-NB-r16-IEs ::=	SEQUENCE {
+	pur-ConfigRequest-r16					PUR-ConfigRequest-NB-r16			OPTIONAL,
+	lateNonCriticalExtension				OCTET STRING						OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}							OPTIONAL
+}
+
+PUR-ConfigRequest-NB-r16 ::=		CHOICE{
+	pur-ReleaseRequest					NULL,
+	pur-SetupRequest					SEQUENCE {
+		requestedNumOccasions-r16			ENUMERATED {one, infinite},
+		requestedPeriodicityAndOffset-r16	PUR-PeriodicityAndOffset-NB-r16,
+		requestedTBS-r16					ENUMERATED {b328, b376, b424, b472, b504, b552, b584,
+														b616, b680, b744, b776, b808, b872, b904,
+														b936, b968, b1000, b1032, b1096, b1128,
+														b1192, b1224, b1256, b1352, b1384, b1544,
+														b1608, b1736, b1800, b2024, b2280, b2536},
+		rrc-ACK-r16							ENUMERATED {true}					OPTIONAL
+	}
+}
+
+
+
+RRCConnectionReconfiguration-NB ::=	SEQUENCE {
+	rrc-TransactionIdentifier				RRC-TransactionIdentifier,
+	criticalExtensions						CHOICE {
+		c1										CHOICE{
+			rrcConnectionReconfiguration-r13		RRCConnectionReconfiguration-NB-r13-IEs,
+			spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReconfiguration-NB-r13-IEs ::= SEQUENCE {
+	dedicatedInfoNASList-r13			SEQUENCE (SIZE(1..maxDRB-NB-r13)) OF
+													DedicatedInfoNAS		OPTIONAL,	-- Need ON
+	radioResourceConfigDedicated-r13	RadioResourceConfigDedicated-NB-r13	OPTIONAL,	-- Need ON
+	fullConfig-r13						ENUMERATED {true}					OPTIONAL,	-- Cond Reestab
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}	OPTIONAL
+}
+
+
+
+RRCConnectionReconfigurationComplete-NB ::= SEQUENCE {
+	rrc-TransactionIdentifier				RRC-TransactionIdentifier,
+	criticalExtensions						CHOICE {
+		rrcConnectionReconfigurationComplete-r13	RRCConnectionReconfigurationComplete-NB-r13-IEs,
+		criticalExtensionsFuture					SEQUENCE {}
+	}
+}
+
+RRCConnectionReconfigurationComplete-NB-r13-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+
+
+
+RRCConnectionReestablishment-NB ::=	SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			rrcConnectionReestablishment-r13	RRCConnectionReestablishment-NB-r13-IEs,
+			spare1	NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReestablishment-NB-r13-IEs ::= SEQUENCE {
+	radioResourceConfigDedicated-r13			RadioResourceConfigDedicated-NB-r13,
+	nextHopChainingCount-r13					NextHopChainingCount,
+	lateNonCriticalExtension					OCTET STRING						OPTIONAL,
+	nonCriticalExtension						RRCConnectionReestablishment-NB-v1430-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishment-NB-v1430-IEs ::=	SEQUENCE {
+	dl-NAS-MAC							BIT STRING (SIZE (16))	OPTIONAL,	-- Cond Reestablish-CP
+	nonCriticalExtension				SEQUENCE {}				OPTIONAL
+}
+
+
+
+RRCConnectionReestablishmentComplete-NB ::= SEQUENCE {
+	rrc-TransactionIdentifier				RRC-TransactionIdentifier,
+	criticalExtensions						CHOICE {
+		rrcConnectionReestablishmentComplete-r13	RRCConnectionReestablishmentComplete-NB-r13-IEs,
+		criticalExtensionsFuture					SEQUENCE {}
+	}
+}
+
+RRCConnectionReestablishmentComplete-NB-r13-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				RRCConnectionReestablishmentComplete-NB-v1470-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-NB-v1470-IEs ::= SEQUENCE {
+	measResultServCell-r14			MeasResultServCell-NB-r14		OPTIONAL,
+	nonCriticalExtension			RRCConnectionReestablishmentComplete-NB-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionReestablishmentComplete-NB-v1610-IEs ::= SEQUENCE {
+	rlf-InfoAvailable-r16				ENUMERATED {true}				OPTIONAL,
+	anr-InfoAvailable-r16				ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+
+RRCConnectionReestablishmentRequest-NB ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcConnectionReestablishmentRequest-r13
+											RRCConnectionReestablishmentRequest-NB-r13-IEs,
+		later								CHOICE {
+			rrcConnectionReestablishmentRequest-r14
+											RRCConnectionReestablishmentRequest-NB-r14-IEs,
+			later							CHOICE {
+				rrcConnectionReestablishmentRequest-r16
+											RRCConnectionReestablishmentRequest-5GC-NB-r16-IEs,
+				criticalExtensionsFuture	SEQUENCE {}
+			}
+		}
+	}
+}
+
+RRCConnectionReestablishmentRequest-NB-r13-IEs ::= SEQUENCE {
+	ue-Identity-r13						ReestabUE-Identity,
+	reestablishmentCause-r13			ReestablishmentCause-NB-r13,
+	cqi-NPDCCH-r14						CQI-NPDCCH-NB-r14,
+	earlyContentionResolution-r14		BOOLEAN,
+	spare								BIT STRING (SIZE (20))
+}
+
+RRCConnectionReestablishmentRequest-NB-r14-IEs ::= SEQUENCE {
+	ue-Identity-r14						ReestabUE-Identity-CP-NB-r14,
+	reestablishmentCause-r14			ReestablishmentCause-NB-r13,
+	cqi-NPDCCH-r14						CQI-NPDCCH-Short-NB-r14,
+	earlyContentionResolution-r14		BOOLEAN,
+	spare								BIT STRING (SIZE (1))
+}
+
+RRCConnectionReestablishmentRequest-5GC-NB-r16-IEs ::= SEQUENCE {
+	ue-Identity-r16						ReestabUE-Identity-CP-5GC-NB-r16,
+	reestablishmentCause-r16			ReestablishmentCause-NB-r13,
+	cqi-NPDCCH-r16						CQI-NPDCCH-Short-NB-r14,
+	spare								BIT STRING (SIZE (1))
+}
+
+ReestablishmentCause-NB-r13 ::=			ENUMERATED {
+											reconfigurationFailure, otherFailure,
+											spare2, spare1}
+
+ReestabUE-Identity-CP-NB-r14 ::=		SEQUENCE {
+	s-TMSI-r14								S-TMSI,
+	ul-NAS-MAC-r14							BIT STRING (SIZE (16)),
+	ul-NAS-Count-r14						BIT STRING (SIZE (5))
+}
+
+ReestabUE-Identity-CP-5GC-NB-r16 ::=	SEQUENCE {
+	truncated5G-S-TMSI-r16					BIT STRING (SIZE (40)),
+	ul-NAS-MAC-r16							BIT STRING (SIZE (16)),
+	ul-NAS-Count-r16						BIT STRING (SIZE (5))
+}
+
+
+
+RRCConnectionReject-NB ::=				SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			rrcConnectionReject-r13				RRCConnectionReject-NB-r13-IEs,
+			spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionReject-NB-r13-IEs ::=		SEQUENCE {
+	extendedWaitTime-r13					INTEGER (1..1800),
+	rrc-SuspendIndication-r13				ENUMERATED {true}			OPTIONAL,	-- Need ON
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}					OPTIONAL
+}
+
+
+
+RRCConnectionRelease-NB ::=		SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			rrcConnectionRelease-r13			RRCConnectionRelease-NB-r13-IEs,
+			spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionRelease-NB-r13-IEs ::=	SEQUENCE {
+	releaseCause-r13					ReleaseCause-NB-r13,
+	resumeIdentity-r13					ResumeIdentity-r13				OPTIONAL,	-- Need OR
+	extendedWaitTime-r13				INTEGER (1..1800)				OPTIONAL,	-- Need ON
+	redirectedCarrierInfo-r13			RedirectedCarrierInfo-NB-r13	OPTIONAL,	-- Need ON
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				RRCConnectionRelease-NB-v1430-IEs		OPTIONAL
+}
+
+RRCConnectionRelease-NB-v1430-IEs ::=	SEQUENCE {
+	redirectedCarrierInfo-v1430			RedirectedCarrierInfo-NB-v1430	OPTIONAL,	-- Cond Redirection
+	extendedWaitTime-CPdata-r14		INTEGER (1..1800)	OPTIONAL,	-- Cond NoExtendedWaitTime
+	nonCriticalExtension				RRCConnectionRelease-NB-v1530-IEs	OPTIONAL
+}
+
+RRCConnectionRelease-NB-v1530-IEs ::=	SEQUENCE {
+	drb-ContinueROHC-r15					ENUMERATED {true}			OPTIONAL,	-- Cond UP-EDT
+	nextHopChainingCount-r15				NextHopChainingCount		OPTIONAL,	-- Cond EarlySec
+	nonCriticalExtension				RRCConnectionRelease-NB-v1550-IEs	OPTIONAL
+}
+
+RRCConnectionRelease-NB-v1550-IEs ::=	SEQUENCE {
+	redirectedCarrierInfo-v1550			RedirectedCarrierInfo-NB-v1550	OPTIONAL,	-- Cond Redirection-TDD
+	nonCriticalExtension				RRCConnectionRelease-NB-v15b0-IEs	OPTIONAL
+}
+
+RRCConnectionRelease-NB-v15b0-IEs ::=	SEQUENCE {
+	noLastCellUpdate-r15					ENUMERATED {true} 		OPTIONAL,	-- Need OP
+	nonCriticalExtension					RRCConnectionRelease-NB-v1610-IEs		OPTIONAL
+}
+
+RRCConnectionRelease-NB-v1610-IEs ::=	SEQUENCE {
+	resumeIdentity-r16						I-RNTI-r15					OPTIONAL,	-- Need OR
+	anr-MeasConfig-r16						ANR-MeasConfig-NB-r16		OPTIONAL,	-- Need OP
+	pur-Config-r16							SetupRelease {PUR-Config-NB-r16}
+																		OPTIONAL,	-- Need ON
+	nonCriticalExtension					SEQUENCE {}		OPTIONAL
+}
+
+ReleaseCause-NB-r13 ::=					ENUMERATED {loadBalancingTAUrequired, other,
+													rrc-Suspend, spare1}
+RedirectedCarrierInfo-NB-r13::=			CarrierFreq-NB-r13
+
+RedirectedCarrierInfo-NB-v1430	::=		SEQUENCE {
+	redirectedCarrierOffsetDedicated-r14	ENUMERATED{
+												dB1, dB2, dB3, dB4, dB5, dB6, dB8, dB10,
+												dB12, dB14, dB16, dB18, dB20, dB22, dB24, dB26},
+	t322-r14								ENUMERATED{
+												min5, min10, min20, min30, min60, min120, min180,
+												spare1}
+}
+
+RedirectedCarrierInfo-NB-v1550::=		CarrierFreq-NB-v1550
+
+
+
+RRCConnectionRequest-NB ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcConnectionRequest-r13			RRCConnectionRequest-NB-r13-IEs,
+		later								CHOICE {
+			rrcConnectionRequest-r16			RRCConnectionRequest-5GC-NB-r16-IEs,
+			criticalExtensionsFuture			SEQUENCE {}
+		}
+	}
+}
+
+RRCConnectionRequest-NB-r13-IEs ::=		SEQUENCE {
+	ue-Identity-r13							InitialUE-Identity,
+	establishmentCause-r13					EstablishmentCause-NB-r13,
+	multiToneSupport-r13					ENUMERATED {true}				OPTIONAL,
+	multiCarrierSupport-r13					ENUMERATED {true}				OPTIONAL,
+	earlyContentionResolution-r14			BOOLEAN,
+	cqi-NPDCCH-r14							CQI-NPDCCH-NB-r14,
+	spare									BIT STRING (SIZE (17))
+}
+
+RRCConnectionRequest-5GC-NB-r16-IEs ::=	SEQUENCE {
+	ue-Identity-r16							InitialUE-Identity-5GC-NB-r16,
+	establishmentCause-r16					ENUMERATED {
+												mt-Access, mo-Signalling, mo-Data, mo-ExceptionData,
+												spare4, spare3, spare2, spare1},
+	cqi-NPDCCH-r16							CQI-NPDCCH-NB-r14,
+	spare									BIT STRING (SIZE (11))
+}
+
+InitialUE-Identity-5GC-NB-r16 ::=		CHOICE {
+	ng-5G-S-TMSI-r16						NG-5G-S-TMSI-r15,
+	randomValue								BIT STRING (SIZE (48))
+}
+
+
+
+RRCConnectionResume-NB ::=		SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			rrcConnectionResume-r13				RRCConnectionResume-NB-r13-IEs,
+			spare1								NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionResume-NB-r13-IEs ::=		SEQUENCE {
+	radioResourceConfigDedicated-r13		RadioResourceConfigDedicated-NB-r13	OPTIONAL,		-- Need ON
+	nextHopChainingCount-r13				NextHopChainingCount,
+	drb-ContinueROHC-r13					ENUMERATED {true}				OPTIONAL,	-- Need OP
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					RRCConnectionResume-NB-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionResume-NB-v1610-IEs ::=	SEQUENCE {
+	fullConfig-r16							ENUMERATED {true}		OPTIONAL,	-- Cond 5GC
+	nonCriticalExtension					SEQUENCE {}				OPTIONAL
+}
+
+
+
+RRCConnectionResumeComplete-NB ::= SEQUENCE {
+	rrc-TransactionIdentifier				RRC-TransactionIdentifier,
+	criticalExtensions							CHOICE {
+		rrcConnectionResumeComplete-r13				RRCConnectionResumeComplete-NB-r13-IEs,
+		criticalExtensionsFuture					SEQUENCE {}
+	}
+}
+
+RRCConnectionResumeComplete-NB-r13-IEs ::= SEQUENCE {
+	selectedPLMN-Identity-r13					INTEGER (1..maxPLMN-r11)	OPTIONAL,
+	dedicatedInfoNAS-r13						DedicatedInfoNAS	OPTIONAL,
+	lateNonCriticalExtension					OCTET STRING					OPTIONAL,
+	nonCriticalExtension						RRCConnectionResumeComplete-NB-v1470-IEs	OPTIONAL
+}
+
+RRCConnectionResumeComplete-NB-v1470-IEs ::= SEQUENCE {
+	measResultServCell-r14						MeasResultServCell-NB-r14	OPTIONAL,
+	nonCriticalExtension						RRCConnectionResumeComplete-NB-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionResumeComplete-NB-v1610-IEs ::= SEQUENCE {
+	rlf-InfoAvailable-r16				ENUMERATED {true}				OPTIONAL,
+	anr-InfoAvailable-r16				ENUMERATED {true}				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+
+
+RRCConnectionResumeRequest-NB ::=	SEQUENCE {
+	criticalExtensions						CHOICE {
+		rrcConnectionResumeRequest-r13			RRCConnectionResumeRequest-NB-r13-IEs,
+		later									CHOICE {
+			rrcConnectionResumeRequest-r16			RRCConnectionResumeRequest-5GC-NB-r16-IEs,
+			criticalExtensionsFuture				SEQUENCE {}
+		}
+	}
+}
+
+RRCConnectionResumeRequest-NB-r13-IEs ::=	SEQUENCE {
+	resumeID-r13								ResumeIdentity-r13,
+	shortResumeMAC-I-r13						ShortMAC-I,
+	resumeCause-r13								EstablishmentCause-NB-r13,
+	earlyContentionResolution-r14				BOOLEAN,
+	cqi-NPDCCH-r14								CQI-NPDCCH-NB-r14,
+	anr-InfoAvailable-r16						BOOLEAN,
+	spare										BIT STRING (SIZE (3))
+}
+
+RRCConnectionResumeRequest-5GC-NB-r16-IEs ::=	SEQUENCE {
+	resumeID-r16								I-RNTI-r15,
+	shortResumeMAC-I-r16						ShortMAC-I,
+	resumeCause-r16								EstablishmentCause-NB-r13,
+	cqi-NPDCCH-r16								CQI-NPDCCH-NB-r14,
+	spare										BIT STRING (SIZE (4))
+}
+
+
+
+RRCConnectionSetup-NB ::=		SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			rrcConnectionSetup-r13				RRCConnectionSetup-NB-r13-IEs,
+			spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionSetup-NB-r13-IEs ::=		SEQUENCE {
+	radioResourceConfigDedicated-r13		RadioResourceConfigDedicated-NB-r13,
+	lateNonCriticalExtension				OCTET STRING						OPTIONAL,
+	nonCriticalExtension					RRCConnectionSetup-NB-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionSetup-NB-v1610-IEs ::=		SEQUENCE {
+	dedicatedInfoNAS-r16					DedicatedInfoNAS			OPTIONAL,	-- Need ON
+	nonCriticalExtension					SEQUENCE {}					OPTIONAL
+}
+
+
+
+RRCConnectionSetupComplete-NB ::=	SEQUENCE {
+	rrc-TransactionIdentifier				RRC-TransactionIdentifier,
+	criticalExtensions						CHOICE{
+			rrcConnectionSetupComplete-r13		RRCConnectionSetupComplete-NB-r13-IEs,
+			criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCConnectionSetupComplete-NB-r13-IEs ::= SEQUENCE {
+	selectedPLMN-Identity-r13				INTEGER (1..maxPLMN-r11),
+	s-TMSI-r13								S-TMSI							OPTIONAL,
+	registeredMME-r13						RegisteredMME					OPTIONAL,
+	dedicatedInfoNAS-r13					DedicatedInfoNAS,
+	attachWithoutPDN-Connectivity-r13		ENUMERATED {true}				OPTIONAL,
+	up-CIoT-EPS-Optimisation-r13			ENUMERATED {true}				OPTIONAL,
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					RRCConnectionSetupComplete-NB-v1430-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-NB-v1430-IEs ::= SEQUENCE {
+	gummei-Type-r14							ENUMERATED { mapped}	OPTIONAL,
+	dcn-ID-r14								INTEGER (0..65535)			OPTIONAL,
+	nonCriticalExtension					RRCConnectionSetupComplete-NB-v1470-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-NB-v1470-IEs ::= SEQUENCE {
+	measResultServCell-r14						MeasResultServCell-NB-r14	OPTIONAL,
+	nonCriticalExtension						RRCConnectionSetupComplete-NB-v1610-IEs	OPTIONAL
+}
+
+RRCConnectionSetupComplete-NB-v1610-IEs ::= SEQUENCE {
+	ng-5G-S-TMSI-r16							NG-5G-S-TMSI-r15			OPTIONAL,
+	registeredAMF-r16							RegisteredAMF-r15			OPTIONAL,
+	gummei-Type-v1610							ENUMERATED {mappedFrom5G}	OPTIONAL,
+	guami-Type-r16								ENUMERATED {native, mapped}	OPTIONAL,
+	s-NSSAI-list-r16							SEQUENCE(SIZE (1..maxNrofS-NSSAI-r15)) OF
+														S-NSSAI-r15		OPTIONAL,
+	ng-U-DataTransfer-r16						ENUMERATED {true}			OPTIONAL,
+	up-CIoT-5GS-Optimisation-r16				ENUMERATED {true}			OPTIONAL,
+	rlf-InfoAvailable-r16						ENUMERATED {true}			OPTIONAL,
+	anr-InfoAvailable-r16						ENUMERATED {true}			OPTIONAL,
+	pur-ConfigID-r16							PUR-ConfigID-NB-r16			OPTIONAL,
+	nonCriticalExtension						SEQUENCE {}					OPTIONAL
+}
+
+
+
+RRCEarlyDataComplete-NB-r15 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcEarlyDataComplete-r15			RRCEarlyDataComplete-NB-r15-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+RRCEarlyDataComplete-NB-r15-IEs ::=	SEQUENCE {
+	dedicatedInfoNAS-r15				DedicatedInfoNAS				OPTIONAL,	-- Need ON
+	extendedWaitTime-r15				INTEGER (1..1800)				OPTIONAL,	-- Need ON
+	redirectedCarrierInfo-r15			RedirectedCarrierInfo-NB-r13	OPTIONAL,	-- Need ON
+	redirectedCarrierInfoExt-r15		RedirectedCarrierInfo-NB-v1430	OPTIONAL,	-- Cond Redirection
+	nonCriticalExtension				RRCEarlyDataComplete-NB-v1590-IEs	OPTIONAL
+}
+
+RRCEarlyDataComplete-NB-v1590-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension					OCTET STRING					OPTIONAL,
+	nonCriticalExtension						SEQUENCE {}					OPTIONAL
+}
+
+
+
+RRCEarlyDataRequest-NB-r15 ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		rrcEarlyDataRequest-r15				RRCEarlyDataRequest-NB-r15-IEs,
+		later								CHOICE {
+			rrcEarlyDataRequest-r16				RRCEarlyDataRequest-5GC-NB-r16-IEs,
+			criticalExtensionsFuture			SEQUENCE {}
+		}
+	}
+}
+
+RRCEarlyDataRequest-NB-r15-IEs ::=	SEQUENCE {
+	s-TMSI-r15							S-TMSI,
+	establishmentCause-r15				ENUMERATED {mo-Data, mo-ExceptionData, delayTolerantAccess, mt-Access-v1610},
+	cqi-NPDCCH-r15						CQI-NPDCCH-NB-r14						OPTIONAL,
+	dedicatedInfoNAS-r15				DedicatedInfoNAS,
+	nonCriticalExtension				RRCEarlyDataRequest-NB-v1590-IEs		OPTIONAL
+}
+
+RRCEarlyDataRequest-NB-v1590-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension				OCTET STRING				OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}					OPTIONAL
+}
+
+RRCEarlyDataRequest-5GC-NB-r16-IEs ::=	SEQUENCE {
+	ng-5G-S-TMSI-r16					NG-5G-S-TMSI-r15,
+	establishmentCause-r16				ENUMERATED {mo-Data, mo-ExceptionData, mt-Access, spare1},
+	cqi-NPDCCH-r16						CQI-NPDCCH-NB-r14			OPTIONAL,
+	dedicatedInfoNAS-r16				DedicatedInfoNAS,
+	lateNonCriticalExtension			OCTET STRING				OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+
+
+SCPTMConfiguration-NB-r14 ::=	SEQUENCE {
+	sc-mtch-InfoList-r14			SC-MTCH-InfoList-NB-r14,
+	scptm-NeighbourCellList-r14		SCPTM-NeighbourCellList-NB-r14		OPTIONAL,	-- Need OP
+	lateNonCriticalExtension		OCTET STRING						OPTIONAL,
+	nonCriticalExtension			SCPTMConfiguration-NB-v1610	OPTIONAL
+}
+
+SCPTMConfiguration-NB-v1610 ::=	SEQUENCE {
+	sc-mtch-InfoListMultiTB-r16		SC-MTCH-InfoList-NB-r14,
+	multiTB-Gap-r16					ENUMERATED {sf16, sf32, sf64, sf128}	OPTIONAL,	-- Need OR
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+
+
+SystemInformation-NB ::=		SEQUENCE {
+	criticalExtensions					CHOICE {
+		systemInformation-r13				SystemInformation-NB-r13-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+SystemInformation-NB-r13-IEs ::=	SEQUENCE {
+	sib-TypeAndInfo-r13					SEQUENCE (SIZE (1..maxSIB)) OF CHOICE {
+		sib2-r13							SystemInformationBlockType2-NB-r13,
+		sib3-r13							SystemInformationBlockType3-NB-r13,
+		sib4-r13							SystemInformationBlockType4-NB-r13,
+		sib5-r13							SystemInformationBlockType5-NB-r13,
+		sib14-r13							SystemInformationBlockType14-NB-r13,
+		sib16-r13							SystemInformationBlockType16-NB-r13,
+		...,
+		sib15-v1430							SystemInformationBlockType15-NB-r14,
+		sib20-v1430							SystemInformationBlockType20-NB-r14,
+		sib22-v1430							SystemInformationBlockType22-NB-r14,
+		sib23-v1530							SystemInformationBlockType23-NB-r15,
+		sib27-v1610						SystemInformationBlockType27-NB-r16
+	},
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+SystemInformationBlockType1-NB ::=	SEQUENCE {
+	hyperSFN-MSB-r13					BIT STRING (SIZE (8)),
+	cellAccessRelatedInfo-r13			SEQUENCE {
+		plmn-IdentityList-r13				PLMN-IdentityList-NB-r13,
+		trackingAreaCode-r13				TrackingAreaCode,
+		cellIdentity-r13					CellIdentity,
+		cellBarred-r13						ENUMERATED {barred, notBarred},
+		intraFreqReselection-r13			ENUMERATED {allowed, notAllowed}
+	},
+	cellSelectionInfo-r13				SEQUENCE {
+		q-RxLevMin-r13						Q-RxLevMin,
+		q-QualMin-r13						Q-QualMin-r9
+	},
+	p-Max-r13							P-Max					OPTIONAL,	-- Need OP
+	freqBandIndicator-r13				FreqBandIndicator-NB-r13,
+	freqBandInfo-r13					NS-PmaxList-NB-r13				OPTIONAL,	-- Need OR
+	multiBandInfoList-r13				MultiBandInfoList-NB-r13		OPTIONAL,	-- Need OR
+	downlinkBitmap-r13					DL-Bitmap-NB-r13				OPTIONAL,	-- Cond SIB1
+	eutraControlRegionSize-r13			ENUMERATED {n1, n2, n3}			OPTIONAL,	-- Cond inband
+	nrs-CRS-PowerOffset-r13				ENUMERATED {dB-6,     dB-4dot77, dB-3,
+													dB-1dot77, dB0,       dB1,
+													dB1dot23,  dB2,       dB3,
+													dB4,       dB4dot23,  dB5,
+													dB6,       dB7,       dB8,
+													dB9}		OPTIONAL,	-- Cond inband-SamePCI
+	schedulingInfoList-r13				SchedulingInfoList-NB-r13,
+	si-WindowLength-r13					ENUMERATED {ms160, ms320, ms480, ms640,
+													ms960, ms1280, ms1600, spare1},
+	si-RadioFrameOffset-r13				INTEGER (1..15)		OPTIONAL,	-- Need OP
+	systemInfoValueTagList-r13			SystemInfoValueTagList-NB-r13	OPTIONAL,	-- Need OR
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				SystemInformationBlockType1-NB-v1350	OPTIONAL
+}
+
+SystemInformationBlockType1-NB-v1350 ::=	SEQUENCE {
+	cellSelectionInfo-v1350				CellSelectionInfo-NB-v1350	OPTIONAL,	-- Cond Qrxlevmin
+	nonCriticalExtension				SystemInformationBlockType1-NB-v1430	OPTIONAL
+}
+
+SystemInformationBlockType1-NB-v1430 ::=	SEQUENCE {
+	cellSelectionInfo-v1430				CellSelectionInfo-NB-v1430		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SystemInformationBlockType1-NB-v1450					OPTIONAL
+}
+
+SystemInformationBlockType1-NB-v1450 ::= SEQUENCE {
+	nrs-CRS-PowerOffset-v1450				ENUMERATED {dB-6,  dB-4dot77, dB-3,
+													dB-1dot77, dB0,       dB1,
+													dB1dot23,  dB2,       dB3,
+													dB4,       dB4dot23,  dB5,
+													dB6,       dB7,       dB8,
+													dB9}		OPTIONAL,	-- Cond inband-SamePCI-ExceptAnchor
+	nonCriticalExtension				SystemInformationBlockType1-NB-v1530					OPTIONAL
+}
+
+SystemInformationBlockType1-NB-v1530 ::= SEQUENCE {
+	tdd-Parameters-r15						SEQUENCE {
+		tdd-Config-r15							TDD-Config-NB-r15,
+		tdd-SI-CarrierInfo-r15					ENUMERATED {anchor, non-anchor},
+		tdd-SI-SubframesBitmap-r15				DL-Bitmap-NB-r13		OPTIONAL	-- Cond TDD-SI-NonAnchor
+	}	OPTIONAL,	-- Cond TDD
+	schedulingInfoList-v1530			SchedulingInfoList-NB-v1530		OPTIONAL,	-- Need OR
+	nonCriticalExtension				SystemInformationBlockType1-NB-v1610	OPTIONAL
+}
+
+SystemInformationBlockType1-NB-v1610 ::= SEQUENCE {
+	cellAccessRelatedInfo-5GC-r16			SEQUENCE {
+		plmn-IdentityList-r16				PLMN-IdentityList-5GC-NB-r16,
+		trackingAreaCode-5GC-r16			TrackingAreaCode-5GC-r15,
+		cellIdentity-r16					CellIdentity	OPTIONAL,	-- Need OP
+		cellBarred-5GC-r16					ENUMERATED {barred, notBarred}
+	}	OPTIONAL,	-- Need OR
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+PLMN-IdentityList-NB-r13 ::=		SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-IdentityInfo-NB-r13
+
+PLMN-IdentityList-5GC-NB-r16 ::=	SEQUENCE (SIZE (1..maxPLMN-r11)) OF PLMN-IdentityInfo-5GC-NB-r16
+
+PLMN-IdentityInfo-NB-r13 ::=		SEQUENCE {
+	plmn-Identity-r13						PLMN-Identity,
+	cellReservedForOperatorUse-r13			ENUMERATED {reserved, notReserved},
+	attachWithoutPDN-Connectivity-r13		ENUMERATED {true}	OPTIONAL	-- Need OP
+}
+
+PLMN-IdentityInfo-5GC-NB-r16 ::=	SEQUENCE {
+	plmn-Identity-5GC-r16					CHOICE {
+		plmn-Identity-r16						PLMN-Identity,
+		plmn-Index-r16							INTEGER (1..maxPLMN-r11)
+		},
+	cellReservedForOperatorUse-r16			ENUMERATED {reserved, notReserved},
+	ng-U-DataTransfer-r16					ENUMERATED {true}	OPTIONAL,	-- Need OR
+	up-CIoT-5GS-Optimisation-r16			ENUMERATED {true}	OPTIONAL	-- Need OR
+}
+
+SchedulingInfoList-NB-r13 ::= SEQUENCE (SIZE (1..maxSI-Message-NB-r13)) OF SchedulingInfo-NB-r13
+
+SchedulingInfoList-NB-v1530 ::= SEQUENCE (SIZE (1..maxSI-Message-NB-r13)) OF SchedulingInfo-NB-v1530
+
+SchedulingInfo-NB-r13::=		SEQUENCE {
+	si-Periodicity-r13				ENUMERATED {rf64, rf128, rf256, rf512,
+												rf1024, rf2048, rf4096, spare},
+	si-RepetitionPattern-r13		ENUMERATED {every2ndRF, every4thRF, every8thRF, every16thRF},
+	sib-MappingInfo-r13				SIB-MappingInfo-NB-r13,
+	si-TB-r13						ENUMERATED {b56, b120, b208, b256, b328, b440, b552, b680}
+}
+
+SchedulingInfo-NB-v1530::=		SEQUENCE {
+	sib-MappingInfo-v1530				SIB-MappingInfo-NB-v1530	OPTIONAL	-- Need OR
+}
+
+SystemInfoValueTagList-NB-r13 ::=	SEQUENCE (SIZE (1.. maxSI-Message-NB-r13)) OF
+										SystemInfoValueTagSI-r13
+
+SIB-MappingInfo-NB-r13 ::=			SEQUENCE (SIZE (0..maxSIB-1)) OF SIB-Type-NB-r13
+
+SIB-MappingInfo-NB-v1530 ::=		SEQUENCE (SIZE (1..8)) OF SIB-Type-NB-v1530
+
+SIB-Type-NB-r13 ::=					ENUMERATED {
+										sibType3-NB-r13, sibType4-NB-r13, sibType5-NB-r13,
+										sibType14-NB-r13, sibType16-NB-r13, sibType15-NB-r14,
+										sibType20-NB-r14, sibType22-NB-r14}
+
+SIB-Type-NB-v1530 ::=				ENUMERATED {
+										sibType23-NB-r15, sibType27-NB-r16, spare6, spare5,
+										spare4, spare3, spare2, spare1}
+
+CellSelectionInfo-NB-v1350 ::=		SEQUENCE {
+	delta-RxLevMin-v1350				INTEGER (-8..-1)
+}
+
+CellSelectionInfo-NB-v1430 ::=		SEQUENCE {
+	powerClass14dBm-Offset-r14			ENUMERATED {dB-6, dB-3, dB3, dB6, dB9, dB12}	OPTIONAL,	--	Need OP
+	ce-authorisationOffset-r14			ENUMERATED {dB5, dB10, dB15, dB20, dB25, dB30, dB35}	OPTIONAL	--	Need OP
+}
+
+
+
+UECapabilityEnquiry-NB ::=	SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		c1									CHOICE {
+			ueCapabilityEnquiry-r13				UECapabilityEnquiry-NB-r13-IEs,
+			spare1								NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UECapabilityEnquiry-NB-r13-IEs ::=	SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+UECapabilityInformation-NB ::=	SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE{
+			ueCapabilityInformation-r13		UECapabilityInformation-NB-r13-IEs,
+			criticalExtensionsFuture		SEQUENCE {}
+	}
+}
+
+UECapabilityInformation-NB-r13-IEs ::=	SEQUENCE {
+	ue-Capability-r13						UE-Capability-NB-r13,
+	ue-RadioPagingInfo-r13					UE-RadioPagingInfo-NB-r13,
+	lateNonCriticalExtension				OCTET STRING						OPTIONAL,
+	nonCriticalExtension					UECapabilityInformation-NB-Ext-r14-IEs							OPTIONAL
+}
+
+UECapabilityInformation-NB-Ext-r14-IEs ::=	SEQUENCE {
+	ue-Capability-ContainerExt-r14			OCTET STRING (CONTAINING UE-Capability-NB-Ext-r14-IEs),
+	nonCriticalExtension					SEQUENCE {}							OPTIONAL
+}
+
+
+
+UEInformationRequest-NB-r16	::=			SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		ueInformationRequest-r16			UEInformationRequest-NB-r16-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UEInformationRequest-NB-r16-IEs ::=		SEQUENCE {
+	rach-ReportReq-r16					BOOLEAN,
+	rlf-ReportReq-r16					BOOLEAN,
+	anr-ReportReq-r16					BOOLEAN,
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+UEInformationResponse-NB-r16		::=		SEQUENCE {
+	rrc-TransactionIdentifier			RRC-TransactionIdentifier,
+	criticalExtensions					CHOICE {
+		ueInformationResponse-r16			UEInformationResponse-NB-r16-IEs,
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UEInformationResponse-NB-r16-IEs ::=	SEQUENCE {
+	rach-Report-r16							RACH-Report-NB-r16					OPTIONAL,
+	rlf-Report-r16							RLF-Report-NB-r16					OPTIONAL,
+	anr-MeasReport-r16						ANR-MeasReport-NB-r16				OPTIONAL,
+	lateNonCriticalExtension				OCTET STRING						OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}							OPTIONAL
+}
+
+RACH-Report-NB-r16 ::=					SEQUENCE {
+	numberOfPreamblesSent-r16				INTEGER (1..64),
+	contentionDetected-r16					BOOLEAN,
+	initialNRSRP-Level-r16					INTEGER (0..2),
+	edt-Fallback-r16						BOOLEAN
+}
+
+RLF-Report-NB-r16 ::=					SEQUENCE {
+	failedPCellId-r16						CellGlobalIdEUTRA,
+	reestablishmentCellId-r16				CellGlobalIdEUTRA					OPTIONAL,
+	locationInfo-r16						LocationInfo-r10					OPTIONAL,
+	measResultLastServCell-r16				SEQUENCE {
+		nrsrpResult-r16							NRSRP-Range-NB-r14,
+		nrsrqResult-r16							NRSRQ-Range-NB-r14				OPTIONAL
+	},
+	timeSinceFailure-r16					TimeSinceFailure-r11				OPTIONAL
+}
+
+
+
+ULInformationTransfer-NB ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+			ulInformationTransfer-r13		ULInformationTransfer-NB-r13-IEs,
+			criticalExtensionsFuture		SEQUENCE {}
+	}
+}
+
+ULInformationTransfer-NB-r13-IEs ::=	SEQUENCE {
+	dedicatedInfoNAS-r13					DedicatedInfoNAS,
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}						OPTIONAL
+}
+
+
+
+SystemInformationBlockType2-NB-r13 ::=	SEQUENCE {
+	radioResourceConfigCommon-r13			RadioResourceConfigCommonSIB-NB-r13,
+	ue-TimersAndConstants-r13				UE-TimersAndConstants-NB-r13,
+	freqInfo-r13							SEQUENCE {
+		ul-CarrierFreq-r13						CarrierFreq-NB-r13			OPTIONAL,	-- Need OP
+		additionalSpectrumEmission-r13			AdditionalSpectrumEmission
+	},
+	timeAlignmentTimerCommon-r13			TimeAlignmentTimer,
+	multiBandInfoList-r13	SEQUENCE (SIZE (1..maxMultiBands)) OF AdditionalSpectrumEmission		OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...,
+	[[	cp-Reestablishment-r14				ENUMERATED {true}				OPTIONAL		-- Need OP
+	]],
+	[[	servingCellMeasInfo-r14				ENUMERATED {true}				OPTIONAL,		-- Need OR
+		cqi-Reporting-r14					ENUMERATED {true}				OPTIONAL		-- Need OR
+	]],
+	[[	enhancedPHR-r15						ENUMERATED {true}		OPTIONAL,	-- Need OR
+		freqInfo-v1530						SEQUENCE {
+			tdd-UL-DL-AlignmentOffset-r15		TDD-UL-DL-AlignmentOffset-NB-r15
+		}	OPTIONAL,		-- Cond TDD
+		cp-EDT-r15							ENUMERATED {true}		OPTIONAL,	-- Need OR
+		up-EDT-r15							ENUMERATED {true}		OPTIONAL	-- Need OR
+	]],
+	[[	earlySecurityReactivation-r16		ENUMERATED {true}		OPTIONAL,	-- Need OR
+		cp-EDT-5GC-r16						ENUMERATED {true}		OPTIONAL,	-- Need OR
+		up-EDT-5GC-r16						ENUMERATED {true}		OPTIONAL,	-- Need OR
+		cp-PUR-EPC-r16						ENUMERATED {true}		OPTIONAL,	-- Need OR
+		up-PUR-EPC-r16						ENUMERATED {true}		OPTIONAL,	-- Need OR
+		cp-PUR-5GC-r16						ENUMERATED {true}		OPTIONAL,	-- Need OR
+		up-PUR-5GC-r16						ENUMERATED {true}		OPTIONAL,	-- Need OR
+		rai-ActivationEnh-r16				ENUMERATED {true}		OPTIONAL	-- Need OR
+	]]
+}
+
+
+
+SystemInformationBlockType3-NB-r13 ::=	SEQUENCE {
+	cellReselectionInfoCommon-r13			SEQUENCE {
+		q-Hyst-r13								ENUMERATED {
+													dB0, dB1, dB2, dB3, dB4, dB5, dB6, dB8, dB10,
+													dB12, dB14, dB16, dB18, dB20, dB22, dB24
+													}
+	},
+	cellReselectionServingFreqInfo-r13		SEQUENCE {
+		s-NonIntraSearch-r13					ReselectionThreshold
+	},
+	intraFreqCellReselectionInfo-r13		SEQUENCE {
+		q-RxLevMin-r13							Q-RxLevMin,
+		q-QualMin-r13							Q-QualMin-r9			OPTIONAL,	-- Need OP
+		p-Max-r13								P-Max					OPTIONAL,	-- Need OP
+		s-IntraSearchP-r13						ReselectionThreshold,
+		t-Reselection-r13						T-Reselection-NB-r13
+	},
+	freqBandInfo-r13						NS-PmaxList-NB-r13				OPTIONAL,	-- Need OR
+	multiBandInfoList-r13					SEQUENCE (SIZE (1..maxMultiBands)) OF
+												NS-PmaxList-NB-r13			OPTIONAL,	-- Need OR
+	lateNonCriticalExtension					OCTET STRING				OPTIONAL,
+	...,
+	[[	intraFreqCellReselectionInfo-v1350	IntraFreqCellReselectionInfo-NB-v1350 OPTIONAL	-- Cond Qrxlevmin
+	]],
+	[[	intraFreqCellReselectionInfo-v1360	IntraFreqCellReselectionInfo-NB-v1360 OPTIONAL	-- Need OR
+	]],
+	[[	intraFreqCellReselectionInfo-v1430	IntraFreqCellReselectionInfo-NB-v1430 OPTIONAL	-- Need OR
+	]],
+	[[	cellReselectionInfoCommon-v1450		CellReselectionInfoCommon-NB-v1450	OPTIONAL	-- Need OR
+	]],
+	[[	nsss-RRM-Config-r15					NSSS-RRM-Config-NB-r15	OPTIONAL,	-- Need OR
+		npbch-RRM-Config-r15				ENUMERATED {enabled}	OPTIONAL	-- Need OR
+	]]
+}
+
+IntraFreqCellReselectionInfo-NB-v1350 ::=	SEQUENCE {
+	delta-RxLevMin-v1350						INTEGER (-8..-1)
+}
+
+IntraFreqCellReselectionInfo-NB-v1360 ::=	SEQUENCE {
+	s-IntraSearchP-v1360							ReselectionThreshold-NB-v1360
+}
+
+IntraFreqCellReselectionInfo-NB-v1430 ::=	SEQUENCE {
+	powerClass14dBm-Offset-r14		ENUMERATED {dB-6, dB-3, dB3, dB6, dB9, dB12}	OPTIONAL,	-- Need OP
+	ce-AuthorisationOffset-r14		ENUMERATED {dB5, dB10, dB15, dB20, dB25, dB30, dB35}	OPTIONAL	-- Need OP
+}
+
+CellReselectionInfoCommon-NB-v1450 ::=	SEQUENCE {
+	s-SearchDeltaP-r14					ENUMERATED {dB6, dB9, dB12, dB15}
+}
+
+
+
+SystemInformationBlockType4-NB-r13 ::=		SEQUENCE {
+	intraFreqNeighCellList-r13			IntraFreqNeighCellList	OPTIONAL,	-- Need OR
+	intraFreqBlackCellList-r13			IntraFreqBlackCellList	OPTIONAL,	-- Need OR
+	lateNonCriticalExtension			OCTET STRING			OPTIONAL,
+	...,
+	[[	nsss-RRM-Config-r15				NSSS-RRM-Config-NB-r15	OPTIONAL,	-- Need OR
+		intraFreqNeighCellList-v1530	IntraFreqNeighCellList-NB-v1530	OPTIONAL	-- Need OR
+	]]
+}
+
+IntraFreqNeighCellList-NB-v1530 ::=		SEQUENCE (SIZE (1..maxCellIntra)) OF IntraFreqNeighCellInfo-NB-v1530
+
+IntraFreqNeighCellInfo-NB-v1530 ::=		SEQUENCE {
+	nsss-RRM-Config-r15						NSSS-RRM-Config-NB-r15	OPTIONAL	-- Cond NSSS-RRM
+}
+
+
+
+SystemInformationBlockType5-NB-r13 ::=	SEQUENCE {
+	interFreqCarrierFreqList-r13			InterFreqCarrierFreqList-NB-r13,
+	t-Reselection-r13						T-Reselection-NB-r13,
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...,
+	[[	scptm-FreqOffset-r14				INTEGER (1..8)					OPTIONAL	-- Need OP
+	]]
+}
+
+
+InterFreqCarrierFreqList-NB-r13 ::=		SEQUENCE (SIZE (1..maxFreq)) OF InterFreqCarrierFreqInfo-NB-r13
+
+
+InterFreqCarrierFreqInfo-NB-r13 ::=	SEQUENCE {
+	dl-CarrierFreq-r13					CarrierFreq-NB-r13,
+	q-RxLevMin-r13						Q-RxLevMin,
+	q-QualMin-r13						Q-QualMin-r9					OPTIONAL,		-- Need OP
+	p-Max-r13							P-Max							OPTIONAL,		-- Need OP
+	q-OffsetFreq-r13					Q-OffsetRange					DEFAULT dB0,
+	interFreqNeighCellList-r13			InterFreqNeighCellList-NB-r13	OPTIONAL,		-- Need OR
+	interFreqBlackCellList-r13			InterFreqBlackCellList-NB-r13	OPTIONAL,		-- Need OR
+	multiBandInfoList-r13				MultiBandInfoList-NB-r13		OPTIONAL,		-- Need OR
+	...,
+	[[	delta-RxLevMin-v1350			INTEGER (-8..-1)		OPTIONAL	-- Cond Qrxlevmin
+	]],
+	[[	powerClass14dBm-Offset-r14		ENUMERATED {dB-6, dB-3, dB3, dB6, dB9, dB12}
+OPTIONAL,	--	Need OP
+		ce-AuthorisationOffset-r14		ENUMERATED {dB5, dB10, dB15, dB20, dB25, dB30, dB35}	OPTIONAL	-- Need OP
+	]],
+	[[	nsss-RRM-Config-r15				NSSS-RRM-Config-NB-r15	OPTIONAL,	-- Need OR
+		interFreqNeighCellList-v1530	InterFreqNeighCellList-NB-v1530	OPTIONAL -- Need OR
+	]],
+	[[	dl-CarrierFreq-v1550			CarrierFreq-NB-v1550	OPTIONAL -- Cond TDD
+	]]
+}
+
+InterFreqNeighCellList-NB-r13 ::=		SEQUENCE (SIZE (1..maxCellInter)) OF PhysCellId
+
+InterFreqNeighCellList-NB-v1530 ::=		SEQUENCE (SIZE (1..maxCellInter)) OF InterFreqNeighCellInfo-NB-v1530
+
+InterFreqNeighCellInfo-NB-v1530 ::=		SEQUENCE {
+	nsss-RRM-Config-r15						NSSS-RRM-Config-NB-r15	OPTIONAL	-- Cond NSSS-RRM
+}
+
+InterFreqBlackCellList-NB-r13 ::=		SEQUENCE (SIZE (1..maxCellBlack)) OF PhysCellId
+
+
+
+SystemInformationBlockType14-NB-r13 ::=	SEQUENCE {
+	ab-Param-r13					CHOICE {
+		ab-Common-r13					AB-Config-NB-r13,
+		ab-PerPLMN-List-r13				SEQUENCE (SIZE (1..maxPLMN-r11)) OF AB-ConfigPLMN-NB-r13
+	}															OPTIONAL, -- Need OR
+	lateNonCriticalExtension		OCTET STRING				OPTIONAL,
+	...,
+	[[	ab-PerNRSRP-r15				ENUMERATED {thresh1, thresh2}	OPTIONAL	--	Need OR
+	]],
+	[[	uac-Param-r16				UAC-Param-NB-r16				OPTIONAL	--	Need OR
+	]]
+}
+
+AB-ConfigPLMN-NB-r13 ::=	SEQUENCE {
+	ab-Config-r13					AB-Config-NB-r13			OPTIONAL -- Need OR
+}
+
+AB-Config-NB-r13 ::=		SEQUENCE {
+	ab-Category-r13					ENUMERATED {a, b, c},
+	ab-BarringBitmap-r13			BIT STRING (SIZE(10)),
+	ab-BarringForExceptionData-r13	ENUMERATED {true}			OPTIONAL,	-- Need OP
+	ab-BarringForSpecialAC-r13		BIT STRING (SIZE(5))
+}
+
+UAC-Param-NB-r16	::=		CHOICE {
+	uac-BarringCommon			UAC-Barring-NB-r16,
+	uac-BarringPerPLMN-List		SEQUENCE (SIZE (1..maxPLMN-r11)) OF UAC-Barring-NB-r16
+}
+
+UAC-Barring-NB-r16	::=		SEQUENCE {
+	uac-BarringPerCatList-r16			UAC-BarringPerCatList-NB-r16	OPTIONAL,	-- Need OR
+	uac-AC1-SelectAssistInfo-r16		UAC-AC1-SelectAssistInfo-r15	OPTIONAL,	-- Need OR
+	uac-BarringForAccessIdentity-r16	BIT STRING (SIZE(7))
+}
+
+UAC-BarringPerCatList-NB-r16 ::= SEQUENCE (SIZE (1..maxAccessCat-1-r15)) OF UAC-BarringPerCat-NB-r16
+
+UAC-BarringPerCat-NB-r16 ::=	SEQUENCE {
+	uac-accessCategory-r16			INTEGER (1..maxAccessCat-1-r15),
+	uac-BarringFactor-r16			ENUMERATED {p00, p05, p10, p15, p20, p25, p30, p40,
+												p50, p60, p70, p75, p80, p85, p90, p95},
+	uac-BarringTime-r16				ENUMERATED {s4, s8, s16, s32, s64, s128, s256, s512}
+}
+
+
+
+SystemInformationBlockType15-NB-r14 ::=	SEQUENCE {
+	mbms-SAI-IntraFreq-r14					MBMS-SAI-List-r11				OPTIONAL,	-- Need OR
+	mbms-SAI-InterFreqList-r14				MBMS-SAI-InterFreqList-NB-r14	OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...
+}
+
+MBMS-SAI-InterFreqList-NB-r14 ::=		SEQUENCE (SIZE (1..maxFreq)) OF MBMS-SAI-InterFreq-NB-r14
+
+MBMS-SAI-InterFreq-NB-r14 ::=			SEQUENCE {
+	dl-CarrierFreq-r14						CarrierFreq-NB-r13,
+	mbms-SAI-List-r14						MBMS-SAI-List-r11,
+	multiBandInfoList-r14					AdditionalBandInfoList-NB-r14	OPTIONAL	-- Need OR
+}
+
+
+
+SystemInformationBlockType16-NB-r13 ::= SystemInformationBlockType16-r11
+
+
+
+SystemInformationBlockType20-NB-r14 ::=	SEQUENCE {
+	npdcch-SC-MCCH-Config-r14				NPDCCH-SC-MCCH-Config-NB-r14,
+	sc-mcch-CarrierConfig-r14				CHOICE {
+		dl-CarrierConfig-r14					DL-CarrierConfigCommon-NB-r14,
+		dl-CarrierIndex-r14						INTEGER (0.. maxNonAnchorCarriers-NB-r14)
+	},
+	sc-mcch-RepetitionPeriod-r14			ENUMERATED {rf32, rf128, rf512, rf1024,
+														rf2048, rf4096, rf8192, rf16384},
+	sc-mcch-Offset-r14						INTEGER (0..10),
+	sc-mcch-ModificationPeriod-r14			ENUMERATED { rf32, rf128, rf256, rf512, rf1024,
+													rf2048, rf4096, rf8192, rf16384, rf32768,
+													rf65536, rf131072, rf262144, rf524288,
+													rf1048576, spare1},
+	sc-mcch-SchedulingInfo-r14				SC-MCCH-SchedulingInfo-NB-r14		OPTIONAL,	-- Need OP
+	lateNonCriticalExtension				OCTET STRING						OPTIONAL,
+	...
+}
+
+NPDCCH-SC-MCCH-Config-NB-r14 ::=	SEQUENCE {
+	npdcch-NumRepetitions-SC-MCCH-r14		ENUMERATED {r1, r2, r4, r8, r16,
+														r32, r64, r128, r256,
+														r512, r1024, r2048},
+	npdcch-StartSF-SC-MCCH-r14				ENUMERATED {v1dot5, v2, v4, v8,
+														v16, v32, v48, v64},
+	npdcch-Offset-SC-MCCH-r14				ENUMERATED {zero, oneEighth, oneQuarter,
+														threeEighth, oneHalf, fiveEighth,
+														threeQuarter, sevenEighth}
+}
+
+SC-MCCH-SchedulingInfo-NB-r14::=	SEQUENCE	{
+	onDurationTimerSCPTM-r14					ENUMERATED {
+													pp1, pp2, pp3, pp4,
+													pp8, pp16, pp32, spare},
+	drx-InactivityTimerSCPTM-r14				ENUMERATED {
+													pp0, pp1, pp2, pp3,
+													pp4, pp8, pp16, pp32},
+	schedulingPeriodStartOffsetSCPTM-r14		CHOICE {
+		sf10										INTEGER(0..9),
+		sf20										INTEGER(0..19),
+		sf32										INTEGER(0..31),
+		sf40										INTEGER(0..39),
+		sf64										INTEGER(0..63),
+		sf80										INTEGER(0..79),
+		sf128										INTEGER(0..127),
+		sf160										INTEGER(0..159),
+		sf256										INTEGER(0..255),
+		sf320										INTEGER(0..319),
+		sf512										INTEGER(0..511),
+		sf640										INTEGER(0..639),
+		sf1024										INTEGER(0..1023),
+		sf2048										INTEGER(0..2047),
+		sf4096										INTEGER(0..4095),
+		sf8192										INTEGER(0..8191)
+	},
+	...
+}
+
+
+
+SystemInformationBlockType22-NB-r14 ::=	SEQUENCE {
+	dl-ConfigList-r14					DL-ConfigCommonList-NB-r14	OPTIONAL,	-- Need OR
+	ul-ConfigList-r14					UL-ConfigCommonList-NB-r14	OPTIONAL,	-- Need OR
+	pagingWeightAnchor-r14				PagingWeight-NB-r14			OPTIONAL,	-- Cond pcch-config
+	nprach-ProbabilityAnchorList-r14	NPRACH-ProbabilityAnchorList-NB-r14	OPTIONAL,	-- Cond nprach-config
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	...,
+	[[	mixedOperationModeConfig-r15	SEQUENCE {
+			dl-ConfigListMixed-r15			DL-ConfigCommonList-NB-r14	OPTIONAL,	-- Cond dl-ConfigList
+			ul-ConfigListMixed-r15			UL-ConfigCommonList-NB-r14	OPTIONAL,	-- Cond ul-ConfigList
+			pagingDistribution-r15			ENUMERATED {true}			OPTIONAL,	-- Need OR
+			nprach-Distribution-r15			ENUMERATED {true}			OPTIONAL	-- Need OR
+		}																OPTIONAL,	-- Need OR
+		ul-ConfigList-r15				UL-ConfigCommonListTDD-NB-r15	OPTIONAL	-- Cond TDD
+	]]
+}
+
+DL-ConfigCommonList-NB-r14 ::=		SEQUENCE (SIZE (1.. maxNonAnchorCarriers-NB-r14)) OF
+											DL-ConfigCommon-NB-r14
+
+UL-ConfigCommonList-NB-r14 ::=		SEQUENCE (SIZE (1.. maxNonAnchorCarriers-NB-r14)) OF
+											UL-ConfigCommon-NB-r14
+
+UL-ConfigCommonListTDD-NB-r15 ::=	SEQUENCE (SIZE (1.. maxNonAnchorCarriers-NB-r14)) OF
+											UL-ConfigCommonTDD-NB-r15
+
+DL-ConfigCommon-NB-r14 ::=			SEQUENCE {
+	dl-CarrierConfig-r14				DL-CarrierConfigCommon-NB-r14,
+	pcch-Config-r14					PCCH-Config-NB-r14			OPTIONAL, -- Need OR
+	...,
+	[[	wus-Config-r15					WUS-ConfigPerCarrier-NB-r15		OPTIONAL	-- Cond WUS
+	]],
+	[[	gwus-Config-r16					WUS-ConfigPerCarrier-NB-r15		OPTIONAL	-- Cond GWUS
+	]]
+}
+
+PCCH-Config-NB-r14 ::=				SEQUENCE {
+	npdcch-NumRepetitionPaging-r14		ENUMERATED {
+											r1, r2, r4, r8, r16, r32, r64, r128,
+											r256, r512, r1024, r2048,
+											spare4, spare3, spare2, spare1} OPTIONAL, -- Need OP
+	pagingWeight-r14						PagingWeight-NB-r14	DEFAULT w1,
+	...
+}
+
+PagingWeight-NB-r14	::=			ENUMERATED {w1, w2, w3, w4, w5, w6, w7, w8,
+												w9, w10, w11, w12, w13, w14, w15, w16}
+
+UL-ConfigCommon-NB-r14 ::=			SEQUENCE {
+	ul-CarrierFreq-r14					CarrierFreq-NB-r13,
+	nprach-ParametersList-r14			NPRACH-ParametersList-NB-r14	OPTIONAL, -- Need OR
+	...,
+	[[	nprach-ParametersListEDT-r15	NPRACH-ParametersList-NB-r14	OPTIONAL -- Cond EDT
+	]]
+}
+
+UL-ConfigCommonTDD-NB-r15 ::=		SEQUENCE {
+	tdd-UL-DL-AlignmentOffset-r15		TDD-UL-DL-AlignmentOffset-NB-r15,
+	nprach-ParametersListTDD-r15		NPRACH-ParametersListTDD-NB-r15	OPTIONAL, -- Need OR
+	...
+}
+
+NPRACH-ProbabilityAnchorList-NB-r14 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF
+												NPRACH-ProbabilityAnchor-NB-r14
+
+NPRACH-ProbabilityAnchor-NB-r14 ::=		SEQUENCE {
+	nprach-ProbabilityAnchor-r14			ENUMERATED {
+												zero, oneSixteenth, oneFifteenth, oneFourteenth,
+												oneThirteenth, oneTwelfth, oneEleventh, oneTenth,
+												oneNinth, oneEighth, oneSeventh, oneSixth,
+												oneFifth, oneFourth, oneThird, oneHalf}
+														OPTIONAL	-- Need OP
+}
+
+
+
+SystemInformationBlockType23-NB-r15 ::=	SEQUENCE {
+	ul-ConfigList-v1530					UL-ConfigCommonList-NB-v1530	OPTIONAL,	-- Need OR
+	ul-ConfigListMixed-v1530				UL-ConfigCommonList-NB-v1530	OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...
+}
+
+UL-ConfigCommonList-NB-v1530 ::=		SEQUENCE (SIZE (1.. maxNonAnchorCarriers-NB-r14)) OF
+											UL-ConfigCommon-NB-v1530
+
+UL-ConfigCommon-NB-v1530 ::=			SEQUENCE {
+	nprach-ParametersListFmt2-r15			NPRACH-ParametersListFmt2-NB-r15	OPTIONAL, -- Need OR
+	nprach-ParametersListFmt2EDT-r15		NPRACH-ParametersListFmt2-NB-r15	OPTIONAL, -- Cond EDT
+	...
+}
+
+
+
+SystemInformationBlockType27-NB-r16 ::=	SEQUENCE {
+	carrierFreqListEUTRA-r16				CarrierFreqListEUTRA-NB-r16		OPTIONAL,	-- Need OR
+	carrierFreqsListGERAN-r16				CarrierFreqsListGERAN-NB-r16	OPTIONAL,	-- Need OR
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	...
+}
+
+CarrierFreqListEUTRA-NB-r16 ::=			SEQUENCE (SIZE (1..maxFreqEUTRA-NB-r16)) OF
+													CarrierFreqEUTRA-NB-r16
+
+CarrierFreqsListGERAN-NB-r16 ::=		SEQUENCE (SIZE (1..maxFreqsGERAN-NB-r16)) OF
+													CarrierFreqsGERAN-NB-r16
+
+
+CarrierFreqEUTRA-NB-r16 ::=				SEQUENCE {
+	carrierFreq-r16							ARFCN-ValueEUTRA-r9,
+	sib1-r16								ENUMERATED {supported}		OPTIONAL,	-- Need OR
+	sib1-BR-r16								ENUMERATED {supported}		OPTIONAL,	-- Need OR
+	...
+}
+
+CarrierFreqsGERAN-NB-r16 ::=			SEQUENCE {
+	carrierFreqs-r16						CarrierFreqsGERAN,
+	ec-GSM-IOT-r16							ENUMERATED {supported}		OPTIONAL,	-- Need OR
+	peo-r16									ENUMERATED {supported}		OPTIONAL,	-- Need OR
+	...
+}
+
+
+
+
+CarrierConfigDedicated-NB-r13 ::=		SEQUENCE {
+	dl-CarrierConfig-r13		DL-CarrierConfigDedicated-NB-r13,
+	ul-CarrierConfig-r13		UL-CarrierConfigDedicated-NB-r13
+}
+
+DL-CarrierConfigDedicated-NB-r13 ::=	SEQUENCE {
+	dl-CarrierFreq-r13						CarrierFreq-NB-r13,
+	downlinkBitmapNonAnchor-r13				CHOICE {
+		useNoBitmap-r13							NULL,
+		useAnchorBitmap-r13						NULL,
+		explicitBitmapConfiguration-r13			DL-Bitmap-NB-r13,
+		spare									NULL
+	}		OPTIONAL,	-- Need ON
+	dl-GapNonAnchor-r13						CHOICE {
+		useNoGap-r13							NULL,
+		useAnchorGapConfig-r13					NULL,
+		explicitGapConfiguration-r13			DL-GapConfig-NB-r13,
+		spare									NULL
+	}		OPTIONAL,	-- Need ON
+	inbandCarrierInfo-r13					SEQUENCE {
+		samePCI-Indicator-r13					CHOICE	{
+			samePCI-r13								SEQUENCE {
+				indexToMidPRB-r13						INTEGER (-55..54)
+			},
+			differentPCI-r13						SEQUENCE {
+				eutra-NumCRS-Ports-r13					ENUMERATED {same, four}
+			}
+		}							OPTIONAL,		-- Cond anchor-guardband-or-standalone
+		eutraControlRegionSize-r13				ENUMERATED {n1, n2, n3}	
+	}								OPTIONAL,		-- Cond non-anchor-inband
+	...,
+	[[	nrs-PowerOffsetNonAnchor-v1330		ENUMERATED {dB-12, dB-10, dB-8, dB-6,
+														dB-4, dB-2, dB0, dB3}	
+									OPTIONAL	-- Need ON
+	]],
+	[[	dl-GapNonAnchor-v1530				DL-GapConfig-NB-v1530	OPTIONAL	-- Cond TDD1
+	]],
+	[[	dl-CarrierFreq-v1550				CarrierFreq-NB-v1550	OPTIONAL	-- Cond TDD1
+	]]
+}
+
+UL-CarrierConfigDedicated-NB-r13 ::=	SEQUENCE {
+	ul-CarrierFreq-r13			CarrierFreq-NB-r13		OPTIONAL,	-- Need OP
+	...,
+	[[	tdd-UL-DL-AlignmentOffset-r15		TDD-UL-DL-AlignmentOffset-NB-r15		OPTIONAL		-- Cond TDD
+	]]
+}
+
+
+
+CarrierFreq-NB-r13 ::=		SEQUENCE {
+	carrierFreq-r13				ARFCN-ValueEUTRA-r9,
+	carrierFreqOffset-r13		ENUMERATED {
+									v-10, v-9, v-8,	v-7, v-6, v-5, v-4, v-3, v-2, v-1, v-0dot5,
+									 v0, v1, v2, v3, v4, v5, v6, v7, v8, v9
+									}	OPTIONAL	-- Need ON
+}
+
+CarrierFreq-NB-v1550	::=		SEQUENCE {
+	carrierFreqOffset-v1550		ENUMERATED {v-8dot5, v-4dot5, v3dot5, v7dot5}
+}
+
+
+
+ChannelRasterOffset-NB-r13 ::= ENUMERATED {khz-7dot5, khz-2dot5, khz2dot5, khz7dot5}
+
+
+
+DL-Bitmap-NB-r13 ::=			CHOICE {
+	subframePattern10-r13			BIT STRING (SIZE (10)),
+	subframePattern40-r13			BIT STRING (SIZE (40))
+}
+
+
+
+DL-CarrierConfigCommon-NB-r14 ::=	SEQUENCE {
+	dl-CarrierFreq-r14					CarrierFreq-NB-r13,
+	downlinkBitmapNonAnchor-r14			CHOICE {
+		useNoBitmap-r14						NULL,
+		useAnchorBitmap-r14					NULL,
+		explicitBitmapConfiguration-r14		DL-Bitmap-NB-r13
+	},
+	dl-GapNonAnchor-r14					CHOICE {
+		useNoGap-r14						NULL,
+		useAnchorGapConfig-r14				NULL,
+		explicitGapConfiguration-r14		DL-GapConfig-NB-r13
+	},	
+	inbandCarrierInfo-r14				SEQUENCE {
+		samePCI-Indicator-r14				CHOICE	{
+			samePCI-r14							SEQUENCE {
+				indexToMidPRB-r14					INTEGER (-55..54)
+			},
+			differentPCI-r14					SEQUENCE {
+				eutra-NumCRS-Ports-r14				ENUMERATED {same, four}
+			}
+		}	OPTIONAL,		-- Cond anchor-guardband-or-standalone
+		eutraControlRegionSize-r14			ENUMERATED {n1, n2, n3}	
+	}	OPTIONAL,		-- Cond non-anchor-inband
+	nrs-PowerOffsetNonAnchor-r14		ENUMERATED {dB-12, dB-10, dB-8, dB-6,
+													dB-4, dB-2, dB0, dB3}	DEFAULT dB0,
+	...,
+	[[	dl-GapNonAnchor-v1530			DL-GapConfig-NB-v1530	OPTIONAL	-- Cond TDD
+	]],
+	[[	dl-CarrierFreq-v1550			CarrierFreq-NB-v1550	OPTIONAL	-- Cond TDD
+	]]
+}
+
+
+
+
+DL-GapConfig-NB-r13	::=		SEQUENCE {
+	dl-GapThreshold-r13			ENUMERATED {n32, n64, n128, n256},
+	dl-GapPeriodicity-r13		ENUMERATED {sf64, sf128, sf256, sf512},
+	dl-GapDurationCoeff-r13		ENUMERATED {oneEighth, oneFourth, threeEighth, oneHalf}
+}
+
+DL-GapConfig-NB-v1530	::=	SEQUENCE {
+	dl-GapPeriodicity-v1530		ENUMERATED {sf1024}
+}
+
+
+
+GWUS-Config-NB-r16 ::= 			SEQUENCE {
+	groupAlternation-r16			ENUMERATED {true}			OPTIONAL, -- Need OR
+	commonSequence-r16				ENUMERATED {g0, g126}		OPTIONAL, -- Need OR
+	timeParameters-r16				WUS-Config-NB-r15			OPTIONAL, -- Cond noWUSr15
+	resourceConfigDRX-r16			GWUS-ResourceConfig-NB-r16,
+	resourceConfig-eDRX-Short-r16	GWUS-ResourceConfig-NB-r16	OPTIONAL, -- Need OP
+	resourceConfig-eDRX-Long-r16	GWUS-ResourceConfig-NB-r16	OPTIONAL, -- Cond timeOffset
+	probThreshList-r16				GWUS-ProbThreshList-NB-r16	OPTIONAL, -- Cond probabilityBased
+	...	
+}
+
+GWUS-ResourceConfig-NB-r16 ::= 	SEQUENCE {
+	resourcePosition-r16			ENUMERATED {primary, secondary},
+	numGroupsList-r16				GWUS-NumGroupsList-NB-r16			OPTIONAL, 	-- Need OP
+	groupsForServiceList-r16		GWUS-GroupsForServiceList-NB-r16
+															OPTIONAL 	-- Cond probabilityBased
+}
+
+GWUS-ProbThreshList-NB-r16 ::= 			SEQUENCE (SIZE (1..maxGWUS-ProbThresholds-NB-r16)) OF
+											GWUS-Paging-ProbThresh-NB-r16
+
+GWUS-Paging-ProbThresh-NB-r16 ::= 		ENUMERATED {p20, p30, p40, p50, p60, p70, p80, p90}
+
+GWUS-NumGroupsList-NB-r16 ::= 			SEQUENCE (SIZE (1..maxGWUS-Resources-NB-r16)) OF
+											GWUS-NumGroups-NB-r16
+
+GWUS-NumGroups-NB-r16 ::= 				ENUMERATED {n1, n2, n4, n8}
+
+GWUS-GroupsForServiceList-NB-r16 ::=	SEQUENCE (SIZE (1..maxGWUS-ProbThresholds-NB-r16)) OF
+											INTEGER (1..maxGWUS-Groups-1-NB-r16)
+
+
+
+LogicalChannelConfig-NB-r13 ::=		SEQUENCE {
+	priority-r13						INTEGER (1..16)			OPTIONAL,		-- Cond UL
+	logicalChannelSR-Prohibit-r13		BOOLEAN					OPTIONAL,		-- Need ON
+	...
+}
+
+
+
+MAC-MainConfig-NB-r13 ::=			SEQUENCE {
+	ul-SCH-Config-r13					SEQUENCE {
+		periodicBSR-Timer-r13				PeriodicBSR-Timer-NB-r13		OPTIONAL,	-- Need ON
+		retxBSR-Timer-r13					RetxBSR-Timer-NB-r13
+	}																	OPTIONAL,	-- Need ON
+	drx-Config-r13						DRX-Config-NB-r13				OPTIONAL,	-- Need ON
+	timeAlignmentTimerDedicated-r13		TimeAlignmentTimer,
+	logicalChannelSR-Config-r13			CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			logicalChannelSR-ProhibitTimer-r13	ENUMERATED {
+													pp2, pp8, pp32, pp128, pp512,
+													pp1024, pp2048, spare}
+		}
+	}																	OPTIONAL,	-- Need ON
+	...,
+	[[	rai-Activation-r14						ENUMERATED {true}			OPTIONAL,	-- Need OR
+		dataInactivityTimerConfig-r14	CHOICE {
+			release								NULL,
+			setup								SEQUENCE {
+				dataInactivityTimer-r14				DataInactivityTimer-r14
+			}
+		}																OPTIONAL	-- Need ON
+	]],
+	[[	drx-Cycle-v1430					ENUMERATED {
+									sf1280, sf2560, sf5120, sf10240}	OPTIONAL	-- Need ON
+	]],
+	[[	ra-CFRA-Config-r14				ENUMERATED {true}				OPTIONAL	-- Need ON
+	]]
+}
+
+PeriodicBSR-Timer-NB-r13 ::=		ENUMERATED {
+										pp2, pp4, pp8, pp16, pp64, pp128, infinity, spare}
+
+RetxBSR-Timer-NB-r13 ::=			ENUMERATED {
+										pp4, pp16, pp64, pp128, pp256, pp512, infinity, spare}
+
+DRX-Config-NB-r13 ::=				CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		onDurationTimer-r13					ENUMERATED {
+												pp1, pp2, pp3, pp4, pp8, pp16, pp32, spare},
+		drx-InactivityTimer-r13				ENUMERATED {
+												pp0, pp1, pp2, pp3, pp4, pp8, pp16, pp32},
+		drx-RetransmissionTimer-r13			ENUMERATED {
+												pp0, pp1, pp2, pp4, pp6, pp8, pp16, pp24,
+												pp33, spare7, spare6, spare5,
+												spare4, spare3, spare2, spare1},
+		drx-Cycle-r13						ENUMERATED {
+												sf256, sf512, sf1024, sf1536, sf2048, sf3072,
+												sf4096, sf4608, sf6144, sf7680, sf8192, sf9216,
+												spare4, spare3, spare2, spare1},
+		drx-StartOffset-r13					INTEGER (0..255),
+		drx-ULRetransmissionTimer-r13		ENUMERATED {
+												pp0, pp1, pp2, pp4, pp6, pp8, pp16, pp24,
+												pp33, pp40, pp64, pp80, pp96,
+												pp112, pp128, pp160, pp320}
+	}
+}
+
+
+
+
+NPDCCH-ConfigDedicated-NB-r13 ::=	SEQUENCE {
+	npdcch-NumRepetitions-r13			ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128,
+													r256, r512, r1024, r2048,
+													spare4, spare3, spare2, spare1},
+	npdcch-StartSF-USS-r13				ENUMERATED {v1dot5, v2, v4, v8, v16, v32, v48, v64},
+	npdcch-Offset-USS-r13				ENUMERATED {zero, oneEighth, oneFourth, threeEighth}
+}
+
+NPDCCH-ConfigDedicated-NB-v1530 ::=	SEQUENCE {
+	npdcch-StartSF-USS-v1530			ENUMERATED {v96, v128}
+}
+
+
+
+
+NPDSCH-ConfigCommon-NB-r13 ::=	SEQUENCE {
+	nrs-Power-r13					INTEGER (-60..50)
+}
+
+NPDSCH-ConfigDedicated-NB-r16 ::=	SEQUENCE {
+	npdsch-MultiTB-Config-r16			NPDSCH-MultiTB-Config-NB-r16	 OPTIONAL	-- Cond twoHARQ
+}
+
+NPDSCH-MultiTB-Config-NB-r16 ::=	SEQUENCE {
+	multiTB-Config-r16					ENUMERATED {interleaved, nonInterleaved},
+	harq-AckBundling-r16				ENUMERATED {true}		OPTIONAL	-- Cond interleaved
+}
+
+
+
+NPRACH-ConfigSIB-NB-r13 ::=			SEQUENCE {
+	nprach-CP-Length-r13				ENUMERATED {us66dot7, us266dot7},
+	rsrp-ThresholdsPrachInfoList-r13	RSRP-ThresholdsNPRACH-InfoList-NB-r13	OPTIONAL,	-- Need OR
+	nprach-ParametersList-r13		NPRACH-ParametersList-NB-r13
+}
+
+NPRACH-ConfigSIB-NB-v1330 ::=		SEQUENCE {
+	nprach-ParametersList-v1330			NPRACH-ParametersList-NB-v1330
+}
+
+NPRACH-ConfigSIB-NB-v1450 ::=		SEQUENCE {
+	maxNumPreambleAttemptCE-r14			ENUMERATED {n3, n4, n5, n6, n7, n8, n10, spare1}
+}
+
+NPRACH-ConfigSIB-NB-v1530 ::=		SEQUENCE {
+	tdd-Parameters-r15					SEQUENCE {
+		nprach-PreambleFormat-r15			ENUMERATED {
+												fmt0, fmt1, fmt2, fmt0-a, fmt1-a},
+		dummy								ENUMERATED {
+												n1, n2, n4, n8, n16, n32, n64, n128,
+												n256, n512, n1024},
+		nprach-ParametersListTDD-r15		NPRACH-ParametersListTDD-NB-r15
+	}	OPTIONAL,		-- Cond TDD
+	fmt2-Parameters-r15					SEQUENCE {
+		nprach-ParametersListFmt2-r15		NPRACH-ParametersListFmt2-NB-r15 OPTIONAL,	-- Need OR
+		nprach-ParametersListFmt2EDT-r15	NPRACH-ParametersListFmt2-NB-r15 OPTIONAL	-- Cond EDT2
+	}	OPTIONAL,		-- Need OR
+	edt-Parameters-r15					SEQUENCE {
+		edt-SmallTBS-Subset-r15				ENUMERATED {true}				OPTIONAL,	-- Need OR
+		edt-TBS-InfoList-r15				EDT-TBS-InfoList-NB-r15,
+		nprach-ParametersListEDT-r15		NPRACH-ParametersList-NB-r14	OPTIONAL	-- Need OR
+	}	OPTIONAL		-- Cond EDT1
+}
+
+NPRACH-ConfigSIB-NB-v1550 ::=		SEQUENCE {
+	tdd-Parameters-v1550				SEQUENCE {
+		nprach-ParametersListTDD-v1550		NPRACH-ParametersListTDD-NB-v1550
+	}
+}
+
+NPRACH-ParametersList-NB-r13 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF NPRACH-Parameters-NB-r13
+
+NPRACH-ParametersList-NB-v1330 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF NPRACH-Parameters-NB-v1330
+
+NPRACH-Parameters-NB-r13::=			SEQUENCE {
+	nprach-Periodicity-r13					ENUMERATED {ms40, ms80, ms160, ms240,
+														ms320, ms640, ms1280, ms2560},
+	nprach-StartTime-r13					ENUMERATED {ms8, ms16, ms32, ms64,
+														ms128, ms256, ms512, ms1024},
+	nprach-SubcarrierOffset-r13				ENUMERATED {n0, n12, n24, n36, n2, n18, n34, spare1},
+	nprach-NumSubcarriers-r13				ENUMERATED {n12, n24, n36, n48},
+	nprach-SubcarrierMSG3-RangeStart-r13	ENUMERATED {zero, oneThird, twoThird, one},
+	maxNumPreambleAttemptCE-r13				ENUMERATED {n3, n4, n5, n6, n7, n8, n10, spare1},
+	numRepetitionsPerPreambleAttempt-r13	ENUMERATED {n1, n2, n4, n8, n16, n32, n64, n128},
+	npdcch-NumRepetitions-RA-r13			ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128,
+														r256, r512, r1024, r2048,
+														spare4, spare3, spare2, spare1},
+	npdcch-StartSF-CSS-RA-r13				ENUMERATED {v1dot5, v2, v4, v8, v16, v32, v48, v64},
+	npdcch-Offset-RA-r13					ENUMERATED {zero, oneEighth, oneFourth, threeEighth}
+}
+
+NPRACH-Parameters-NB-v1330 ::=		SEQUENCE {
+	nprach-NumCBRA-StartSubcarriers-r13		ENUMERATED {n8, n10, n11, n12, n20, n22, n23, n24,
+														n32, n34, n35, n36, n40, n44, n46, n48}
+}
+
+NPRACH-ParametersList-NB-r14 ::=		SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF
+											NPRACH-Parameters-NB-r14
+
+NPRACH-Parameters-NB-r14 ::=			SEQUENCE {
+	nprach-Parameters-r14					SEQUENCE {
+		nprach-Periodicity-r14					ENUMERATED {ms40, ms80, ms160, ms240,
+															ms320, ms640, ms1280, ms2560}
+													OPTIONAL,	-- NEED OP
+		nprach-StartTime-r14					ENUMERATED {ms8, ms16, ms32, ms64,
+															ms128, ms256, ms512, ms1024}
+													OPTIONAL,	-- NEED OP
+		nprach-SubcarrierOffset-r14				ENUMERATED {n0, n12, n24, n36, n2, n18, n34, spare1}
+													OPTIONAL,	-- NEED OP
+		nprach-NumSubcarriers-r14				ENUMERATED {n12, n24, n36, n48}
+													OPTIONAL,	-- NEED OP
+		nprach-SubcarrierMSG3-RangeStart-r14	ENUMERATED {zero, oneThird, twoThird, one}
+													OPTIONAL,	-- NEED OP
+		npdcch-NumRepetitions-RA-r14			ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128,
+															r256, r512, r1024, r2048,
+															spare4, spare3, spare2, spare1}
+													OPTIONAL,	-- NEED OP
+		npdcch-StartSF-CSS-RA-r14				ENUMERATED {v1dot5, v2, v4, v8, v16, v32, v48, v64}
+														OPTIONAL,	-- NEED OP
+		npdcch-Offset-RA-r14					ENUMERATED {zero, oneEighth, oneFourth, threeEighth}
+													OPTIONAL,	-- NEED OP
+		nprach-NumCBRA-StartSubcarriers-r14		ENUMERATED {n8, n10, n11, n12, n20, n22, n23, n24,
+															n32, n34, n35, n36, n40, n44, n46, n48}
+													OPTIONAL,	-- NEED OP
+		npdcch-CarrierIndex-r14					INTEGER (1..maxNonAnchorCarriers-NB-r14)
+													OPTIONAL,	-- Need OP
+		...
+	}	OPTIONAL	-- Need OR
+}
+
+NPRACH-ParametersListTDD-NB-r15 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF
+											NPRACH-ParametersTDD-NB-r15
+
+NPRACH-ParametersTDD-NB-r15 ::=		SEQUENCE {
+	nprach-Parameters-r15					SEQUENCE {
+		nprach-Periodicity-r15					ENUMERATED {ms80, ms160, ms320, ms640,
+															ms1280, ms2560, ms5120, ms10240}
+													OPTIONAL,	-- NEED OP
+		nprach-StartTime-r15					ENUMERATED {ms10, ms20, ms40, ms80,
+															ms160, ms320, ms640, ms1280,
+															ms2560, ms5120, spare6, spare5,
+															spare4, spare3, spare2, spare1}
+													OPTIONAL,	-- NEED OP
+		nprach-SubcarrierOffset-r15				ENUMERATED {n0, n12, n24, n36, n2, n18, n34, spare1}
+													OPTIONAL,	-- NEED OP
+		nprach-NumSubcarriers-r15				ENUMERATED {n12, n24, n36, n48}
+													OPTIONAL,	-- NEED OP
+		nprach-SubcarrierMSG3-RangeStart-r15	ENUMERATED {zero, oneThird, twoThird, one}
+													OPTIONAL,	-- NEED OP
+		npdcch-NumRepetitions-RA-r15			ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128,
+															r256, r512, r1024, r2048,
+															spare4, spare3, spare2, spare1}
+													OPTIONAL,	-- NEED OP
+		npdcch-StartSF-CSS-RA-r15				ENUMERATED {v4, v8, v16, v32, v48, v64, v96, v128}
+														OPTIONAL,	-- NEED OP
+		npdcch-Offset-RA-r15					ENUMERATED {zero, oneEighth, oneFourth, threeEighth}
+													OPTIONAL,	-- NEED OP
+		nprach-NumCBRA-StartSubcarriers-r15		ENUMERATED {n8, n10, n11, n12, n20, n22, n23, n24,
+															n32, n34, n35, n36, n40, n44, n46, n48}
+													OPTIONAL,	-- NEED OP
+		...
+	}	OPTIONAL	-- Need OR
+}
+
+NPRACH-ParametersListTDD-NB-v1550 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF
+												NPRACH-ParametersTDD-NB-v1550
+
+NPRACH-ParametersTDD-NB-v1550 ::=	SEQUENCE {
+	maxNumPreambleAttemptCE-v1550			ENUMERATED {n3, n4, n5, n6, n7, n8, n10, spare1},
+	numRepetitionsPerPreambleAttempt-v1550	ENUMERATED {n1, n2, n4, n8, n16, n32, n64, n128,
+															 n256, n512, n1024}
+}
+
+NPRACH-ParametersListFmt2-NB-r15 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF NPRACH-ParametersFmt2-NB-r15
+
+NPRACH-ParametersFmt2-NB-r15 ::=		SEQUENCE {
+	nprach-Parameters-r15					SEQUENCE {
+		nprach-Periodicity-r15					ENUMERATED {ms40, ms80, ms160, ms320,
+															ms640, ms1280, ms2560, ms5120}
+													OPTIONAL,	-- NEED OP
+		nprach-StartTime-r15					ENUMERATED {ms8, ms16, ms32, ms64,
+															ms128, ms256, ms512, ms1024}
+													OPTIONAL,	-- NEED OP
+		nprach-SubcarrierOffset-r15				ENUMERATED {n0, n36, n72, n108, n6, n54, n102, n42,
+															n78, n90, n12, n24, n48, n84, n60, n18}
+													OPTIONAL,	-- NEED OP
+		nprach-NumSubcarriers-r15				ENUMERATED {n36, n72, n108, n144}
+													OPTIONAL,	-- NEED OP
+		nprach-SubcarrierMSG3-RangeStart-r15	ENUMERATED {zero, oneThird, twoThird, one}
+													OPTIONAL,	-- NEED OP
+		npdcch-NumRepetitions-RA-r15			ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128,
+															r256, r512, r1024, r2048,
+															spare4, spare3, spare2, spare1}
+													OPTIONAL,	-- NEED OP
+		npdcch-StartSF-CSS-RA-r15				ENUMERATED {v1dot5, v2, v4, v8, v16, v32, v48, v64}
+														OPTIONAL,	-- NEED OP
+		npdcch-Offset-RA-r15					ENUMERATED {zero, oneEighth, oneFourth, threeEighth}
+													OPTIONAL,	-- NEED OP
+		nprach-NumCBRA-StartSubcarriers-r15		ENUMERATED {
+													n24, n30, n33, n36, n60, n66, n69, n72,
+													n96, n102, n105, n108, n120, n132, n138, n144}
+													OPTIONAL,	-- NEED OP
+		npdcch-CarrierIndex-r15					INTEGER (1..maxNonAnchorCarriers-NB-r14)
+													OPTIONAL,	-- Need OP
+		...
+	}	OPTIONAL	-- Need OR
+}
+
+RSRP-ThresholdsNPRACH-InfoList-NB-r13 ::= SEQUENCE (SIZE(1..2)) OF RSRP-Range
+
+EDT-TBS-InfoList-NB-r15 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF EDT-TBS-NB-r15
+
+EDT-TBS-NB-r15 ::=	SEQUENCE {
+	edt-SmallTBS-Enabled-r15		BOOLEAN,
+	edt-TBS-r15						ENUMERATED {b328, b408, b504, b584, b680, b808, b936, b1000}
+}
+
+
+
+NPUSCH-ConfigCommon-NB-r13 ::=		SEQUENCE {
+	ack-NACK-NumRepetitions-Msg4-r13	SEQUENCE (SIZE(1.. maxNPRACH-Resources-NB-r13)) OF
+														ACK-NACK-NumRepetitions-NB-r13,
+	srs-SubframeConfig-r13				ENUMERATED {
+											sc0, sc1, sc2, sc3, sc4, sc5, sc6, sc7,
+											sc8, sc9, sc10, sc11, sc12, sc13, sc14, sc15
+											}							OPTIONAL,	-- Need OR
+	dmrs-Config-r13						SEQUENCE {
+		threeTone-BaseSequence-r13			INTEGER (0..12)			OPTIONAL,	-- Need OP
+		threeTone-CyclicShift-r13			INTEGER (0..2),
+		sixTone-BaseSequence-r13			INTEGER (0..14)			OPTIONAL,	-- Need OP
+		sixTone-CyclicShift-r13				INTEGER (0..3),
+		twelveTone-BaseSequence-r13			INTEGER (0..30)			OPTIONAL	-- Need OP
+	}		OPTIONAL,	-- Need OR
+	ul-ReferenceSignalsNPUSCH-r13		UL-ReferenceSignalsNPUSCH-NB-r13
+}
+
+UL-ReferenceSignalsNPUSCH-NB-r13 ::=	SEQUENCE {
+	groupHoppingEnabled-r13					BOOLEAN,
+	groupAssignmentNPUSCH-r13				INTEGER (0..29)
+}
+
+NPUSCH-ConfigDedicated-NB-r13 ::=	SEQUENCE {
+	ack-NACK-NumRepetitions-r13			ACK-NACK-NumRepetitions-NB-r13	OPTIONAL,	-- Need ON
+	npusch-AllSymbols-r13				BOOLEAN							OPTIONAL,	-- Cond SRS
+	groupHoppingDisabled-r13			ENUMERATED {true}				OPTIONAL	-- Need OR
+}
+
+NPUSCH-ConfigDedicated-NB-v1610 ::=	SEQUENCE {
+	npusch-MultiTB-Config-r16			ENUMERATED {interleaved, nonInterleaved}
+}
+
+ACK-NACK-NumRepetitions-NB-r13	::=	ENUMERATED {r1, r2, r4, r8, r16, r32, r64, r128}
+
+
+
+
+PDCP-Config-NB-r13 ::=		SEQUENCE {
+	discardTimer-r13			ENUMERATED {
+									ms5120, ms10240, ms20480, ms40960,
+									ms81920, infinity, spare2, spare1
+									}	OPTIONAL,			-- Cond Setup
+	headerCompression-r13		CHOICE {
+		notUsed						NULL,
+		rohc						SEQUENCE {
+			maxCID-r13					INTEGER (1..16383)				DEFAULT 15,
+			profiles-r13				SEQUENCE {
+				profile0x0002				BOOLEAN,
+				profile0x0003				BOOLEAN,
+				profile0x0004				BOOLEAN,
+				profile0x0006				BOOLEAN,
+				profile0x0102				BOOLEAN,
+				profile0x0103				BOOLEAN,
+				profile0x0104				BOOLEAN
+			},
+			...
+		}
+	},
+	...,
+	[[	cipheringDisabled-r16		ENUMERATED {true}		OPTIONAL    -- Cond ConnectedTo5GC
+	]]
+}
+
+
+
+PhysicalConfigDedicated-NB-r13 ::=	SEQUENCE {
+	carrierConfigDedicated-r13			CarrierConfigDedicated-NB-r13		OPTIONAL,	-- Need ON
+	npdcch-ConfigDedicated-r13			NPDCCH-ConfigDedicated-NB-r13		OPTIONAL,	-- Need ON
+	npusch-ConfigDedicated-r13			NPUSCH-ConfigDedicated-NB-r13		OPTIONAL,	-- Need ON
+	uplinkPowerControlDedicated-r13		UplinkPowerControlDedicated-NB-r13	OPTIONAL,	-- Need ON
+	...,
+	[[	twoHARQ-ProcessesConfig-r14		ENUMERATED {true}	OPTIONAL	-- Need OR
+	]],
+	[[	interferenceRandomisationConfig-r14	ENUMERATED {true}	OPTIONAL	-- Need OR
+	]],
+	[[	npdcch-ConfigDedicated-v1530	NPDCCH-ConfigDedicated-NB-v1530		OPTIONAL	-- Cond TDD
+	]],
+	[[	additionalTxSIB1-Config-v1540	ENUMERATED {true}	OPTIONAL	-- Cond additionalSIB1
+	]],
+	[[	npusch-ConfigDedicated-v1610		NPUSCH-ConfigDedicated-NB-v1610
+																	OPTIONAL,	-- Cond twoHARQ
+		npdsch-ConfigDedicated-r16			NPDSCH-ConfigDedicated-NB-r16
+																	OPTIONAL,
+		resourceReservationConfigDL-r16		SetupRelease {ResourceReservationConfig-NB-r16}
+																		OPTIONAL,	-- Cond dl-NonAnchor
+		resourceReservationConfigUL-r16		SetupRelease {ResourceReservationConfig-NB-r16}
+																	OPTIONAL	-- Cond ul-NonAnchor
+	]]
+}
+
+
+
+PUR-Config-NB-r16	::=				SEQUENCE {
+	pur-ConfigID-r16					PUR-ConfigID-NB-r16				OPTIONAL,	--Need OR
+	pur-TimeAlignmentTimer-r16			INTEGER (1..8)				OPTIONAL,	--Need OR
+	pur-NRSRP-ChangeThreshold-r16		SetupRelease {PUR-NRSRP-ChangeThreshold-r16}
+																		OPTIONAL,	--Need ON
+	pur-ImplicitReleaseAfter-r16		ENUMERATED {n2, n4, n8, spare}	OPTIONAL,	--Need OR
+	pur-RNTI-r16						C-RNTI							OPTIONAL,	--Need ON
+	pur-ResponseWindowTimer-r16			ENUMERATED {pp1, pp2, pp3, pp4, pp8, pp16, pp32, pp64}
+																		OPTIONAL,	--Need ON
+	pur-StartTimeParameters-r16			SEQUENCE {
+		periodicityAndOffset-r16			PUR-PeriodicityAndOffset-NB-r16,
+		startSFN-r16						INTEGER (0..1023),
+		startSubframe-r16					INTEGER (0..9),
+		hsfn-LSB-Info-r16					BIT STRING (SIZE(1))
+	}																	OPTIONAL,	--Need ON
+	pur-NumOccasions-r16				ENUMERATED {one, infinite},
+	pur-PhysicalConfig-r16				SEQUENCE {
+		carrierConfig-r16					CarrierConfigDedicated-NB-r13,
+		npusch-NumRUsIndex-r16				INTEGER (0..7),
+		npusch-NumRepetitionsIndex-r16		INTEGER (0..7),
+		npusch-SubCarrierSetIndex-r16		CHOICE {
+			khz15								INTEGER (0..18),
+			khz3dot75							INTEGER (0..47)
+		},
+		npusch-MCS-r16						CHOICE {
+			singleTone							INTEGER (0..10),
+			multiTone							INTEGER (0..13)
+		},
+		p0-UE-NPUSCH-r16					INTEGER (-8..7),
+		alpha-r16							ENUMERATED {al0, al04, al05, al06,
+														al07, al08, al09, al1},
+		npusch-CyclicShift-r16				ENUMERATED {n0, n6},
+		npdcch-Config-r16					NPDCCH-ConfigDedicated-NB-r13
+	}	OPTIONAL,	-- Need ON
+	...
+}
+
+PUR-NRSRP-ChangeThreshold-r16 ::=	SEQUENCE {
+	increaseThresh-r16						NRSRP-ChangeThresh-NB-r16,
+	decreaseThresh-r16						NRSRP-ChangeThresh-NB-r16	OPTIONAL	--Need OP
+}
+
+NRSRP-ChangeThresh-NB-r16 ::= ENUMERATED {dB4, dB6, dB8, dB10, dB14, dB18, dB22, dB26, dB30, dB34, spare6, spare5, spare4, spare3, spare2, spare1}
+
+
+
+PUR-ConfigID-NB-r16 ::= BIT STRING (SIZE(20))
+
+
+
+PUR-PeriodicityAndOffset-NB-r16 ::= 	CHOICE {
+	periodicity8		INTEGER (1..7),
+	periodicity16		INTEGER (1..15),
+	periodicity32		INTEGER (1..31),
+	periodicity64		INTEGER (1..63),
+	periodicity128		INTEGER (1..127),
+	periodicity256		INTEGER (1..257),
+	periodicity512		INTEGER (1..511),
+	periodicity1024		INTEGER (1..1023),
+	periodicity2048		INTEGER (1..2047),
+	periodicity4096		INTEGER (1..4095),
+	periodicity8192		INTEGER (1..8191)
+}
+
+
+
+RACH-ConfigCommon-NB-r13 ::=		SEQUENCE {
+	preambleTransMax-CE-r13				PreambleTransMax,
+	powerRampingParameters-r13			PowerRampingParameters,
+	rach-InfoList-r13					RACH-InfoList-NB-r13,
+	connEstFailOffset-r13				INTEGER (0..15)					OPTIONAL,	-- Need OP
+	...,
+	[[	powerRampingParameters-v1450	PowerRampingParameters-NB-v1450	OPTIONAL	-- Need OR
+	]],
+	[[ rach-InfoList-v1530				RACH-InfoList-NB-v1530	OPTIONAL -- Cond EDT
+	]]
+}
+
+RACH-InfoList-NB-r13 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF RACH-Info-NB-r13
+
+RACH-InfoList-NB-v1530 ::=	SEQUENCE (SIZE (1.. maxNPRACH-Resources-NB-r13)) OF RACH-Info-NB-v1530
+
+RACH-Info-NB-r13	::=		SEQUENCE {
+	ra-ResponseWindowSize-r13			ENUMERATED {
+											pp2, pp3, pp4, pp5, pp6, pp7, pp8, pp10},
+	mac-ContentionResolutionTimer-r13	ENUMERATED {
+											pp1, pp2, pp3, pp4, pp8, pp16, pp32, pp64}
+}
+
+RACH-Info-NB-v1530 ::=		SEQUENCE {
+	mac-ContentionResolutionTimer-r15	ENUMERATED {
+											pp1, pp2, pp3, pp4, pp8, pp16, pp32, pp64}
+}
+
+PowerRampingParameters-NB-v1450 ::=		SEQUENCE {
+	preambleInitialReceivedTargetPower-v1450		ENUMERATED {
+													dBm-130, dBm-128, dBm-126, dBm-124, dBm-122,
+													dBm-88, dBm-86, dBm-84,dBm-82, dBm-80}
+													OPTIONAL,	-- Need OR
+	powerRampingParametersCE1-r14				SEQUENCE {
+		powerRampingStepCE1-r14						ENUMERATED {dB0, dB2, dB4, dB6},
+		preambleInitialReceivedTargetPowerCE1-r14	ENUMERATED {
+													dBm-130, dBm-128, dBm-126, dBm-124, dBm-122,
+													dBm-120, dBm-118, dBm-116, dBm-114, dBm-112,
+													dBm-110, dBm-108, dBm-106, dBm-104, dBm-102,
+													dBm-100, dBm-98, dBm-96, dBm-94, dBm-92,
+													dBm-90, dBm-88, dBm-86, dBm-84,	dBm-82, dBm-80}
+	} OPTIONAL	-- Need OR
+}
+
+
+
+RadioResourceConfigCommonSIB-NB-r13 ::=	SEQUENCE {
+	rach-ConfigCommon-r13					RACH-ConfigCommon-NB-r13,
+	bcch-Config-r13							BCCH-Config-NB-r13,
+	pcch-Config-r13							PCCH-Config-NB-r13,
+	nprach-Config-r13						NPRACH-ConfigSIB-NB-r13,
+	npdsch-ConfigCommon-r13					NPDSCH-ConfigCommon-NB-r13,
+	npusch-ConfigCommon-r13					NPUSCH-ConfigCommon-NB-r13,
+	dl-Gap-r13								DL-GapConfig-NB-r13			OPTIONAL,		-- Need OP
+	uplinkPowerControlCommon-r13			UplinkPowerControlCommon-NB-r13,
+	...,
+	[[	nprach-Config-v1330					NPRACH-ConfigSIB-NB-v1330	OPTIONAL		-- Need OR
+	]],
+	[[	nprach-Config-v1450					NPRACH-ConfigSIB-NB-v1450	OPTIONAL		-- Cond EnhPowerControl
+	]],
+	[[	nprach-Config-v1530					NPRACH-ConfigSIB-NB-v1530	OPTIONAL,	-- Need OR
+		dl-Gap-v1530						DL-GapConfig-NB-v1530		OPTIONAL,	-- Cond TDD
+		wus-Config-r15						WUS-Config-NB-r15			OPTIONAL	-- Need OR
+	]],
+	[[	nprach-Config-v1550					NPRACH-ConfigSIB-NB-v1550	OPTIONAL	-- Cond TDD1
+	]],
+	[[
+		gwus-Config-r16						GWUS-Config-NB-r16			OPTIONAL,	-- Need OR
+		nrs-NonAnchorConfig-r16				ENUMERATED {true}			OPTIONAL,	-- Need OR
+		ue-SpecificDRX-CycleMin-r16			ENUMERATED {rf32, rf64, rf128, rf256, rf512,
+															rf1024}		OPTIONAL	-- Need OR
+	]]
+}
+
+BCCH-Config-NB-r13 ::=					SEQUENCE {
+	modificationPeriodCoeff-r13				ENUMERATED {n16, n32, n64, n128}
+}
+
+PCCH-Config-NB-r13 ::=					SEQUENCE {
+	defaultPagingCycle-r13					ENUMERATED {rf128, rf256, rf512, rf1024},
+	nB-r13									ENUMERATED {
+												fourT, twoT, oneT, halfT, quarterT, one8thT,
+												one16thT, one32ndT, one64thT,
+												one128thT, one256thT, one512thT, one1024thT,
+												spare3, spare2, spare1},
+	npdcch-NumRepetitionPaging-r13			ENUMERATED {
+												r1, r2, r4, r8, r16, r32, r64, r128,
+												r256, r512, r1024, r2048,
+												spare4, spare3, spare2, spare1}
+}
+
+
+
+RadioResourceConfigDedicated-NB-r13 ::=	SEQUENCE {
+	srb-ToAddModList-r13					SRB-ToAddModList-NB-r13			OPTIONAL,	-- Need ON
+	drb-ToAddModList-r13					DRB-ToAddModList-NB-r13			OPTIONAL,	-- Need ON
+	drb-ToReleaseList-r13					DRB-ToReleaseList-NB-r13		OPTIONAL,	-- Need ON
+	mac-MainConfig-r13						CHOICE {
+		explicitValue-r13						MAC-MainConfig-NB-r13,
+		defaultValue-r13						NULL
+	}																		OPTIONAL,	-- Need ON
+	physicalConfigDedicated-r13				PhysicalConfigDedicated-NB-r13	OPTIONAL,	-- Need ON
+	rlf-TimersAndConstants-r13				RLF-TimersAndConstants-NB-r13	OPTIONAL,	-- Need ON
+	...,
+	[[	schedulingRequestConfig-r15			SchedulingRequestConfig-NB-r15	OPTIONAL	-- Need ON
+	]],
+	[[	newUE-Identity-r16					C-RNTI							OPTIONAL	-- Need OP
+	]]
+}
+
+SRB-ToAddModList-NB-r13 ::=			SEQUENCE (SIZE (1)) OF SRB-ToAddMod-NB-r13
+
+SRB-ToAddMod-NB-r13 ::=				SEQUENCE {
+	rlc-Config-r13						CHOICE {
+		explicitValue						RLC-Config-NB-r13,
+		defaultValue						NULL
+	}		OPTIONAL,															-- Cond Setup
+	logicalChannelConfig-r13			CHOICE {
+		explicitValue						LogicalChannelConfig-NB-r13,
+		defaultValue						NULL
+	}		OPTIONAL,															-- Cond Setup
+	...,
+	[[	rlc-Config-v1430				RLC-Config-NB-v1430			OPTIONAL	-- Need ON
+	]]
+}
+
+DRB-ToAddModList-NB-r13 ::=			SEQUENCE (SIZE (1..maxDRB-NB-r13)) OF DRB-ToAddMod-NB-r13
+
+DRB-ToAddMod-NB-r13 ::=				SEQUENCE {
+	eps-BearerIdentity-r13				INTEGER (0..15)				OPTIONAL,	-- Cond DRB-Setup-EPC
+	drb-Identity-r13					DRB-Identity,
+	pdcp-Config-r13						PDCP-Config-NB-r13			OPTIONAL,	-- Cond Setup
+	rlc-Config-r13						RLC-Config-NB-r13			OPTIONAL,	-- Cond Setup
+	logicalChannelIdentity-r13			INTEGER (3..10)				OPTIONAL,	-- Cond DRB-Setup
+	logicalChannelConfig-r13			LogicalChannelConfig-NB-r13	OPTIONAL,	-- Cond Setup
+	...,
+	[[	rlc-Config-v1430				RLC-Config-NB-v1430			OPTIONAL	-- Need ON
+	]],
+	[[	pdu-Session-r16				PDU-SessionID-NB-r16		OPTIONAL	-- Cond DRB-Setup-5GC
+	]]
+}
+
+PDU-SessionID-NB-r16 ::=			INTEGER (0..255)
+
+DRB-ToReleaseList-NB-r13 ::=		SEQUENCE (SIZE (1..maxDRB-NB-r13)) OF DRB-Identity
+
+
+
+ResourceReservationConfig-NB-r16::=	SEQUENCE {
+	periodicity-r16				ENUMERATED {ms10, ms20, ms40, ms80, ms160, spare3, spare2, spare1},
+	startPosition-r16			INTEGER (0..15),
+	resourceReservation-r16		CHOICE {
+		subframeBitmap-r16			CHOICE {
+			subframePattern10ms			BIT STRING (SIZE (10)),
+			subframePattern40ms			BIT STRING (SIZE (40))
+		},
+		slotConfig-r16				SEQUENCE {
+			slotBitmap-r16				CHOICE {
+				slotPattern10ms				BIT STRING (SIZE (20)),
+				slotPattern40ms				BIT STRING (SIZE (80))
+			},
+			symbolBitmap-r16			CHOICE {
+				symbolBitmapFddDl			SEQUENCE {
+					symbolBitmap1-r16			BIT STRING (SIZE (5))	OPTIONAL,	-- Cond Bitmap1
+					symbolBitmap2-r16			BIT STRING (SIZE (5))	OPTIONAL	-- Cond Bitmap2
+				},
+				symbolBitmapFddUlOrTdd		SEQUENCE {
+					symbolBitmap1-r16			BIT STRING (SIZE (7))	OPTIONAL,	-- Cond Bitmap1
+					symbolBitmap2-r16			BIT STRING (SIZE (7))	OPTIONAL	-- Cond Bitmap2
+				}
+			}
+		}
+	},
+	...
+}
+
+
+
+RLC-Config-NB-r13 ::=	CHOICE	{
+	am						SEQUENCE {
+		ul-AM-RLC-r13				UL-AM-RLC-NB-r13,
+		dl-AM-RLC-r13				DL-AM-RLC-NB-r13
+	},
+	...,
+	um-Bi-Directional-r15		NULL,
+	um-Uni-Directional-UL-r15	NULL,
+	um-Uni-Directional-DL-r15	NULL
+}
+
+RLC-Config-NB-v1430 ::=	SEQUENCE {
+	t-Reordering-r14			T-Reordering		OPTIONAL		-- Cond twoHARQ
+}
+
+UL-AM-RLC-NB-r13 ::=		SEQUENCE {
+	t-PollRetransmit-r13		T-PollRetransmit-NB-r13,
+	maxRetxThreshold-r13		ENUMERATED {t1, t2, t3, t4, t6, t8, t16, t32}
+}
+
+DL-AM-RLC-NB-r13 ::=		SEQUENCE {
+	enableStatusReportSN-Gap-r13	ENUMERATED {true}	OPTIONAL
+}
+
+T-PollRetransmit-NB-r13 ::=	ENUMERATED {
+									ms250,	ms500,	ms1000,	ms2000,	ms3000,	ms4000,
+									ms6000, ms10000, ms15000, ms25000, ms40000, ms60000,
+									ms90000, ms120000, ms180000, ms300000-v1530}
+
+
+
+
+
+RLF-TimersAndConstants-NB-r13 ::=	CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		t301-r13							ENUMERATED {
+												ms2500, ms4000, ms6000, ms10000,
+												ms15000, ms25000, ms40000, ms60000},
+		t310-r13							ENUMERATED {
+												ms0, ms200, ms500, ms1000, ms2000, ms4000, ms8000},
+		n310-r13							ENUMERATED {
+												n1, n2, n3, n4, n6, n8, n10, n20},
+		t311-r13							ENUMERATED {
+												ms1000, ms3000, ms5000, ms10000, ms15000,
+												ms20000, ms30000},
+		n311-r13							ENUMERATED {
+												n1, n2, n3, n4, n5, n6, n8, n10},
+		...,
+		[[ t311-v1350						ENUMERATED {
+												ms40000, ms60000, ms90000, ms120000}
+														OPTIONAL	-- Need OR
+		]],
+		[[	t301-v1530						ENUMERATED {
+												ms80000, ms100000, ms120000}
+														OPTIONAL,	-- Cond TDD
+			t311-v1530						ENUMERATED {
+												ms160000, ms200000}
+														OPTIONAL	-- Cond TDD
+		]]
+	}
+}
+
+
+
+SchedulingRequestConfig-NB-r15 ::=	SEQUENCE {
+	sr-WithHARQ-ACK-Config-r15			ENUMERATED {true}	OPTIONAL,
+	sr-WithoutHARQ-ACK-Config-r15			SR-WithoutHARQ-ACK-Config-NB-r15	OPTIONAL,	-- Need ON
+	sr-SPS-BSR-Config-r15				SR-SPS-BSR-Config-NB-r15			OPTIONAL,	-- Need ON
+	...
+}
+
+SR-WithoutHARQ-ACK-Config-NB-r15 ::= CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		sr-ProhibitTimer-r15				INTEGER (0..7)	OPTIONAL,	-- Need ON
+		sr-NPRACH-Resource-r15				SR-NPRACH-Resource-NB-r15	OPTIONAL -- Need ON
+	}
+}
+
+SR-NPRACH-Resource-NB-r15		::=	SEQUENCE {
+	nprach-CarrierIndex-r15				INTEGER (0..maxNonAnchorCarriers-NB-r14),
+	nprach-ResourceIndex-r15			INTEGER (1..maxNPRACH-Resources-NB-r13),
+	nprach-SubCarrierIndex-r15			CHOICE {
+		nprach-Fmt0Fmt1-r15					INTEGER (0..47),
+		nprach-Fmt2-r15						INTEGER (0..143)
+	},
+	p0-SR-r15							INTEGER (-126..24),
+	alpha-r15							ENUMERATED {al0, al04, al05, al06, al07, al08, al09, al1}}
+
+SR-SPS-BSR-Config-NB-r15	 ::= CHOICE {
+	release								NULL,
+	setup								SEQUENCE {
+		semiPersistSchedC-RNTI-r15			C-RNTI,
+		semiPersistSchedIntervalUL-r15		ENUMERATED {sf128, sf256, sf512, sf1024,
+														sf1280, sf2048, sf2560, sf5120}
+	}
+}
+
+
+
+TDD-Config-NB-r15 ::=					SEQUENCE {
+	subframeAssignment-r15					ENUMERATED {
+												sa1, sa2, sa3, sa4, sa5},
+	specialSubframePatterns-r15				ENUMERATED {
+												ssp0, ssp1, ssp2, ssp3, ssp4, ssp5, ssp6, ssp7,
+												ssp8, ssp9, ssp10, ssp10-CRS-LessDwPTS}
+}
+
+
+
+TDD-UL-DL-AlignmentOffset-NB-r15 ::=				ENUMERATED {	khz-7dot5, khz0, khz7dot5}
+
+
+
+
+UplinkPowerControlCommon-NB-r13 ::=	SEQUENCE {
+	p0-NominalNPUSCH-r13				INTEGER (-126..24),
+	alpha-r13							ENUMERATED {al0, al04, al05, al06, al07, al08, al09, al1},
+	deltaPreambleMsg3-r13				INTEGER (-1..6)
+}
+
+UplinkPowerControlDedicated-NB-r13 ::=	SEQUENCE {
+	p0-UE-NPUSCH-r13						INTEGER (-8..7)
+}
+
+
+
+WUS-Config-NB-r15 ::=			SEQUENCE {
+	maxDurationFactor-r15			WUS-MaxDurationFactor-NB-r15,
+	numPOs-r15						ENUMERATED {n1, n2, n4}		DEFAULT n1,	
+	numDRX-CyclesRelaxed-r15			ENUMERATED {n1, n2, n4, n8},	
+	timeOffsetDRX-r15				ENUMERATED {ms40, ms80, ms160, ms240},
+	timeOffset-eDRX-Short-r15		ENUMERATED {ms40, ms80, ms160, ms240},
+	timeOffset-eDRX-Long-r15		ENUMERATED {ms1000, ms2000}	OPTIONAL,	-- Need OP
+	...	
+}
+
+WUS-ConfigPerCarrier-NB-r15 ::=	SEQUENCE {
+	maxDurationFactor-r15			WUS-MaxDurationFactor-NB-r15
+}
+
+WUS-MaxDurationFactor-NB-r15 ::= ENUMERATED {one128th, one64th, one32th, one16th,
+											oneEighth, oneQuarter, oneHalf}
+
+
+AdditionalBandInfoList-NB-r14 ::=	SEQUENCE (SIZE (1..maxMultiBands)) OF FreqBandIndicator-NB-r13
+
+
+
+FreqBandIndicator-NB-r13 ::=			INTEGER (1.. maxFBI2)
+
+
+
+MultiBandInfoList-NB-r13 ::=	SEQUENCE (SIZE (1..maxMultiBands)) OF MultiBandInfo-NB-r13
+
+MultiBandInfo-NB-r13 ::=		SEQUENCE {
+	freqBandIndicator-r13			FreqBandIndicator-NB-r13		OPTIONAL,	-- Need OR
+	freqBandInfo-r13				NS-PmaxList-NB-r13				OPTIONAL	-- Need OR
+}
+
+
+
+NS-PmaxList-NB-r13 ::=			SEQUENCE (SIZE (1..maxNS-Pmax-NB-r13)) OF NS-PmaxValue-NB-r13
+
+NS-PmaxValue-NB-r13 ::=			SEQUENCE {
+	additionalPmax-r13				P-Max						OPTIONAL,	-- Need OR
+	additionalSpectrumEmission-r13	AdditionalSpectrumEmission
+}
+
+
+
+ReselectionThreshold-NB-v1360 ::=			INTEGER (32..63)
+
+
+
+T-Reselection-NB-r13 ::=		ENUMERATED {s0, s3, s6, s9, s12, s15, s18, s21}
+
+
+
+ANR-MeasConfig-NB-r16 ::= SEQUENCE {
+	anr-QualityThreshold-r16		NRSRP-Range-NB-r14,
+	anr-CarrierList-r16				ANR-CarrierList-NB-r16,
+	...
+}
+
+ANR-CarrierList-NB-r16 ::=		SEQUENCE (SIZE (1..maxFreqANR-NB-r16)) OF ANR-Carrier-NB-r16
+
+ANR-Carrier-NB-r16::=			SEQUENCE {
+	carrierFreqIndex-r16			INTEGER (1..maxFreq),
+	blackCellList-r16				ANR-BlackCellList-NB-r16	OPTIONAL,		-- Need OP
+	...
+}
+
+ANR-BlackCellList-NB-r16 ::=	SEQUENCE (SIZE (1..maxCellBlack)) OF PhysCellId
+
+
+
+ANR-MeasReport-NB-r16 ::=	SEQUENCE {
+	servCellIdentity-r16			CellGlobalIdEUTRA			OPTIONAL,
+	measResultServCell-r16			MeasResultServCell-NB-r14,
+	relativeTimeStamp-r16			INTEGER (0..95),
+	measResultList-r16					SEQUENCE (SIZE (1..maxFreqANR-NB-r16)) OF ANR-MeasResult-NB-r16,
+	...
+}
+
+ANR-MeasResult-NB-r16 ::=	SEQUENCE {
+	carrierFreq-r16						CarrierFreq-NB-r13,
+	physCellId-r16						PhysCellId					OPTIONAL,
+	measResultLastServCell-r16			MeasResultServCell-NB-r14,
+	measResult-r16						NRSRP-Range-NB-r14		OPTIONAL,
+	cgi-Info-r16						SEQUENCE {
+		cellGlobalId-r16					CellGlobalIdEUTRA,
+		trackingAreaCode-r16				TrackingAreaCode,
+		plmn-IdentityList-r16				PLMN-IdentityList2		OPTIONAL
+	}	OPTIONAL
+}
+
+
+CQI-NPDCCH-NB-r14 ::=	ENUMERATED {
+							noMeasurements, candidateRep-A, candidateRep-B, candidateRep-C,
+							candidateRep-D, candidateRep-E, candidateRep-F, candidateRep-G,
+							candidateRep-H, candidateRep-I, candidateRep-J, candidateRep-K,
+							candidateRep-L}
+
+
+
+CQI-NPDCCH-Short-NB-r14 ::=	ENUMERATED {
+								noMeasurements, candidateRep-1, candidateRep-2, candidateRep-3}
+
+
+
+MeasResultServCell-NB-r14 ::=	SEQUENCE {
+	nrsrpResult-r14					NRSRP-Range-NB-r14,
+	nrsrqResult-r14					NRSRQ-Range-NB-r14
+}
+
+
+
+NRSRP-Range-NB-r14 ::=				INTEGER(0..113)
+
+
+
+NRSRQ-Range-NB-r14 ::=				INTEGER(-30..46)
+
+
+
+NSSS-RRM-Config-NB-r15	::=				SEQUENCE {
+	nsss-RRM-PowerOffset-r15			ENUMERATED {dB-3, db0, dB3},
+	nsss-NumOccDiffPrecoders-r15		ENUMERATED {n1, n2, n4, n8}	OPTIONAL	--	Need OP
+}
+
+
+EstablishmentCause-NB-r13 ::=			ENUMERATED {
+											mt-Access, mo-Signalling, mo-Data, mo-ExceptionData,
+											delayTolerantAccess-v1330, mt-EDT-v1610, spare2, spare1}
+
+
+
+UE-Capability-NB-r13 ::=		SEQUENCE {
+	accessStratumRelease-r13		AccessStratumRelease-NB-r13,
+	ue-Category-NB-r13				ENUMERATED {nb1}					OPTIONAL,
+	multipleDRB-r13					ENUMERATED {supported}				OPTIONAL,
+	pdcp-Parameters-r13				PDCP-Parameters-NB-r13				OPTIONAL,
+	phyLayerParameters-r13			PhyLayerParameters-NB-r13,
+	rf-Parameters-r13				RF-Parameters-NB-r13,
+	dummy							SEQUENCE {}							OPTIONAL
+}
+
+UE-Capability-NB-Ext-r14-IEs ::=		SEQUENCE {
+	ue-Category-NB-r14					ENUMERATED {nb2}				OPTIONAL,
+	mac-Parameters-r14					MAC-Parameters-NB-r14			OPTIONAL,
+	phyLayerParameters-v1430			PhyLayerParameters-NB-v1430		OPTIONAL,
+	rf-Parameters-v1430					RF-Parameters-NB-v1430,
+	nonCriticalExtension				UE-Capability-NB-v1440-IEs		OPTIONAL
+}
+
+UE-Capability-NB-v1440-IEs ::=		SEQUENCE {
+	phyLayerParameters-v1440			PhyLayerParameters-NB-v1440		OPTIONAL,
+	nonCriticalExtension				UE-Capability-NB-v14x0-IEs		OPTIONAL
+}
+
+UE-Capability-NB-v14x0-IEs ::=		SEQUENCE {
+-- Following field is only to be used for late REL-14 extensions
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				UE-Capability-NB-v1530-IEs		OPTIONAL
+}
+
+UE-Capability-NB-v1530-IEs ::=		SEQUENCE {
+	earlyData-UP-r15					ENUMERATED {supported}			OPTIONAL,
+	rlc-Parameters-r15					RLC-Parameters-NB-r15,
+	mac-Parameters-v1530				MAC-Parameters-NB-v1530,
+	phyLayerParameters-v1530			PhyLayerParameters-NB-v1530		OPTIONAL,
+	tdd-UE-Capability-r15				TDD-UE-Capability-NB-r15		OPTIONAL,
+	nonCriticalExtension				UE-Capability-NB-v15x0-IEs		OPTIONAL
+}
+
+UE-Capability-NB-v15x0-IEs ::=		SEQUENCE {
+-- Following field is only to be used for late REL-15 extensions
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				UE-Capability-NB-v1610-IEs		OPTIONAL
+}
+
+UE-Capability-NB-v1610-IEs ::=		SEQUENCE {
+	earlySecurityReactivation-r16		ENUMERATED {supported}			OPTIONAL,
+	earlyData-UP-5GC-r16				ENUMERATED {supported}			OPTIONAL,
+	pur-Parameters-r16					PUR-Parameters-NB-r16			OPTIONAL,
+	mac-Parameters-v1610				MAC-Parameters-NB-v1610,
+	phyLayerParameters-v1610			PhyLayerParameters-NB-v1610		OPTIONAL,
+	son-Parameters-r16					SON-Parameters-NB-r16		OPTIONAL,
+	meas-Parameters-r16					Meas-Parameters-NB-r16,
+	tdd-UE-Capability-v1610				TDD-UE-Capability-NB-v1610		OPTIONAL,
+	nonCriticalExtension				SEQUENCE	{}					OPTIONAL
+}
+
+TDD-UE-Capability-NB-r15 ::=		SEQUENCE {
+	ue-Category-NB-r15					ENUMERATED {nb2}				OPTIONAL,
+	phyLayerParametersRel13-r15			PhyLayerParameters-NB-r13		OPTIONAL,
+	phyLayerParametersRel14-r15			PhyLayerParameters-NB-v1430		OPTIONAL,
+	phyLayerParameters-v1530			PhyLayerParameters-NB-v1530		OPTIONAL,
+	...
+}
+
+TDD-UE-Capability-NB-v1610 ::=		SEQUENCE {
+	slotSymbolResourceResvDL-r16			ENUMERATED {supported}			OPTIONAL,
+	slotSymbolResourceResvUL-r16			ENUMERATED {supported}			OPTIONAL,
+	subframeResourceResvDL-r16				ENUMERATED {supported}			OPTIONAL,
+	subframeResourceResvUL-r16			ENUMERATED {supported}			OPTIONAL
+}
+
+AccessStratumRelease-NB-r13 ::=		ENUMERATED {rel13, rel14, rel15, rel16, spare4, spare3, spare2, spare1, ...}
+
+PDCP-Parameters-NB-r13		::= SEQUENCE {
+	supportedROHC-Profiles-r13			SEQUENCE {
+		profile0x0002						BOOLEAN,
+		profile0x0003						BOOLEAN,
+		profile0x0004						BOOLEAN,
+		profile0x0006						BOOLEAN,
+		profile0x0102						BOOLEAN,
+		profile0x0103						BOOLEAN,
+		profile0x0104						BOOLEAN
+	},
+	maxNumberROHC-ContextSessions-r13	ENUMERATED {cs2, cs4, cs8, cs12}	DEFAULT cs2,
+	...
+}
+
+RLC-Parameters-NB-r15		::=		SEQUENCE {
+	rlc-UM-r15							ENUMERATED {supported}				OPTIONAL
+}
+
+MAC-Parameters-NB-r14		::=		SEQUENCE {
+	dataInactMon-r14					ENUMERATED {supported}					OPTIONAL,
+	rai-Support-r14						ENUMERATED {supported}				OPTIONAL
+}
+
+MAC-Parameters-NB-v1530		::=		SEQUENCE {
+	sr-SPS-BSR-r15						ENUMERATED {supported}			OPTIONAL
+}
+
+MAC-Parameters-NB-v1610		::=		SEQUENCE {
+	rai-SupportEnh-r16					ENUMERATED {supported}			OPTIONAL
+}
+
+Meas-Parameters-NB-r16		::=		SEQUENCE {
+	dl-ChannelQualityReporting-r16		ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-NB-r13	::=		SEQUENCE {
+	multiTone-r13						ENUMERATED {supported}			OPTIONAL,
+	multiCarrier-r13						ENUMERATED {supported}			OPTIONAL
+	}
+
+PhyLayerParameters-NB-v1430	::=		SEQUENCE {
+	multiCarrier-NPRACH-r14				ENUMERATED {supported}			OPTIONAL,
+	twoHARQ-Processes-r14				ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-NB-v1440	::=		SEQUENCE {
+	interferenceRandomisation-r14		ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-NB-v1530	::=		SEQUENCE {
+	mixedOperationMode-r15				ENUMERATED {supported}			OPTIONAL,
+	sr-WithHARQ-ACK-r15					ENUMERATED {supported}			OPTIONAL,
+	sr-WithoutHARQ-ACK-r15				ENUMERATED {supported}			OPTIONAL,
+	nprach-Format2-r15					ENUMERATED {supported}			OPTIONAL,
+	additionalTransmissionSIB1-r15		ENUMERATED {supported}			OPTIONAL,
+	npusch-3dot75kHz-SCS-TDD-r15		ENUMERATED {supported}			OPTIONAL
+}
+
+PhyLayerParameters-NB-v1610	::=		SEQUENCE {
+	npdsch-MultiTB-r16					ENUMERATED {supported}			OPTIONAL,
+	npdsch-MultiTB-Interleaving-r16		ENUMERATED {supported}			OPTIONAL,
+	npusch-MultiTB-r16					ENUMERATED {supported}			OPTIONAL,
+	npusch-MultiTB-Interleaving-r16		ENUMERATED {supported}			OPTIONAL,
+	multiTB-HARQ-AckBundling-r16		ENUMERATED {supported}			OPTIONAL,
+	slotSymbolResourceResvDL-r16			ENUMERATED {supported}			OPTIONAL,
+	slotSymbolResourceResvUL-r16			ENUMERATED {supported}			OPTIONAL,
+	subframeResourceResvDL-r16				ENUMERATED {supported}			OPTIONAL,
+	subframeResourceResvUL-r16			ENUMERATED {supported}			OPTIONAL
+}
+
+PUR-Parameters-NB-r16	::=			SEQUENCE {
+	pur-CP-EPC-r16						ENUMERATED {supported}			OPTIONAL,
+	pur-CP-5GC-r16						ENUMERATED {supported}			OPTIONAL,
+	pur-UP-EPC-r16						ENUMERATED {supported}			OPTIONAL,
+	pur-UP-5GC-r16						ENUMERATED {supported}			OPTIONAL,
+	pur-NRSRP-Validation-r16			ENUMERATED {supported}			OPTIONAL,
+	pur-CP-L1Ack-r16					ENUMERATED {supported}			OPTIONAL
+}
+
+RF-Parameters-NB-r13	::=			SEQUENCE {
+	supportedBandList-r13				SupportedBandList-NB-r13,
+	multiNS-Pmax-r13					ENUMERATED {supported}		OPTIONAL
+}
+
+RF-Parameters-NB-v1430 ::=			SEQUENCE {
+	powerClassNB-14dBm-r14				ENUMERATED {supported}		OPTIONAL
+}
+
+SupportedBandList-NB-r13 ::=		SEQUENCE (SIZE (1..maxBands)) OF SupportedBand-NB-r13
+
+SupportedBand-NB-r13	::=			SEQUENCE {
+	band-r13							FreqBandIndicator-NB-r13,
+	powerClassNB-20dBm-r13				ENUMERATED {supported}		OPTIONAL
+}
+
+SON-Parameters-NB-r16 ::=			SEQUENCE {
+	anr-Report-r16						ENUMERATED {supported}		OPTIONAL,
+	rach-Report-r16						ENUMERATED {supported}		OPTIONAL
+}
+
+
+
+UE-RadioPagingInfo-NB-r13 ::=		SEQUENCE {
+	ue-Category-NB-r13				ENUMERATED {nb1}			OPTIONAL,
+	...,
+	[[ multiCarrierPaging-r14		ENUMERATED {true}			OPTIONAL
+	]],
+	[[	mixedOperationMode-r15		ENUMERATED {supported}		OPTIONAL,
+		wakeUpSignal-r15			ENUMERATED {true}			OPTIONAL,
+		wakeUpSignalMinGap-eDRX-r15	ENUMERATED {ms40, ms240, ms1000, ms2000}	OPTIONAL,
+		multiCarrierPagingTDD-r15	ENUMERATED {true}			OPTIONAL
+	]],
+	[[	ue-Category-NB-r16					ENUMERATED {nb2}			OPTIONAL,
+		groupWakeUpSignal-r16				ENUMERATED {true}			OPTIONAL,
+		groupWakeUpSignalAlternation-r16	ENUMERATED {true}			OPTIONAL
+	]]
+
+}
+
+
+
+UE-TimersAndConstants-NB-r13 ::=	SEQUENCE {
+	t300-r13							ENUMERATED {
+											ms2500, ms4000, ms6000, ms10000,
+											ms15000, ms25000, ms40000, ms60000},
+	t301-r13							ENUMERATED {
+											ms2500, ms4000, ms6000, ms10000,
+											ms15000, ms25000, ms40000, ms60000},
+	t310-r13							ENUMERATED {
+											ms0, ms200, ms500, ms1000, ms2000, ms4000, ms8000},
+	n310-r13							ENUMERATED {
+											n1, n2, n3, n4, n6, n8, n10, n20},
+	t311-r13							ENUMERATED {
+											ms1000, ms3000, ms5000, ms10000, ms15000,
+											ms20000, ms30000},
+	n311-r13							ENUMERATED {
+											n1, n2, n3, n4, n5, n6, n8, n10},
+	...,
+	[[ t311-v1350						ENUMERATED {
+											ms40000, ms60000, ms90000, ms120000}
+														OPTIONAL	-- Need OR
+	]],
+	[[	t300-v1530						ENUMERATED {
+											ms80000, ms100000, ms120000}	OPTIONAL,	-- Cond TDD
+		t301-v1530						ENUMERATED {
+											ms80000, ms100000, ms120000}	OPTIONAL,	-- Cond TDD
+		t311-v1530						ENUMERATED {
+											ms160000, ms200000}				OPTIONAL,	-- Cond TDD
+		t300-r15						ENUMERATED {ms6000, ms10000, ms15000, ms25000, ms40000,
+											ms60000, ms80000, ms120000}	OPTIONAL		-- Cond EDTorPUR
+	]]
+}
+
+
+
+SC-MTCH-InfoList-NB-r14 ::=			SEQUENCE (SIZE (0.. maxSC-MTCH-NB-r14)) OF SC-MTCH-Info-NB-r14
+
+SC-MTCH-Info-NB-r14 ::=				SEQUENCE	{
+	sc-mtch-CarrierConfig-r14			CHOICE {
+		dl-CarrierConfig-r14					DL-CarrierConfigCommon-NB-r14,
+		dl-CarrierIndex-r14					INTEGER (0.. maxNonAnchorCarriers-NB-r14)
+	},
+	mbmsSessionInfo-r14					MBMSSessionInfo-r13,
+	g-RNTI-r14							BIT STRING(SIZE(16)),
+	sc-mtch-SchedulingInfo-r14			SC-MTCH-SchedulingInfo-NB-r14		OPTIONAL,	-- Need OP
+	sc-mtch-NeighbourCell-r14			BIT STRING (SIZE(maxNeighCell-SCPTM-NB-r14))	OPTIONAL,	-- Need OP
+	npdcch-NPDSCH-MaxTBS-SC-MTCH-r14		ENUMERATED {n680, n2536},
+	npdcch-NumRepetitions-SC-MTCH-r14	ENUMERATED {r1, r2, r4, r8, r16,
+													r32, r64, r128, r256,
+													r512, r1024, r2048, spare4,
+													spare3, spare2, spare1},
+	npdcch-StartSF-SC-MTCH-r14			ENUMERATED {v1dot5, v2, v4, v8,
+													v16, v32, v48, v64},
+	npdcch-Offset-SC-MTCH-r14			ENUMERATED {zero, oneEighth, oneQuarter,
+													threeEighth, oneHalf, fiveEighth,
+													threeQuarter, sevenEighth},
+	...
+}
+
+SC-MTCH-SchedulingInfo-NB-r14 ::=		SEQUENCE	{
+	onDurationTimerSCPTM-r14				ENUMERATED {
+												pp1, pp2, pp3, pp4,
+												pp8, pp16, pp32, spare},
+	drx-InactivityTimerSCPTM-r14			ENUMERATED {
+												pp0, pp1, pp2, pp3,
+												pp4, pp8, pp16, pp32},
+	schedulingPeriodStartOffsetSCPTM-r14	CHOICE {
+		sf10									INTEGER(0..9),
+		sf20									INTEGER(0..19),
+		sf32									INTEGER(0..31),
+		sf40									INTEGER(0..39),
+		sf64									INTEGER(0..63),
+		sf80									INTEGER(0..79),
+		sf128									INTEGER(0..127),
+		sf160									INTEGER(0..159),
+		sf256									INTEGER(0..255),
+		sf320									INTEGER(0..319),
+		sf512									INTEGER(0..511),
+		sf640									INTEGER(0..639),
+		sf1024									INTEGER(0..1023),
+		sf2048									INTEGER(0..2047),
+		sf4096									INTEGER(0..4095),
+		sf8192									INTEGER(0..8191)
+	},
+	...
+}
+
+
+
+SCPTM-NeighbourCellList-NB-r14 ::=	SEQUENCE (SIZE (1..maxNeighCell-SCPTM-NB-r14)) OF PCI-ARFCN-NB-r14
+
+PCI-ARFCN-NB-r14 ::=				SEQUENCE {
+	physCellId-r14						PhysCellId,
+	carrierFreq-r14						CarrierFreq-NB-r13		OPTIONAL	-- Need OP
+}
+
+
+
+maxFreqANR-NB-r16			INTEGER ::= 2	-- Maximum number of NB-IOT carrier frequencies that can
+											-- be configured or reported for ANR measurement
+maxFreqEUTRA-NB-r16			INTEGER ::= 8	-- Maximum number of EUTRAN carrier frequencies that can
+											-- be provided as assistance information for inter-RAT
+											-- cell selection
+maxFreqsGERAN-NB-r16		INTEGER ::= 8	-- Maximum number of groups of GERAN carrier frequencies
+											-- that can be provided as assistance information for
+											-- inter-RAT cell selection
+maxGWUS-Groups-1-NB-r16		INTEGER ::= 15	-- Maximum number of groups for each paging probability
+											-- group
+maxGWUS-Resources-NB-r16	INTEGER ::= 2	-- Maximum number of GWUS resources for each gap
+maxGWUS-ProbThresholds-NB-r16 INTEGER ::= 3	-- Maximum number of paging probability thresholds
+maxNPRACH-Resources-NB-r13	INTEGER ::=	3	-- Maximum number of NPRACH resources for NB-IoT
+maxNonAnchorCarriers-NB-r14	INTEGER ::= 15	-- Maximum number of non-anchor carriers for NB-IoT
+maxDRB-NB-r13				INTEGER ::= 2	-- Maximum number of Data Radio Bearers for NB-IoT
+maxNeighCell-SCPTM-NB-r14	INTEGER ::= 8	-- Maximum number of SCPTM neighbour cells
+maxNS-Pmax-NB-r13			INTEGER ::= 4	-- Maximum number of NS and P-Max values per band
+maxSC-MTCH-NB-r14			INTEGER ::= 64	-- Maximum number of SC-MTCHs in one cell for NB-IoT
+maxSI-Message-NB-r13		INTEGER ::= 8	-- Maximum number of SI messages for NB-IoT
+
+
+
+END
+
+
+
+EUTRA-UE-Variables DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+	AbsoluteTimeInfo-r10,
+	AreaConfiguration-r10,
+	AreaConfiguration-v1130,
+	ARFCN-ValueNR-r15,
+	BT-NameList-r15,
+	CarrierFreqGERAN,
+	CellIdentity,
+	CellList-r15,
+	CondReconfigurationToAddModList-r16,
+	ConnEstFailReport-r11,
+	EUTRA-CarrierList-r15,
+	SpeedStateScaleFactors,
+	C-RNTI,
+	LoggingDuration-r10,
+	LoggingInterval-r10,
+	LogMeasInfo-r10,
+	MeasCSI-RS-Id-r12,
+	MeasId,
+	MeasId-v1250,
+	MeasIdToAddModList,
+	MeasIdToAddModListExt-r12,
+	MeasIdToAddModList-v1310,
+	MeasIdToAddModListExt-v1310,
+	MeasObjectToAddModList,
+	MeasObjectToAddModList-v9e0,
+	MeasObjectToAddModListExt-r13,
+	MeasResultListExtIdle-r16,
+	MeasResultListIdle-r15,
+	MeasResultListIdleNR-r16,
+	MeasScaleFactor-r12,
+	MobilityStateParameters,
+	NeighCellConfig,
+	NR-CarrierList-r16,
+	PhysCellId,
+	PhysCellIdCDMA2000,
+	PhysCellIdGERAN,
+	PhysCellIdUTRA-FDD,
+	PhysCellIdUTRA-TDD,
+	PLMN-Identity,
+	PLMN-IdentityList3-r11,
+	QuantityConfig,
+	ReportConfigToAddModList,
+	RLF-Report-r9,
+	TargetMBSFN-AreaList-r12,
+	TraceReference-r10,
+	Tx-ResourcePoolMeasList-r14,
+	VisitedCellInfoList-r12,
+	maxCellMeas,
+	maxCSI-RS-Meas-r12,
+	maxMeasId,
+	maxMeasId-r12,
+	maxRS-Index-r15,
+	PhysCellIdNR-r15,
+	RS-IndexNR-r15,
+	UL-DelayConfig-r13,
+	ValidityAreaList-r16,
+	WLAN-CarrierInfo-r13,
+	WLAN-Identifiers-r12,
+	WLAN-Id-List-r13,
+	WLAN-NameList-r15,
+	WLAN-Status-r13,
+	WLAN-Status-v1430,
+	WLAN-SuspendConfig-r14
+
+FROM EUTRA-RRC-Definitions;
+
+
+
+VarConditionalReconfiguration ::= SEQUENCE {
+    -- Conditional reconfigurations list
+	condReconfigurationList-r16			CondReconfigurationToAddModList-r16
+	OPTIONAL
+}
+
+
+
+VarConnEstFailReport-r11 ::=		SEQUENCE {
+	connEstFailReport-r11				ConnEstFailReport-r11,
+	plmn-Identity-r11					PLMN-Identity
+}
+
+
+
+VarLogMeasConfig-r10 ::=				SEQUENCE {
+	areaConfiguration-r10			AreaConfiguration-r10		OPTIONAL,
+	loggingDuration-r10				LoggingDuration-r10,
+	loggingInterval-r10				LoggingInterval-r10
+}
+
+VarLogMeasConfig-r11 ::=		SEQUENCE {
+	areaConfiguration-r10			AreaConfiguration-r10		OPTIONAL,
+	areaConfiguration-v1130			AreaConfiguration-v1130		OPTIONAL,
+	loggingDuration-r10				LoggingDuration-r10,
+	loggingInterval-r10				LoggingInterval-r10
+}
+
+VarLogMeasConfig-r12 ::=		SEQUENCE {
+	areaConfiguration-r10			AreaConfiguration-r10		OPTIONAL,
+	areaConfiguration-v1130			AreaConfiguration-v1130		OPTIONAL,
+	loggingDuration-r10				LoggingDuration-r10,
+	loggingInterval-r10				LoggingInterval-r10,
+	targetMBSFN-AreaList-r12		TargetMBSFN-AreaList-r12	OPTIONAL
+}
+
+VarLogMeasConfig-r15 ::=		SEQUENCE {
+	areaConfiguration-r10			AreaConfiguration-r10		OPTIONAL,
+	areaConfiguration-v1130			AreaConfiguration-v1130		OPTIONAL,
+	loggingDuration-r10				LoggingDuration-r10,
+	loggingInterval-r10				LoggingInterval-r10,
+	targetMBSFN-AreaList-r12			TargetMBSFN-AreaList-r12		OPTIONAL,
+	bt-NameList-r15				BT-NameList-r15					OPTIONAL,
+	wlan-NameList-r15				WLAN-NameList-r15					OPTIONAL
+}
+
+
+
+VarLogMeasReport-r10 ::=				SEQUENCE {
+	traceReference-r10					TraceReference-r10,
+	traceRecordingSessionRef-r10			OCTET STRING (SIZE (2)),
+	tce-Id-r10							OCTET STRING (SIZE (1)),
+	plmn-Identity-r10					PLMN-Identity,
+	absoluteTimeInfo-r10				AbsoluteTimeInfo-r10,
+	logMeasInfoList-r10					LogMeasInfoList2-r10
+}
+
+VarLogMeasReport-r11 ::=			SEQUENCE {
+	traceReference-r10					TraceReference-r10,
+	traceRecordingSessionRef-r10		OCTET STRING (SIZE (2)),
+	tce-Id-r10							OCTET STRING (SIZE (1)),
+	plmn-IdentityList-r11				PLMN-IdentityList3-r11,
+	absoluteTimeInfo-r10				AbsoluteTimeInfo-r10,
+	logMeasInfoList-r10					LogMeasInfoList2-r10
+}
+
+LogMeasInfoList2-r10 ::=				SEQUENCE (SIZE (1..maxLogMeas-r10)) OF LogMeasInfo-r10
+
+
+
+VarMeasConfig ::=					SEQUENCE {
+	-- Measurement identities
+	measIdList							MeasIdToAddModList					OPTIONAL,
+	measIdListExt-r12					MeasIdToAddModListExt-r12			OPTIONAL,
+	measIdList-v1310						MeasIdToAddModList-v1310				OPTIONAL,
+	measIdListExt-v1310					MeasIdToAddModListExt-v1310			OPTIONAL,
+	-- Measurement objects
+	measObjectList						MeasObjectToAddModList				OPTIONAL,
+	measObjectListExt-r13				MeasObjectToAddModListExt-r13		OPTIONAL,
+	measObjectList-v9i0					MeasObjectToAddModList-v9e0			OPTIONAL,
+	-- Reporting configurations
+	reportConfigList					ReportConfigToAddModList			OPTIONAL,
+	-- Other parameters
+	quantityConfig						QuantityConfig						OPTIONAL,
+	measScaleFactor-r12					MeasScaleFactor-r12					OPTIONAL,
+	s-Measure							INTEGER (-140..-44)					OPTIONAL,
+	speedStatePars						CHOICE {
+		release								NULL,
+		setup								SEQUENCE {
+			mobilityStateParameters				MobilityStateParameters,
+			timeToTrigger-SF					SpeedStateScaleFactors
+		}
+	}																		OPTIONAL,
+	allowInterruptions-r11			BOOLEAN								OPTIONAL
+}
+
+
+
+VarMeasIdleConfig-r15 ::=	SEQUENCE {
+	measIdleCarrierListEUTRA-r15			EUTRA-CarrierList-r15			OPTIONAL,
+	measIdleDuration-r15					ENUMERATED {sec10, sec30, sec60, sec120,
+														sec180, sec240, sec300}
+}
+
+VarMeasIdleConfig-r16 ::=	SEQUENCE {
+	measIdleCarrierListNR-r16				NR-CarrierList-r16		OPTIONAL,
+	validityAreaList-r16					ValidityAreaList-r16	OPTIONAL
+}
+
+
+
+VarMeasIdleReport-r15 ::=	SEQUENCE {
+	measReportIdle-r15				MeasResultListIdle-r15
+}
+
+VarMeasIdleReport-r16 ::=	SEQUENCE {
+	measReportIdle-r16				MeasResultListExtIdle-r16					OPTIONAL,
+	measReportIdleNR-r16			MeasResultListIdleNR-r16						OPTIONAL
+}
+
+
+
+VarMeasReportList ::=				SEQUENCE (SIZE (1..maxMeasId)) OF VarMeasReport
+VarMeasReportList-r12 ::=			SEQUENCE (SIZE (1..maxMeasId-r12)) OF VarMeasReport
+
+VarMeasReport ::=					SEQUENCE {
+	-- List of measurement that have been triggered
+	measId								MeasId,
+	measId-v1250						MeasId-v1250					OPTIONAL,
+	cellsTriggeredList					CellsTriggeredList				OPTIONAL,
+	csi-RS-TriggeredList-r12			CSI-RS-TriggeredList-r12		OPTIONAL,
+	poolsTriggeredList-r14				Tx-ResourcePoolMeasList-r14	OPTIONAL,
+	numberOfReportsSent					INTEGER
+}
+
+CellsTriggeredList ::=				SEQUENCE (SIZE (1..maxCellMeas)) OF CHOICE {
+	physCellIdEUTRA							PhysCellId,
+	physCellIdUTRA							CHOICE {
+		fdd										PhysCellIdUTRA-FDD,
+		tdd										PhysCellIdUTRA-TDD
+	},
+	physCellIdGERAN							SEQUENCE {
+		carrierFreq								CarrierFreqGERAN,
+		physCellId								PhysCellIdGERAN
+	},
+	physCellIdCDMA2000						PhysCellIdCDMA2000,
+	wlan-Identifiers-r13					WLAN-Identifiers-r12,
+	physCellIdNR-r15						SEQUENCE {
+		carrierFreq								ARFCN-ValueNR-r15,
+		physCellId								PhysCellIdNR-r15,
+		rs-IndexList-r15						SSB-IndexList-r15				OPTIONAL
+	}
+}
+
+CSI-RS-TriggeredList-r12 ::=		SEQUENCE (SIZE (1..maxCSI-RS-Meas-r12)) OF MeasCSI-RS-Id-r12
+
+SSB-IndexList-r15::=			SEQUENCE (SIZE (1..maxRS-Index-r15)) OF RS-IndexNR-r15
+
+
+VarMobilityHistoryReport-r12 ::=	VisitedCellInfoList-r12
+
+
+
+VarPendingRnaUpdate-r15 ::=					SEQUENCE {
+	pendingRnaUpdate					BOOLEAN								OPTIONAL
+}
+
+
+
+VarRLF-Report-r10 ::=				SEQUENCE {
+	rlf-Report-r10							RLF-Report-r9,
+	plmn-Identity-r10						PLMN-Identity
+}
+
+VarRLF-Report-r11 ::=				SEQUENCE {
+	rlf-Report-r10						RLF-Report-r9,
+	plmn-IdentityList-r11				PLMN-IdentityList3-r11
+}
+
+
+
+VarShortINACTIVE-MAC-Input-r15 ::=		SEQUENCE {
+	cellIdentity-r15							CellIdentity,
+	physCellId-r15							PhysCellId,
+	c-RNTI-r15								C-RNTI
+}
+
+
+
+VarShortMAC-Input ::=					SEQUENCE {
+	cellIdentity							CellIdentity,
+	physCellId								PhysCellId,
+	c-RNTI									C-RNTI
+}
+
+
+
+VarShortResumeMAC-Input-r13 ::=		SEQUENCE {
+	cellIdentity-r13						CellIdentity,
+	physCellId-r13							PhysCellId,
+	c-RNTI-r13								C-RNTI,
+	resumeDiscriminator-r13					BIT STRING(SIZE(1))
+}
+
+
+
+VarWLAN-MobilityConfig ::=					SEQUENCE {
+	wlan-MobilitySet-r13					WLAN-Id-List-r13			OPTIONAL,
+	successReportRequested					ENUMERATED {true}			OPTIONAL,
+	wlan-SuspendConfig-r14					WLAN-SuspendConfig-r14		OPTIONAL
+}
+
+
+
+VarWLAN-Status-r13 ::=				SEQUENCE {
+	status-r13								WLAN-Status-r13,
+	status-r14								WLAN-Status-v1430	OPTIONAL
+}
+
+
+
+maxLogMeas-r10				INTEGER ::= 4060-- Maximum number of logged measurement entries
+											-- that can be stored by the UE
+
+
+
+END
+
+
+
+NBIOT-UE-Variables DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+	CellGlobalIdEUTRA,
+	maxFreq,
+	PLMN-IdentityList3-r11
+
+FROM EUTRA-RRC-Definitions
+	VarShortMAC-Input,
+	VarShortResumeMAC-Input-r13
+
+FROM EUTRA-UE-Variables
+
+	ANR-CarrierList-NB-r16,
+	ANR-MeasResult-NB-r16,
+	maxFreqANR-NB-r16,
+	MeasResultServCell-NB-r14,
+	NRSRP-Range-NB-r14,
+	RLF-Report-NB-r16
+
+FROM NBIOT-RRC-Definitions;
+
+
+
+
+VarANR-MeasConfig-NB-r16::=	SEQUENCE {
+	anr-QualityThreshold-r16			NRSRP-Range-NB-r14,
+	anr-CarrierList-r16					ANR-CarrierList-NB-r16
+}
+
+
+
+VarANR-MeasReport-NB-r16::=	SEQUENCE {
+	plmn-IdentityList-r16			PLMN-IdentityList3-r11,
+	servCellIdentity-r16			CellGlobalIdEUTRA,
+	measResultServCell-r16			MeasResultServCell-NB-r14,
+	relativeTimeStamp-r16			INTEGER (0..95),
+	measResultList-r16				SEQUENCE (SIZE (1..maxFreqANR-NB-r16)) OF ANR-MeasResult-NB-r16
+}
+
+
+
+VarRLF-Report-NB-r16 ::=		SEQUENCE {
+	rlf-Report-r16					RLF-Report-NB-r16,
+	plmn-IdentityList-r16			PLMN-IdentityList3-r11
+
+}
+
+
+
+VarShortMAC-Input-NB-r13	::=		VarShortMAC-Input
+
+
+
+VarShortResumeMAC-Input-NB-r13	::=		VarShortResumeMAC-Input-r13
+
+
+
+END
+
+
+
+EUTRA-Sidelink-Preconf DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+	AdditionalSpectrumEmission,
+	AdditionalSpectrumEmission-v10l0,
+	ARFCN-ValueEUTRA-r9,
+	FilterCoefficient,
+	maxCBR-Level-r14,
+	maxCBR-Level-1-r14,
+	maxFreq,
+	maxFreqV2X-r14,
+	maxSL-TxPool-r12,
+	maxSL-CommRxPoolPreconf-v1310,
+	maxSL-CommTxPoolPreconf-v1310,
+	maxSL-DiscRxPoolPreconf-r13,
+	maxSL-DiscTxPoolPreconf-r13,
+	maxSL-V2X-CBRConfig2-r14,
+	maxSL-V2X-CBRConfig2-1-r14,
+	maxSL-V2X-RxPoolPreconf-r14,
+	maxSL-V2X-TxConfig2-r14,
+	maxSL-V2X-TxConfig2-1-r14,
+	maxSL-V2X-TxPoolPreconf-r14,
+	MCS-PSSCH-Range-r15,
+	P-Max,
+	ReselectionInfoRelay-r13,
+	SL-AnchorCarrierFreqList-V2X-r14,
+	SL-CBR-Levels-Config-r14,
+	SL-CBR-PSSCH-TxConfig-r14,
+	SL-CommTxPoolSensingConfig-r14,
+	SL-CP-Len-r12,
+	SL-HoppingConfigComm-r12,
+	SL-NR-AnchorCarrierFreqList-r16,
+	SL-OffsetIndicator-r12,
+	SL-OffsetIndicatorSync-r12,
+	SL-OffsetIndicatorSync-v1430,
+	SL-PeriodComm-r12,
+	RSRP-RangeSL3-r12,
+	SL-MinT2ValueList-r15,
+	SL-PriorityList-r13,
+	SL-TF-ResourceConfig-r12,
+	SL-TRPT-Subset-r12,
+	SL-TxParameters-r12,
+	SL-ZoneConfig-r14,
+	P0-SL-r12,
+	TDD-ConfigSL-r12,
+	SubframeBitmapSL-r14,
+	SL-P2X-ResourceSelectionConfig-r14,
+	SL-RestrictResourceReservationPeriodList-r14,
+	SL-SyncAllowed-r14,
+	SL-OffsetIndicatorSync-r14,
+	SL-Priority-r13,
+	SL-V2X-FreqSelectionConfigList-r15,
+	SL-V2X-PacketDuplicationConfig-r15,
+	SL-V2X-SyncFreqList-r15
+FROM EUTRA-RRC-Definitions;
+
+
+
+SL-Preconfiguration-r12 ::=		SEQUENCE {
+	preconfigGeneral-r12				SL-PreconfigGeneral-r12,
+	preconfigSync-r12					SL-PreconfigSync-r12,
+	preconfigComm-r12					SL-PreconfigCommPoolList4-r12,
+	...,
+	[[	preconfigComm-v1310				SEQUENCE {
+			commRxPoolList-r13			SL-PreconfigCommRxPoolList-r13,
+			commTxPoolList-r13			SL-PreconfigCommTxPoolList-r13		OPTIONAL
+		}																		OPTIONAL,
+		preconfigDisc-r13				SEQUENCE {
+			discRxPoolList-r13				SL-PreconfigDiscRxPoolList-r13,
+			discTxPoolList-r13				SL-PreconfigDiscTxPoolList-r13		OPTIONAL
+		}																		OPTIONAL,
+		preconfigRelay-r13				SL-PreconfigRelay-r13				OPTIONAL
+	]]
+
+}
+
+SL-PreconfigGeneral-r12 ::=		SEQUENCE {
+	-- PDCP configuration
+	rohc-Profiles-r12					SEQUENCE {
+		profile0x0001-r12						BOOLEAN,
+		profile0x0002-r12						BOOLEAN,
+		profile0x0004-r12						BOOLEAN,
+		profile0x0006-r12						BOOLEAN,
+		profile0x0101-r12						BOOLEAN,
+		profile0x0102-r12						BOOLEAN,
+		profile0x0104-r12						BOOLEAN
+	},
+	-- Physical configuration
+	carrierFreq-r12						ARFCN-ValueEUTRA-r9,
+	maxTxPower-r12						P-Max,
+	additionalSpectrumEmission-r12		AdditionalSpectrumEmission,
+	sl-bandwidth-r12					ENUMERATED {n6, n15, n25, n50, n75, n100},
+	tdd-ConfigSL-r12					TDD-ConfigSL-r12,
+	reserved-r12						BIT STRING (SIZE (19)),
+	...,
+	[[	additionalSpectrumEmission-v1440		AdditionalSpectrumEmission-v10l0		OPTIONAL
+	]]
+}
+
+SL-PreconfigSync-r12 ::=	SEQUENCE {
+	syncCP-Len-r12						SL-CP-Len-r12,
+	syncOffsetIndicator1-r12			SL-OffsetIndicatorSync-r12,
+	syncOffsetIndicator2-r12			SL-OffsetIndicatorSync-r12,
+	syncTxParameters-r12				P0-SL-r12,
+	syncTxThreshOoC-r12					RSRP-RangeSL3-r12,
+	filterCoefficient-r12				FilterCoefficient,
+	syncRefMinHyst-r12					ENUMERATED {dB0, dB3, dB6, dB9, dB12},
+	syncRefDiffHyst-r12					ENUMERATED {dB0, dB3, dB6, dB9, dB12, dBinf},
+	...,
+	[[	syncTxPeriodic-r13					ENUMERATED {true}			OPTIONAL
+	]]
+}
+
+SL-PreconfigCommPoolList4-r12 ::=	SEQUENCE (SIZE (1..maxSL-TxPool-r12)) OF SL-PreconfigCommPool-r12
+
+SL-PreconfigCommRxPoolList-r13 ::=	SEQUENCE (SIZE (1..maxSL-CommRxPoolPreconf-v1310)) OF SL-PreconfigCommPool-r12
+
+SL-PreconfigCommTxPoolList-r13 ::=	SEQUENCE (SIZE (1..maxSL-CommTxPoolPreconf-v1310)) OF SL-PreconfigCommPool-r12
+
+SL-PreconfigCommPool-r12 ::=		SEQUENCE {
+-- This IE is same as SL-CommResourcePool with rxParametersNCell absent
+	sc-CP-Len-r12						SL-CP-Len-r12,
+	sc-Period-r12						SL-PeriodComm-r12,
+	sc-TF-ResourceConfig-r12			SL-TF-ResourceConfig-r12,
+	sc-TxParameters-r12					P0-SL-r12,
+	data-CP-Len-r12						SL-CP-Len-r12,
+	data-TF-ResourceConfig-r12			SL-TF-ResourceConfig-r12,
+	dataHoppingConfig-r12				SL-HoppingConfigComm-r12,
+	dataTxParameters-r12				P0-SL-r12,
+	trpt-Subset-r12						SL-TRPT-Subset-r12,
+	...,
+	[[	priorityList-r13				SL-PriorityList-r13			OPTIONAL	-- For Tx
+	]]
+}
+
+SL-PreconfigDiscRxPoolList-r13 ::=	SEQUENCE (SIZE (1..maxSL-DiscRxPoolPreconf-r13)) OF SL-PreconfigDiscPool-r13
+
+SL-PreconfigDiscTxPoolList-r13 ::=	SEQUENCE (SIZE (1..maxSL-DiscTxPoolPreconf-r13)) OF SL-PreconfigDiscPool-r13
+
+SL-PreconfigDiscPool-r13 ::=		SEQUENCE {
+-- This IE is same as SL-DiscResourcePool with rxParameters absent
+	cp-Len-r13						SL-CP-Len-r12,
+	discPeriod-r13				ENUMERATED {rf4, rf6, rf7, rf8, rf12, rf14, rf16, rf24, rf28,
+										rf32, rf64, rf128, rf256, rf512, rf1024, spare},
+	numRetx-r13					INTEGER (0..3),
+	numRepetition-r13				INTEGER (1..50),
+	tf-ResourceConfig-r13			SL-TF-ResourceConfig-r12,
+	txParameters-r13				SEQUENCE {
+		txParametersGeneral-r13		P0-SL-r12,
+		txProbability-r13			ENUMERATED {p25, p50, p75, p100}
+	}																OPTIONAL,
+	...
+}
+
+SL-PreconfigRelay-r13 ::=	SEQUENCE {
+	reselectionInfoOoC-r13			ReselectionInfoRelay-r13
+}
+
+
+
+SL-V2X-Preconfiguration-r14 ::=	SEQUENCE {
+	v2x-PreconfigFreqList-r14		SL-V2X-PreconfigFreqList-r14,
+	anchorCarrierFreqList-r14		SL-AnchorCarrierFreqList-V2X-r14				OPTIONAL,
+	cbr-PreconfigList-r14			SL-CBR-PreconfigTxConfigList-r14				OPTIONAL,
+	...,
+	[[	v2x-PacketDuplicationConfig-r15	SL-V2X-PacketDuplicationConfig-r15			OPTIONAL,
+		syncFreqList-r15			SL-V2X-SyncFreqList-r15						OPTIONAL,
+		slss-TxMultiFreq-r15		ENUMERATED {true}							OPTIONAL,
+		v2x-TxProfileList-r15		SL-V2X-TxProfileList-r15					OPTIONAL
+	]],
+	[[	anchorCarrierFreqListNR-r16		SL-NR-AnchorCarrierFreqList-r16			OPTIONAL
+	]]
+}
+
+SL-CBR-PreconfigTxConfigList-r14 ::=	SEQUENCE {
+	cbr-RangeCommonConfigList-r14	SEQUENCE (SIZE (1..maxSL-V2X-CBRConfig2-r14)) OF SL-CBR-Levels-Config-r14,
+	sl-CBR-PSSCH-TxConfigList-r14	SEQUENCE (SIZE (1..maxSL-V2X-TxConfig2-r14)) OF SL-CBR-PSSCH-TxConfig-r14
+}
+
+SL-V2X-PreconfigFreqList-r14 ::=	SEQUENCE (SIZE (1..maxFreqV2X-r14)) OF SL-V2X-PreconfigFreqInfo-r14
+
+SL-V2X-PreconfigFreqInfo-r14 ::=		SEQUENCE {
+	v2x-CommPreconfigGeneral-r14		SL-PreconfigGeneral-r12,
+	v2x-CommPreconfigSync-r14			SL-PreconfigV2X-Sync-r14				OPTIONAL,
+	v2x-CommRxPoolList-r14				SL-PreconfigV2X-RxPoolList-r14,
+	v2x-CommTxPoolList-r14				SL-PreconfigV2X-TxPoolList-r14,
+	p2x-CommTxPoolList-r14				SL-PreconfigV2X-TxPoolList-r14,
+	v2x-ResourceSelectionConfig-r14			SL-CommTxPoolSensingConfig-r14			OPTIONAL,
+	zoneConfig-r14						SL-ZoneConfig-r14						OPTIONAL,
+	syncPriority-r14					ENUMERATED {gnss, enb},
+	thresSL-TxPrioritization-r14		SL-Priority-r13						OPTIONAL,
+	offsetDFN-r14						INTEGER (0..1000)					OPTIONAL,
+	...,
+	[[	v2x-FreqSelectionConfigList-r15	SL-V2X-FreqSelectionConfigList-r15	OPTIONAL
+	]]
+}
+
+SL-PreconfigV2X-RxPoolList-r14 ::=	SEQUENCE (SIZE (1..maxSL-V2X-RxPoolPreconf-r14)) OF SL-V2X-PreconfigCommPool-r14
+
+SL-PreconfigV2X-TxPoolList-r14 ::=	SEQUENCE (SIZE (1..maxSL-V2X-TxPoolPreconf-r14)) OF SL-V2X-PreconfigCommPool-r14
+
+SL-V2X-PreconfigCommPool-r14 ::=		SEQUENCE {
+-- This IE is same as SL-CommResourcePoolV2X with rxParametersNCell absent
+	sl-OffsetIndicator-r14				SL-OffsetIndicator-r12		OPTIONAL,
+	sl-Subframe-r14						SubframeBitmapSL-r14,
+	adjacencyPSCCH-PSSCH-r14			BOOLEAN,
+	sizeSubchannel-r14					ENUMERATED {
+										n4, n5, n6, n8, n9, n10, n12, n15, n16, n18, n20, n25, n30,
+										n48, n50, n72, n75, n96, n100, spare13, spare12, spare11,
+										spare10, spare9, spare8, spare7, spare6, spare5, spare4,
+										spare3, spare2, spare1},
+	numSubchannel-r14					ENUMERATED {n1, n3, n5, n8, n10, n15, n20, spare1},
+	startRB-Subchannel-r14				INTEGER (0..99),
+	startRB-PSCCH-Pool-r14				INTEGER (0..99)				OPTIONAL,
+	dataTxParameters-r14				P0-SL-r12,
+	zoneID-r14							INTEGER (0..7)				OPTIONAL,
+	threshS-RSSI-CBR-r14					INTEGER (0..45)				OPTIONAL,
+	cbr-pssch-TxConfigList-r14			SL-CBR-PPPP-TxPreconfigList-r14	OPTIONAL,
+	resourceSelectionConfigP2X-r14		SL-P2X-ResourceSelectionConfig-r14	OPTIONAL,
+	syncAllowed-r14						SL-SyncAllowed-r14				OPTIONAL,
+	restrictResourceReservationPeriod-r14	SL-RestrictResourceReservationPeriodList-r14	OPTIONAL,
+	...,
+	[[	sl-MinT2ValueList-r15			SL-MinT2ValueList-r15			OPTIONAL,
+		cbr-pssch-TxConfigList-v1530	SL-CBR-PPPP-TxPreconfigList-v1530	OPTIONAL
+	]]
+}
+
+SL-PreconfigV2X-Sync-r14 ::=	SEQUENCE {
+	syncOffsetIndicators-r14			SL-V2X-SyncOffsetIndicators-r14,
+	syncTxParameters-r14				P0-SL-r12,
+	syncTxThreshOoC-r14					RSRP-RangeSL3-r12,
+	filterCoefficient-r14				FilterCoefficient,
+	syncRefMinHyst-r14					ENUMERATED {dB0, dB3, dB6, dB9, dB12},
+	syncRefDiffHyst-r14					ENUMERATED {dB0, dB3, dB6, dB9, dB12, dBinf},
+	...,
+	[[	slss-TxDisabled-r15				ENUMERATED {true}				OPTIONAL
+	]]
+}
+
+SL-V2X-SyncOffsetIndicators-r14 ::=	SEQUENCE {
+	syncOffsetIndicator1-r14			SL-OffsetIndicatorSync-r14,
+	syncOffsetIndicator2-r14			SL-OffsetIndicatorSync-r14,
+	syncOffsetIndicator3-r14			SL-OffsetIndicatorSync-r14			OPTIONAL
+}
+
+SL-CBR-PPPP-TxPreconfigList-r14 ::=	SEQUENCE (SIZE (1..8)) OF SL-PPPP-TxPreconfigIndex-r14
+
+SL-PPPP-TxPreconfigIndex-r14 ::=	SEQUENCE {
+	priorityThreshold-r14			SL-Priority-r13,
+	defaultTxConfigIndex-r14		INTEGER(0..maxCBR-Level-1-r14),
+	cbr-ConfigIndex-r14				INTEGER(0..maxSL-V2X-CBRConfig2-1-r14),
+	tx-ConfigIndexList-r14			SEQUENCE (SIZE (1..maxCBR-Level-r14)) OF Tx-PreconfigIndex-r14
+}
+
+Tx-PreconfigIndex-r14 ::=			INTEGER(0..maxSL-V2X-TxConfig2-1-r14)
+
+SL-CBR-PPPP-TxPreconfigList-v1530 ::=	SEQUENCE (SIZE (1..8)) OF SL-PPPP-TxPreconfigIndex-v1530
+
+SL-PPPP-TxPreconfigIndex-v1530 ::=		SEQUENCE {
+	mcs-PSSCH-Range-r15				SEQUENCE (SIZE (1..maxCBR-Level-r14)) OF MCS-PSSCH-Range-r15						OPTIONAL
+}
+
+SL-V2X-TxProfileList-r15 ::=	SEQUENCE (SIZE (1..256)) OF SL-V2X-TxProfile-r15
+
+SL-V2X-TxProfile-r15 ::=		ENUMERATED {
+									rel14, rel15, spare6, spare5, spare4,
+									spare3, spare2, spare1, ...}
+
+END
+
+
+
+EUTRA-InterNodeDefinitions DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+	AntennaInfoCommon,
+	AntennaInfoDedicated-v10i0,
+	ARFCN-ValueEUTRA,
+	ARFCN-ValueEUTRA-v9e0,
+	ARFCN-ValueEUTRA-r9,
+	CellIdentity,
+	C-RNTI,
+	DAPS-PowerCoordinationInfo-r16,
+	DL-DCCH-Message,
+	DRB-Identity,
+	DRB-ToReleaseList,
+	DRB-ToReleaseList-r15,
+	FreqBandIndicator-r11,
+	InDeviceCoexIndication-r11,
+	LWA-Config-r13,
+	MasterInformationBlock,
+	maxBands,
+	maxFreq,
+	maxDRB,
+	maxDRBExt-r15,
+	maxDRB-r15,
+	maxSCell-r10,
+	maxSCell-r13,
+	maxServCell-r10,
+	maxServCell-r13,
+	MBMSInterestIndication-r11,
+	MeasConfig,
+	MeasGapConfig,
+	MeasGapConfigPerCC-List-r14,
+	MeasResultForRSSI-r13,
+	MeasResultListWLAN-r13,
+	OtherConfig-r9,
+	PhysCellId,
+	P-Max,
+	PowerCoordinationInfo-r12,
+	SidelinkUEInformation-r12,
+
+	SL-CommConfig-r12,
+	SL-DiscConfig-r12,
+	SubframeAssignment-r15,
+	RadioResourceConfigDedicated,
+	RadioResourceConfigDedicated-v13c0,
+	RadioResourceConfigDedicated-v1370,
+	RAN-NotificationAreaInfo-r15,
+	RCLWI-Configuration-r13,
+	RSRP-Range,
+	RSRQ-Range,
+	RSRQ-Range-v1250,
+	RS-SINR-Range-r13,
+	SCellToAddModList-r10,
+	SCellToAddModList-v13c0,
+	SCellToAddModListExt-r13,
+	SCellToAddModListExt-v13c0,
+	SCG-ConfigPartSCG-r12,
+	SCG-ConfigPartSCG-v12f0,
+	SCG-ConfigPartSCG-v13c0,
+	SecurityAlgorithmConfig,
+	SCellIndex-r10,
+	SCellIndex-r13,
+	SCellToReleaseList-r10,
+	SCellToReleaseListExt-r13,
+	ServCellIndex-r10,
+	ServCellIndex-r13,
+	ShortMAC-I,
+	MeasResultServFreqListNR-r15,
+	MeasResultSSTD-r13,
+	SL-V2X-ConfigDedicated-r14,
+	SystemInformationBlockType1,
+	SystemInformationBlockType1-v890-IEs,
+	SystemInformationBlockType2,
+	TDM-PatternConfig-r15,
+	UEAssistanceInformation-r11,
+	UECapabilityInformation,
+	UE-CapabilityRAT-ContainerList,
+	UE-RadioPagingInfo-r12,
+	WLANConnectionStatusReport-r13,
+	WLAN-OffloadConfig-r12
+FROM EUTRA-RRC-Definitions;
+
+
+
+HandoverCommand ::=					SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			handoverCommand-r8					HandoverCommand-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+HandoverCommand-r8-IEs ::=			SEQUENCE {
+	handoverCommandMessage				OCTET STRING (CONTAINING DL-DCCH-Message),
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+HandoverPreparationInformation ::=	SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			handoverPreparationInformation-r8	HandoverPreparationInformation-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+HandoverPreparationInformation-r8-IEs ::= SEQUENCE {
+	ue-RadioAccessCapabilityInfo		UE-CapabilityRAT-ContainerList,
+	as-Config							AS-Config					OPTIONAL,		-- Cond HO
+	rrm-Config							RRM-Config					OPTIONAL,
+	as-Context							AS-Context				OPTIONAL,		-- Cond HO
+	nonCriticalExtension				HandoverPreparationInformation-v920-IEs		OPTIONAL
+}
+
+HandoverPreparationInformation-v920-IEs	::= SEQUENCE {
+	ue-ConfigRelease-r9					ENUMERATED {
+										rel9, rel10, rel11, rel12, v10j0, v11e0,
+										v1280, rel13, ..., rel14, rel15, rel16}		OPTIONAL,	-- Cond HO2
+	nonCriticalExtension				HandoverPreparationInformation-v9d0-IEs		OPTIONAL
+}
+
+HandoverPreparationInformation-v9d0-IEs	::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING (CONTAINING HandoverPreparationInformation-v9j0-IEs)	OPTIONAL,
+	nonCriticalExtension				HandoverPreparationInformation-v9e0-IEs			OPTIONAL
+}
+
+-- Late non-critical extensions:
+HandoverPreparationInformation-v9j0-IEs ::= SEQUENCE {
+	-- Following field is only for pre REL-10 late non-critical extensions
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				HandoverPreparationInformation-v10j0-IEs		OPTIONAL
+}
+
+HandoverPreparationInformation-v10j0-IEs ::= SEQUENCE {
+	as-Config-v10j0						AS-Config-v10j0			OPTIONAL,
+	nonCriticalExtension				HandoverPreparationInformation-v10x0-IEs		OPTIONAL
+}
+
+HandoverPreparationInformation-v10x0-IEs ::= SEQUENCE {
+	-- Following field is only for late non-critical extensions from REL-10 to REL-12
+	lateNonCriticalExtension			OCTET STRING					OPTIONAL,
+	nonCriticalExtension				HandoverPreparationInformation-v13c0-IEs		OPTIONAL
+}
+
+HandoverPreparationInformation-v13c0-IEs ::= SEQUENCE {
+	as-Config-v13c0						AS-Config-v13c0			OPTIONAL,
+	-- Following field is only for late non-critical extensions from REL-13
+	nonCriticalExtension				SEQUENCE {}					OPTIONAL
+}
+
+-- Regular non-critical extensions:
+HandoverPreparationInformation-v9e0-IEs	::= SEQUENCE {
+	as-Config-v9e0						AS-Config-v9e0					OPTIONAL,	-- Cond HO2
+	nonCriticalExtension				HandoverPreparationInformation-v1130-IEs		OPTIONAL
+}
+
+HandoverPreparationInformation-v1130-IEs	::= SEQUENCE {
+	as-Context-v1130					AS-Context-v1130				OPTIONAL,	-- Cond HO2
+	nonCriticalExtension				HandoverPreparationInformation-v1250-IEs						OPTIONAL
+}
+
+HandoverPreparationInformation-v1250-IEs ::= SEQUENCE {
+	ue-SupportedEARFCN-r12				ARFCN-ValueEUTRA-r9				OPTIONAL,	-- Cond HO3
+	as-Config-v1250					AS-Config-v1250				OPTIONAL,	-- Cond HO2
+	nonCriticalExtension				HandoverPreparationInformation-v1320-IEs						OPTIONAL
+}
+
+HandoverPreparationInformation-v1320-IEs ::= SEQUENCE {
+	as-Config-v1320						AS-Config-v1320					OPTIONAL,	-- Cond HO2
+	as-Context-v1320					AS-Context-v1320				OPTIONAL,	-- Cond HO2
+	nonCriticalExtension				HandoverPreparationInformation-v1430-IEs						OPTIONAL
+}
+
+HandoverPreparationInformation-v1430-IEs ::= SEQUENCE {
+	as-Config-v1430					AS-Config-v1430						OPTIONAL,	-- Cond HO2
+	makeBeforeBreakReq-r14			ENUMERATED {true}				OPTIONAL,	-- Cond HO2
+	nonCriticalExtension			HandoverPreparationInformation-v1530-IEs			OPTIONAL
+}
+
+HandoverPreparationInformation-v1530-IEs ::= SEQUENCE {
+	ran-NotificationAreaInfo-r15		RAN-NotificationAreaInfo-r15			OPTIONAL,
+	nonCriticalExtension				HandoverPreparationInformation-v1540-IEs							OPTIONAL
+}
+
+HandoverPreparationInformation-v1540-IEs ::= SEQUENCE {
+	sourceRB-ConfigIntra5GC-r15		OCTET STRING						OPTIONAL,	--Cond HO4
+	nonCriticalExtension				HandoverPreparationInformation-v1610-IEs	OPTIONAL
+}
+
+HandoverPreparationInformation-v1610-IEs ::= SEQUENCE {
+	as-Context-v1610			AS-Context-v1610						OPTIONAL,	--Cond HO5
+	nonCriticalExtension		HandoverPreparationInformation-v1620-IEs	OPTIONAL
+}
+
+HandoverPreparationInformation-v1620-IEs ::= SEQUENCE {
+	as-Context-v1620			AS-Context-v1620						OPTIONAL, 	--Cond HO2
+	nonCriticalExtension		HandoverPreparationInformation-v1630-IEs	OPTIONAL
+}
+
+HandoverPreparationInformation-v1630-IEs ::= SEQUENCE {
+	as-Context-v1630			AS-Context-v1630						OPTIONAL, 	--Cond HO2
+	nonCriticalExtension		SEQUENCE {}								OPTIONAL
+}
+
+
+
+SCG-Config-r12 ::=					SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			scg-Config-r12					SCG-Config-r12-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SCG-Config-r12-IEs ::=				SEQUENCE {
+	scg-RadioConfig-r12					SCG-ConfigPartSCG-r12				OPTIONAL,
+	nonCriticalExtension					SCG-Config-v12i0a-IEs				OPTIONAL
+}
+
+SCG-Config-v12i0a-IEs ::=				SEQUENCE {
+	-- Following field is only for late non-critical extensions from REL-12
+	lateNonCriticalExtension			OCTET STRING (CONTAINING SCG-Config-v12i0b-IEs)	OPTIONAL,
+	nonCriticalExtension				SCG-Config-v13c0-IEs				OPTIONAL
+}
+
+SCG-Config-v12i0b-IEs ::=				SEQUENCE {
+	scg-RadioConfig-v12i0				SCG-ConfigPartSCG-v12f0			OPTIONAL,	-- Need ON
+	nonCriticalExtension				SEQUENCE {}						OPTIONAL
+}
+
+SCG-Config-v13c0-IEs ::=				SEQUENCE {
+	scg-RadioConfig-v13c0				SCG-ConfigPartSCG-v13c0				OPTIONAL,
+	-- Following field is only for late non-critical extensions from REL-13 onwards
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+SCG-ConfigInfo-r12 ::=					SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			scg-ConfigInfo-r12					SCG-ConfigInfo-r12-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+SCG-ConfigInfo-r12-IEs ::=			SEQUENCE {
+	radioResourceConfigDedMCG-r12	RadioResourceConfigDedicated		OPTIONAL,
+	sCellToAddModListMCG-r12		SCellToAddModList-r10				OPTIONAL,
+	measGapConfig-r12				MeasGapConfig						OPTIONAL,
+	powerCoordinationInfo-r12		PowerCoordinationInfo-r12			OPTIONAL,
+	scg-RadioConfig-r12				SCG-ConfigPartSCG-r12				OPTIONAL,
+	eutra-CapabilityInfo-r12		OCTET STRING (CONTAINING UECapabilityInformation)	OPTIONAL,
+	scg-ConfigRestrictInfo-r12		SCG-ConfigRestrictInfo-r12			OPTIONAL,
+	mbmsInterestIndication-r12		OCTET STRING (CONTAINING
+										MBMSInterestIndication-r11)		OPTIONAL,
+	measResultServCellListSCG-r12	MeasResultServCellListSCG-r12		OPTIONAL,
+	drb-ToAddModListSCG-r12			DRB-InfoListSCG-r12					OPTIONAL,
+	drb-ToReleaseListSCG-r12		DRB-ToReleaseList					OPTIONAL,
+	sCellToAddModListSCG-r12		SCellToAddModListSCG-r12			OPTIONAL,
+	sCellToReleaseListSCG-r12		SCellToReleaseList-r10				OPTIONAL,
+	p-Max-r12							P-Max								OPTIONAL,
+	nonCriticalExtension			SCG-ConfigInfo-v1310-IEs			OPTIONAL
+}
+
+SCG-ConfigInfo-v1310-IEs ::=		SEQUENCE {
+	measResultSSTD-r13				MeasResultSSTD-r13					OPTIONAL,
+	sCellToAddModListMCG-Ext-r13		SCellToAddModListExt-r13			OPTIONAL,
+	measResultServCellListSCG-Ext-r13	MeasResultServCellListSCG-Ext-r13	OPTIONAL,
+	sCellToAddModListSCG-Ext-r13		SCellToAddModListSCG-Ext-r13			OPTIONAL,
+	sCellToReleaseListSCG-Ext-r13	SCellToReleaseListExt-r13			OPTIONAL,
+	nonCriticalExtension			SCG-ConfigInfo-v1330-IEs			OPTIONAL
+}
+
+SCG-ConfigInfo-v1330-IEs ::=		SEQUENCE {
+	measResultListRSSI-SCG-r13		MeasResultListRSSI-SCG-r13			OPTIONAL,
+	nonCriticalExtension			SCG-ConfigInfo-v1430-IEs							OPTIONAL
+}
+
+SCG-ConfigInfo-v1430-IEs ::=		SEQUENCE {
+	makeBeforeBreakSCG-Req-r14		ENUMERATED {true}					OPTIONAL,
+	measGapConfigPerCC-List		MeasGapConfigPerCC-List-r14			OPTIONAL,
+	nonCriticalExtension			SCG-ConfigInfo-v1530-IEs					OPTIONAL
+}
+
+SCG-ConfigInfo-v1530-IEs ::=		SEQUENCE {
+	drb-ToAddModListSCG-r15			DRB-InfoListSCG-r15					OPTIONAL,
+	drb-ToReleaseListSCG-r15		DRB-ToReleaseList-r15				OPTIONAL,
+	nonCriticalExtension			SEQUENCE {}							OPTIONAL
+}
+
+DRB-InfoListSCG-r12 ::=				SEQUENCE (SIZE (1..maxDRB)) OF DRB-InfoSCG-r12
+DRB-InfoListSCG-r15 ::=				SEQUENCE (SIZE (1..maxDRB-r15)) OF DRB-InfoSCG-r12
+
+DRB-InfoSCG-r12 ::=				SEQUENCE {
+	eps-BearerIdentity-r12			INTEGER (0..15)				OPTIONAL,	-- Cond DRB-Setup
+	drb-Identity-r12				DRB-Identity,
+	drb-Type-r12					ENUMERATED {split, scg}		OPTIONAL,	-- Cond DRB-Setup
+	...
+}
+
+SCellToAddModListSCG-r12 ::=	SEQUENCE (SIZE (1..maxSCell-r10)) OF Cell-ToAddMod-r12
+
+SCellToAddModListSCG-Ext-r13 ::=	SEQUENCE (SIZE (1..maxSCell-r13)) OF Cell-ToAddMod-r12
+
+Cell-ToAddMod-r12 ::=				SEQUENCE {
+	sCellIndex-r12						SCellIndex-r10,
+	cellIdentification-r12				SEQUENCE {
+		physCellId-r12						PhysCellId,
+		dl-CarrierFreq-r12					ARFCN-ValueEUTRA-r9
+	}																OPTIONAL,	-- Cond SCellAdd
+	measResultCellToAdd-r12				SEQUENCE {
+		rsrpResult-r12						RSRP-Range,
+		rsrqResult-r12						RSRQ-Range
+	}																OPTIONAL,	-- Cond SCellAdd2
+	...,
+	[[		sCellIndex-r13					SCellIndex-r13				OPTIONAL,
+		measResultCellToAdd-v1310			SEQUENCE {
+			rs-sinr-Result-r13					RS-SINR-Range-r13
+		}															OPTIONAL	-- Cond SCellAdd2
+	]]
+}
+
+MeasResultServCellListSCG-r12 ::=	SEQUENCE (SIZE (1..maxServCell-r10)) OF MeasResultServCellSCG-r12
+
+MeasResultServCellListSCG-Ext-r13 ::=	SEQUENCE (SIZE (1..maxServCell-r13)) OF MeasResultServCellSCG-r12
+
+MeasResultServCellSCG-r12 ::=			SEQUENCE {
+	servCellId-r12						ServCellIndex-r10,
+	measResultSCell-r12					SEQUENCE {
+		rsrpResultSCell-r12					RSRP-Range,
+		rsrqResultSCell-r12					RSRQ-Range
+	},
+	...,
+	[[		servCellId-r13						ServCellIndex-r13		OPTIONAL,
+		measResultSCell-v1310				SEQUENCE {
+			rs-sinr-ResultSCell-r13				RS-SINR-Range-r13
+		}															OPTIONAL
+	]]
+}
+
+MeasResultListRSSI-SCG-r13 ::=	SEQUENCE (SIZE (1..maxServCell-r13)) OF MeasResultRSSI-SCG-r13
+
+MeasResultRSSI-SCG-r13 ::=			SEQUENCE {
+	servCellId-r13						ServCellIndex-r13,
+	measResultForRSSI-r13				MeasResultForRSSI-r13
+}
+
+SCG-ConfigRestrictInfo-r12 ::=		SEQUENCE {
+	maxSCH-TB-BitsDL-r12				INTEGER (1..100),
+	maxSCH-TB-BitsUL-r12				INTEGER (1..100)
+}
+
+
+
+UEPagingCoverageInformation ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			uePagingCoverageInformation-r13			UEPagingCoverageInformation-r13-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UEPagingCoverageInformation-r13-IEs ::= SEQUENCE {
+	mpdcch-NumRepetition-r13				INTEGER (1..256)	OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}		OPTIONAL
+}
+
+
+
+UERadioAccessCapabilityInformation ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			ueRadioAccessCapabilityInformation-r8
+												UERadioAccessCapabilityInformation-r8-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UERadioAccessCapabilityInformation-r8-IEs ::= SEQUENCE {
+	ue-RadioAccessCapabilityInfo		OCTET STRING (CONTAINING UECapabilityInformation),
+	nonCriticalExtension				SEQUENCE {}							OPTIONAL
+}
+
+
+
+UERadioPagingInformation ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			ueRadioPagingInformation-r12			UERadioPagingInformation-r12-IEs,
+			spare7 NULL,
+			spare6 NULL, spare5 NULL, spare4 NULL,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UERadioPagingInformation-r12-IEs ::= SEQUENCE {
+	ue-RadioPagingInfo-r12				OCTET STRING (CONTAINING UE-RadioPagingInfo-r12),
+	nonCriticalExtension				UERadioPagingInformation-v1310-IEs			OPTIONAL
+}
+
+UERadioPagingInformation-v1310-IEs ::= SEQUENCE {
+	supportedBandListEUTRAForPaging-r13		SEQUENCE (SIZE (1..maxBands)) OF FreqBandIndicator-r11 OPTIONAL,
+	nonCriticalExtension					UERadioPagingInformation-v1610-IEs		OPTIONAL
+
+}
+
+UERadioPagingInformation-v1610-IEs ::= SEQUENCE {
+	accessStratumRelease-r16				ENUMERATED {true}						OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}								OPTIONAL
+}
+
+
+
+AS-Config ::=				SEQUENCE {
+	sourceMeasConfig					MeasConfig,
+	sourceRadioResourceConfig			RadioResourceConfigDedicated,
+	sourceSecurityAlgorithmConfig		SecurityAlgorithmConfig,
+	sourceUE-Identity					C-RNTI,
+	sourceMasterInformationBlock		MasterInformationBlock,
+	sourceSystemInformationBlockType1	SystemInformationBlockType1(WITH COMPONENTS
+											{..., nonCriticalExtension ABSENT}),
+	sourceSystemInformationBlockType2	SystemInformationBlockType2,
+	antennaInfoCommon					AntennaInfoCommon,
+	sourceDl-CarrierFreq				ARFCN-ValueEUTRA,
+	...,
+	[[	sourceSystemInformationBlockType1Ext	OCTET STRING (CONTAINING
+												SystemInformationBlockType1-v890-IEs)	OPTIONAL,
+		sourceOtherConfig-r9				OtherConfig-r9
+	-- sourceOtherConfig-r9 should have been optional. A target eNB compliant with this transfer
+	-- syntax should support receiving an AS-Config not including this extension addition group
+	-- e.g. from a legacy source eNB
+	]],
+	[[	sourceSCellConfigList-r10			SCellToAddModList-r10			OPTIONAL
+	]],
+	[[	sourceConfigSCG-r12					SCG-Config-r12		OPTIONAL
+	]],
+	[[	as-ConfigNR-r15						AS-ConfigNR-r15					OPTIONAL
+	]],
+	[[	as-Config-v1550						AS-Config-v1550					OPTIONAL
+	]],
+	[[	as-ConfigNR-v1570					AS-ConfigNR-v1570				OPTIONAL
+	]],
+	[[	as-ConfigNR-v1620					AS-ConfigNR-v1620				OPTIONAL
+	]]
+}
+
+AS-Config-v9e0 ::=				SEQUENCE {
+	sourceDl-CarrierFreq-v9e0		ARFCN-ValueEUTRA-v9e0
+}
+
+AS-Config-v10j0 ::=				SEQUENCE {
+	antennaInfoDedicatedPCell-v10i0		AntennaInfoDedicated-v10i0			OPTIONAL
+}
+
+AS-Config-v1250 ::=				SEQUENCE {
+	sourceWlan-OffloadConfig-r12		WLAN-OffloadConfig-r12				OPTIONAL,
+	sourceSL-CommConfig-r12				SL-CommConfig-r12					OPTIONAL,
+	sourceSL-DiscConfig-r12				SL-DiscConfig-r12					OPTIONAL
+}
+
+AS-Config-v1320 ::=				SEQUENCE {
+	sourceSCellConfigList-r13			SCellToAddModListExt-r13			OPTIONAL,
+	sourceRCLWI-Configuration-r13		RCLWI-Configuration-r13				OPTIONAL
+}
+
+AS-Config-v13c0 ::=				SEQUENCE {
+	radioResourceConfigDedicated-v13c01	RadioResourceConfigDedicated-v1370	OPTIONAL,
+	radioResourceConfigDedicated-v13c02	RadioResourceConfigDedicated-v13c0	OPTIONAL,
+	sCellToAddModList-v13c0				SCellToAddModList-v13c0				OPTIONAL,
+	sCellToAddModListExt-v13c0			SCellToAddModListExt-v13c0			OPTIONAL
+}
+
+AS-Config-v1430 ::=				SEQUENCE {
+	sourceSL-V2X-CommConfig-r14			SL-V2X-ConfigDedicated-r14					OPTIONAL,
+	sourceLWA-Config-r14				LWA-Config-r13						OPTIONAL,
+	sourceWLAN-MeasResult-r14			MeasResultListWLAN-r13				OPTIONAL
+}
+
+AS-ConfigNR-r15 ::=				SEQUENCE {
+	sourceRB-ConfigNR-r15				OCTET STRING			OPTIONAL,
+	sourceRB-ConfigSN-NR-r15				OCTET STRING			OPTIONAL,
+	sourceOtherConfigSN-NR-r15			OCTET STRING			OPTIONAL
+}
+
+AS-ConfigNR-v1570 ::=				SEQUENCE {
+	sourceSCG-ConfiguredNR-r15			ENUMERATED {true}
+}
+
+AS-Config-v1550 ::=			SEQUENCE {
+	tdm-PatternConfig-r15		SEQUENCE {
+		subframeAssignment-r15		SubframeAssignment-r15,
+		harq-Offset-r15				INTEGER (0.. 9)
+	}												OPTIONAL,
+	p-MaxEUTRA-r15				P-Max		OPTIONAL
+}
+
+AS-ConfigNR-v1620 ::=			SEQUENCE {
+	tdm-PatternConfig2-r16		TDM-PatternConfig-r15
+}
+
+
+
+AS-Context ::=							SEQUENCE {
+	reestablishmentInfo						ReestablishmentInfo			OPTIONAL	-- Cond HO
+}
+
+AS-Context-v1130 ::=					SEQUENCE {
+	idc-Indication-r11						OCTET STRING (CONTAINING
+											InDeviceCoexIndication-r11)	OPTIONAL,	-- Cond HO2
+	mbmsInterestIndication-r11				OCTET STRING (CONTAINING
+											MBMSInterestIndication-r11)	OPTIONAL,	-- Cond HO2
+	ueAssistanceInformation-r11					OCTET STRING (CONTAINING
+											UEAssistanceInformation-r11)	OPTIONAL,	-- Cond HO2
+	...,
+	[[	sidelinkUEInformation-r12				OCTET STRING (CONTAINING
+												SidelinkUEInformation-r12)	OPTIONAL	-- Cond HO2
+	]],
+	[[	sourceContextEN-DC-r15				OCTET STRING					OPTIONAL	-- Cond HO2
+	]],
+	[[	selectedbandCombinationInfoEN-DC-v1540		OCTET STRING			OPTIONAL	-- Cond HO2
+	]]
+}
+
+AS-Context-v1320 ::=					SEQUENCE {
+	wlanConnectionStatusReport-r13			OCTET STRING (CONTAINING
+											WLANConnectionStatusReport-r13)	OPTIONAL	-- Cond HO2
+}
+
+AS-Context-v1610 ::=					SEQUENCE {
+	sidelinkUEInformationNR-r16				OCTET STRING	OPTIONAL, -- Cond HO3
+	ueAssistanceInformationNR-r16			OCTET STRING	OPTIONAL, -- Cond HO3
+	configRestrictInfoDAPS-r16				ConfigRestrictInfoDAPS-r16		OPTIONAL -- Cond HO2
+}
+
+AS-Context-v1620 ::=					SEQUENCE {
+	ueAssistanceInformationNR-SCG-r16		OCTET STRING	OPTIONAL  -- Cond HO2
+}
+
+AS-Context-v1630 ::=					SEQUENCE {
+	configRestrictInfoDAPS-v1630			ConfigRestrictInfoDAPS-v1630		OPTIONAL -- Cond HO2
+}
+
+ConfigRestrictInfoDAPS-r16 ::=		SEQUENCE {
+	maxSCH-TB-BitsDL-r16					INTEGER (1..100)			OPTIONAL,	-- Cond HO2
+	maxSCH-TB-BitsUL-r16					INTEGER (1..100)			OPTIONAL	-- Cond HO2
+}
+
+ConfigRestrictInfoDAPS-v1630 ::=	SEQUENCE {
+	daps-PowerCoordinationInfo-r16		DAPS-PowerCoordinationInfo-r16	OPTIONAL	-- Cond HO2
+}
+
+
+
+ReestablishmentInfo ::=				SEQUENCE {
+	sourcePhysCellId					PhysCellId,
+	targetCellShortMAC-I				ShortMAC-I,
+	additionalReestabInfoList			AdditionalReestabInfoList				OPTIONAL,
+	...
+}
+
+AdditionalReestabInfoList ::=		SEQUENCE ( SIZE (1..maxReestabInfo) ) OF AdditionalReestabInfo
+
+AdditionalReestabInfo ::=	SEQUENCE{
+	cellIdentity						CellIdentity,
+	key-eNodeB-Star					Key-eNodeB-Star,
+	shortMAC-I							ShortMAC-I
+}
+
+Key-eNodeB-Star ::=					BIT STRING (SIZE (256))
+
+
+
+RRM-Config ::=				SEQUENCE {
+	ue-InactiveTime				ENUMERATED {
+									s1, s2, s3, s5, s7, s10, s15, s20,
+									s25, s30, s40, s50, min1, min1s20c, min1s40,
+									min2, min2s30, min3, min3s30, min4, min5, min6,
+									min7, min8, min9, min10, min12, min14, min17, min20,
+									min24, min28, min33, min38, min44, min50, hr1,
+									hr1min30, hr2, hr2min30, hr3, hr3min30, hr4, hr5, hr6,
+									hr8, hr10, hr13, hr16, hr20, day1, day1hr12, day2,
+									day2hr12, day3, day4, day5, day7, day10, day14, day19,
+									day24, day30, dayMoreThan30}		OPTIONAL,
+	...,
+	[[	candidateCellInfoList-r10	CandidateCellInfoList-r10		OPTIONAL
+	]],
+	[[	candidateCellInfoListNR-r15	MeasResultServFreqListNR-r15		OPTIONAL
+	]]
+}
+
+CandidateCellInfoList-r10 ::=	SEQUENCE (SIZE (1..maxFreq)) OF CandidateCellInfo-r10
+
+CandidateCellInfo-r10 ::=		SEQUENCE {
+	-- cellIdentification
+	physCellId-r10					PhysCellId,
+	dl-CarrierFreq-r10				ARFCN-ValueEUTRA,
+	-- available measurement results
+	rsrpResult-r10					RSRP-Range			OPTIONAL,
+	rsrqResult-r10					RSRQ-Range			OPTIONAL,
+	...,
+	[[	dl-CarrierFreq-v1090			ARFCN-ValueEUTRA-v9e0		OPTIONAL
+	]],
+	[[	rsrqResult-v1250				RSRQ-Range-v1250			OPTIONAL
+	]],
+	[[	rs-sinr-Result-r13				RS-SINR-Range-r13			OPTIONAL
+	]]
+}
+
+
+
+maxReestabInfo				INTEGER ::= 32	-- Maximum number of KeNB* and shortMAC-I forwarded
+											-- at handover for re-establishment preparation
+
+
+
+END
+
+
+
+NBIOT-InterNodeDefinitions DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+IMPORTS
+	C-RNTI,
+	PhysCellId,
+	SecurityAlgorithmConfig,
+	ShortMAC-I
+FROM EUTRA-RRC-Definitions
+
+	AdditionalReestabInfoList
+FROM EUTRA-InterNodeDefinitions
+
+	CarrierFreq-NB-r13,
+	CarrierFreq-NB-v1550,
+	RadioResourceConfigDedicated-NB-r13,
+	UECapabilityInformation-NB,
+	UE-Capability-NB-r13,
+	UE-Capability-NB-Ext-r14-IEs,
+	UE-RadioPagingInfo-NB-r13
+FROM NBIOT-RRC-Definitions;
+
+
+
+HandoverPreparationInformation-NB ::=	SEQUENCE {
+	criticalExtensions						CHOICE {
+		c1										CHOICE{
+			handoverPreparationInformation-r13		HandoverPreparationInformation-NB-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+HandoverPreparationInformation-NB-IEs ::= SEQUENCE {
+	ue-RadioAccessCapabilityInfo-r13		UE-Capability-NB-r13,
+	as-Config-r13							AS-Config-NB,
+	rrm-Config-r13							RRM-Config-NB					OPTIONAL,
+	as-Context-r13							AS-Context-NB					OPTIONAL,
+	nonCriticalExtension					HandoverPreparationInformation-NB-v1380-IEs					OPTIONAL
+}
+
+HandoverPreparationInformation-NB-v1380-IEs ::= SEQUENCE {
+	lateNonCriticalExtension			OCTET STRING						OPTIONAL,
+	nonCriticalExtension				HandoverPreparationInformation-NB-Ext-r14-IEs	OPTIONAL
+}
+
+HandoverPreparationInformation-NB-Ext-r14-IEs ::= SEQUENCE {
+	ue-RadioAccessCapabilityInfoExt-r14		OCTET STRING (CONTAINING UE-Capability-NB-Ext-r14-IEs)	OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}						OPTIONAL
+}
+
+
+
+UEPagingCoverageInformation-NB ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			uePagingCoverageInformation-r13			UEPagingCoverageInformation-NB-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UEPagingCoverageInformation-NB-IEs ::= SEQUENCE {
+--	the possible value(s) can differ from those sent on Uu
+	npdcch-NumRepetitionPaging-r13			INTEGER (1..2048)	OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}		OPTIONAL
+}
+
+
+
+UERadioAccessCapabilityInformation-NB ::= SEQUENCE {
+	criticalExtensions						CHOICE {
+		c1										CHOICE{
+			ueRadioAccessCapabilityInformation-r13
+													UERadioAccessCapabilityInformation-NB-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture				SEQUENCE {}
+	}
+}
+
+UERadioAccessCapabilityInformation-NB-IEs ::= SEQUENCE {
+	ue-RadioAccessCapabilityInfo-r13			OCTET STRING (CONTAINING UE-Capability-NB-r13),
+	nonCriticalExtension						UERadioAccessCapabilityInformation-NB-v1380-IEs	OPTIONAL
+}
+
+UERadioAccessCapabilityInformation-NB-v1380-IEs ::= SEQUENCE {
+	lateNonCriticalExtension				OCTET STRING					OPTIONAL,
+	nonCriticalExtension					UERadioAccessCapabilityInformation-NB-r14-IEs				OPTIONAL
+}
+
+UERadioAccessCapabilityInformation-NB-r14-IEs ::= SEQUENCE {
+	ue-RadioAccessCapabilityInfo-r14		OCTET STRING (CONTAINING UECapabilityInformation-NB)	OPTIONAL,
+	nonCriticalExtension					SEQUENCE {}						OPTIONAL
+}
+
+
+
+UERadioPagingInformation-NB ::= SEQUENCE {
+	criticalExtensions					CHOICE {
+		c1									CHOICE{
+			ueRadioPagingInformation-r13			UERadioPagingInformation-NB-IEs,
+			spare3 NULL, spare2 NULL, spare1 NULL
+		},
+		criticalExtensionsFuture			SEQUENCE {}
+	}
+}
+
+UERadioPagingInformation-NB-IEs ::= SEQUENCE {
+	ue-RadioPagingInfo-r13				OCTET STRING (CONTAINING UE-RadioPagingInfo-NB-r13),
+	nonCriticalExtension				SEQUENCE {}									OPTIONAL
+}
+
+
+
+AS-Config-NB ::=					SEQUENCE {
+	sourceRadioResourceConfig-r13			RadioResourceConfigDedicated-NB-r13,
+	sourceSecurityAlgorithmConfig-r13		SecurityAlgorithmConfig,
+	sourceUE-Identity-r13					C-RNTI,
+	sourceDl-CarrierFreq-r13				CarrierFreq-NB-r13,
+	...,
+	[[	sourceDL-CarrierFreq-v1550			CarrierFreq-NB-v1550	OPTIONAL	-- Cond TDD
+	]]
+}
+
+
+
+AS-Context-NB ::=						SEQUENCE {
+	reestablishmentInfo-r13					ReestablishmentInfo-NB			OPTIONAL,
+	...
+}
+
+
+
+ReestablishmentInfo-NB ::=			SEQUENCE {
+	sourcePhysCellId-r13					PhysCellId,
+	targetCellShortMAC-I-r13				ShortMAC-I,
+	additionalReestabInfoList-r13			AdditionalReestabInfoList				OPTIONAL,
+	...
+}
+
+
+
+
+
+RRM-Config-NB ::=				SEQUENCE {
+	ue-InactiveTime				ENUMERATED {
+									s1, s2, s3, s5, s7, s10, s15, s20,
+									s25, s30, s40, s50, min1, min1s20, min1s40,
+									min2, min2s30, min3, min3s30, min4, min5, min6,
+									min7, min8, min9, min10, min12, min14, min17, min20,
+									min24, min28, min33, min38, min44, min50, hr1,
+									hr1min30, hr2, hr2min30, hr3, hr3min30, hr4, hr5, hr6,
+									hr8, hr10, hr13, hr16, hr20, day1, day1hr12, day2,
+									day2hr12, day3, day4, day5, day7, day10, day14, day19,
+									day24, day30, dayMoreThan30}		OPTIONAL,
+	...
+}
+
+
+
+END

--- a/examples/tests/17-rrc.rs
+++ b/examples/tests/17-rrc.rs
@@ -1,0 +1,17 @@
+#![allow(dead_code, unreachable_patterns, non_camel_case_types)]
+
+mod rrc {
+    include!(concat!(env!("OUT_DIR"), "/rrc.rs"));
+}
+
+fn main() {
+    use asn1_codecs::{uper::UperCodec, PerCodecData};
+    let _ = env_logger::init();
+
+    // LTE SIB1 value
+    let raw_sib1 = hex::decode("68CC42821989C402240F3F6BC2D03EA18C80840C22611D0E098FD080814B62E0").unwrap();
+    let mut sib1_codec_data = PerCodecData::from_slice_uper(&raw_sib1);
+    let sib1 = rrc::BCCH_DL_SCH_Message::uper_decode(&mut sib1_codec_data);
+
+    eprintln!("sib1: {:#?}", sib1.unwrap());
+}

--- a/examples/tests/compile.rs
+++ b/examples/tests/compile.rs
@@ -8,4 +8,5 @@ fn tests() {
     t.pass("tests/14-e2ap.rs");
     t.pass("tests/15-supl.rs");
     t.pass("tests/16-example.rs");
+    t.pass("tests/17-rrc.rs");
 }


### PR DESCRIPTION
I fixed an issue where an empty SEQUENCE-OF value would cause the decoder to loop until it consumed all the remaining bits and then error out. 

I also added a test case to the `examples` directory showing the decoding of an LTE SIB1 value which has an empty SEQUENCE-OF value. 