### PR TITLE
asn-compiler: Support for `REAL`

### DIFF
--- a/asn-compiler/src/generator/asn/types/base/mod.rs
+++ b/asn-compiler/src/generator/asn/types/base/mod.rs
@@ -16,6 +16,8 @@ mod null;
 
 mod oid;
 
+mod real;
+
 use proc_macro2::{Ident, TokenStream};
 
 use crate::error::Error;
@@ -36,6 +38,7 @@ impl ResolvedBaseType {
             ResolvedBaseType::OctetString(ref o) => o.generate(name, generator),
             ResolvedBaseType::CharacterString(ref c) => c.generate(name, generator),
             ResolvedBaseType::Null(ref n) => n.generate(name, generator),
+            ResolvedBaseType::Real(ref r) => r.generate(name, generator),
             ResolvedBaseType::ObjectIdentifier(ref o) => o.generate(name, generator),
         }
     }
@@ -55,6 +58,7 @@ impl ResolvedBaseType {
                 c.generate_ident_and_aux_type(generator, input)
             }
             ResolvedBaseType::Null(ref n) => n.generate_ident_and_aux_type(generator, input),
+            ResolvedBaseType::Real(ref r) => r.generate_ident_and_aux_type(generator, input),
             ResolvedBaseType::ObjectIdentifier(ref o) => {
                 o.generate_ident_and_aux_type(generator, input)
             }

--- a/asn-compiler/src/generator/asn/types/base/real.rs
+++ b/asn-compiler/src/generator/asn/types/base/real.rs
@@ -1,0 +1,44 @@
+//! Generator code for 'Asn1ResolvedBoolean'.
+
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+
+use crate::error::Error;
+use crate::generator::Generator;
+use crate::resolver::asn::structs::types::base::Asn1ResolvedReal;
+
+impl Asn1ResolvedReal {
+    pub(crate) fn generate(
+        &self,
+        name: &str,
+        generator: &mut Generator,
+    ) -> Result<TokenStream, Error> {
+        let type_name = generator.to_type_ident(name);
+
+        let vis = generator.get_visibility_tokens();
+        let dir = generator.generate_derive_tokens();
+
+        Ok(quote! {
+            #dir
+            #[asn(type = "REAL")]
+            #vis struct #type_name(#vis f64);
+        })
+    }
+
+    pub(crate) fn generate_ident_and_aux_type(
+        &self,
+        generator: &mut Generator,
+        input: Option<&String>,
+    ) -> Result<Ident, Error> {
+        let unique_name = if input.is_none() {
+            generator.get_unique_name("REAL")
+        } else {
+            input.unwrap().to_string()
+        };
+
+        let item = self.generate(&unique_name, generator)?;
+        generator.aux_items.push(item);
+
+        Ok(generator.to_type_ident(&unique_name))
+    }
+}

--- a/asn-compiler/src/generator/int.rs
+++ b/asn-compiler/src/generator/int.rs
@@ -40,8 +40,11 @@ pub enum Derive {
     /// Generate 'serde::Deserialize' code for the generated structures.
     Deserialize,
 
-    /// Generate `Eq` and `PartialEq` code for the generated structures.
-    EqPartialEq,
+    /// Generate `Eq` code for the generated structures.
+    Eq,
+
+    /// Generate `PartialEq` code for the generated structures.
+    PartialEq,
 
     /// Generate code for all supported derives for the generated structures.
     All,
@@ -71,7 +74,8 @@ lazy_static! {
         m.insert(Derive::Clone, "Clone".to_string());
         m.insert(Derive::Serialize, "serde::Serialize".to_string());
         m.insert(Derive::Deserialize, "serde::Deserialize".to_string());
-        m.insert(Derive::EqPartialEq, "Eq, PartialEq".to_string());
+        m.insert(Derive::Eq, "Eq".to_string());
+        m.insert(Derive::PartialEq, "PartialEq".to_string());
         m
     };
 }

--- a/asn-compiler/src/parser/asn/defs.rs
+++ b/asn-compiler/src/parser/asn/defs.rs
@@ -554,6 +554,10 @@ UE-RadioAccessCapability-LaterNonCriticalExtensions ::= SEQUENCE {
                 input: r#"IdentifierString ::= VisibleString (FROM (ALL EXCEPT " "))"#,
                 success: true,
             },
+            ParseDefinitionTestCase {
+                input: r#"pi REAL ::= 3.14159"#,
+                success: true,
+            },
         ];
 
         for tc in test_cases {

--- a/asn-compiler/src/parser/asn/structs/types/mod.rs
+++ b/asn-compiler/src/parser/asn/structs/types/mod.rs
@@ -21,6 +21,7 @@ pub(crate) enum Asn1BuiltinType {
     Null,
     OctetString,
     ObjectIdentifier,
+    Real,
     RelativeOid,
 
     // Consumes a lot of String Types.

--- a/asn-compiler/src/parser/asn/types/constructed/choice.rs
+++ b/asn-compiler/src/parser/asn/types/constructed/choice.rs
@@ -256,6 +256,14 @@ mod tests {
                 addition_components_count: 0,
                 tokens_consumed: 0,
             },
+            ParseChoiceTestCase {
+                input: "CHOICE { a INTEGER , r REAL, ...}",
+                success: true,
+                components_count: 2,
+                extensions_present: true,
+                addition_components_count: 0,
+                tokens_consumed: 10,
+            },
         ];
 
         for tc in test_cases {

--- a/asn-compiler/src/parser/asn/types/int.rs
+++ b/asn-compiler/src/parser/asn/types/int.rs
@@ -133,6 +133,11 @@ pub(crate) fn parse_type(tokens: &[Token]) -> Result<(Asn1Type, usize), Error> {
             (Asn1TypeKind::Builtin(Asn1BuiltinType::RelativeOid), 1)
         }
 
+        "REAL" => {
+            log::trace!("Parsing `REAL` type.");
+            (Asn1TypeKind::Builtin(Asn1BuiltinType::Real), 1)
+        }
+
         _ => {
             log::trace!("Parsing a Reference type.");
             parse_referenced_type(&tokens[consumed..])?
@@ -405,6 +410,11 @@ mod tests {
                 input: "[PRIVATE bla] INTEGER",
                 success: false,
                 consumed: 3,
+            },
+            ParseTypeTestCase {
+                input: "REAL",
+                success: true,
+                consumed: 1,
             },
         ];
 

--- a/asn-compiler/src/resolver/asn/structs/types/base.rs
+++ b/asn-compiler/src/resolver/asn/structs/types/base.rs
@@ -13,6 +13,7 @@ pub(crate) enum ResolvedBaseType {
     CharacterString(Asn1ResolvedCharacterString),
     ObjectIdentifier(Asn1ResolvedObjectIdentifier),
     Null(Asn1ResolvedNull),
+    Real(Asn1ResolvedReal),
 }
 
 // An intermediate representation for a Resolved Integer Type
@@ -82,6 +83,10 @@ pub(crate) struct Asn1ResolvedBoolean;
 // Just an empty structure for Resolved `NULL` type.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct Asn1ResolvedNull;
+
+// Just an empty structure for Resolved `NULL` type.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct Asn1ResolvedReal;
 
 // A structure representing a Resolved `OCTET STRING`. `SIZE` Constraint is resolved as well. The
 // `CONTAINING` Constraint is not resolved.

--- a/asn-compiler/src/resolver/asn/types/base/mod.rs
+++ b/asn-compiler/src/resolver/asn/types/base/mod.rs
@@ -18,7 +18,7 @@ use crate::resolver::{
     asn::structs::types::base::{
         Asn1ResolvedBitString, Asn1ResolvedBoolean, Asn1ResolvedCharacterString,
         Asn1ResolvedEnumerated, Asn1ResolvedInteger, Asn1ResolvedNull,
-        Asn1ResolvedObjectIdentifier, Asn1ResolvedOctetString, ResolvedBaseType,
+        Asn1ResolvedObjectIdentifier, Asn1ResolvedOctetString, Asn1ResolvedReal, ResolvedBaseType,
     },
     Resolver,
 };
@@ -51,6 +51,7 @@ pub(crate) fn resolve_base_type(
                 Asn1ResolvedObjectIdentifier::default(),
             )),
             Asn1BuiltinType::Null => Ok(ResolvedBaseType::Null(Asn1ResolvedNull::default())),
+            Asn1BuiltinType::Real => Ok(ResolvedBaseType::Real(Asn1ResolvedReal::default())),
             _ => Err(resolve_error!(
                 "parse_base_type: Not Implemented! {:#?}",
                 ty

--- a/asn-compiler/src/tokenizer/types.rs
+++ b/asn-compiler/src/tokenizer/types.rs
@@ -25,7 +25,7 @@ pub(crate) enum TokenType {
     Keyword,              // eg. "INTEGER", "ENUMERATED", "RELATIVE-OID", "TYPE-IDENTIFIER"
     Comment,              // "-- and everything after up to newline or EOF
     AndIdentifier,        // "&Attribute-Type", "&id" etc.
-    NumberInt,            // eg. 123456
+    NumberInt,            // eg. 123456, 3.14
     BitString,            // '010...'B
     HexString,            // 'FEEDBAC...'h
     TString,              // " A string "

--- a/codecs/src/per/aper/decode/mod.rs
+++ b/codecs/src/per/aper/decode/mod.rs
@@ -83,6 +83,15 @@ pub fn decode_bool(data: &mut PerCodecData) -> Result<bool, PerCodecError> {
     decode_bool_common(data, true)
 }
 
+/// Decode a Real
+///
+/// Decode a Boolean value. Returns the decoded value as a `f64`.
+pub fn decode_real(_data: &mut PerCodecData) -> Result<f64, PerCodecError> {
+    log::trace!("decode_real:");
+
+    todo!()
+}
+
 /// Decode an Enumerated Value
 ///
 /// Decodes an Enumerated value as an index into either `root_values` of the ENUMERATED or

--- a/codecs/src/per/aper/encode/mod.rs
+++ b/codecs/src/per/aper/encode/mod.rs
@@ -85,6 +85,15 @@ pub fn encode_bool(data: &mut PerCodecData, value: bool) -> Result<(), PerCodecE
     encode_bool_common(data, value, true)
 }
 
+/// Encode a REAL Value
+///
+/// Encodes a boolean value into the passed `PerCodecData` structure.
+pub fn encode_real(_data: &mut PerCodecData, value: f64) -> Result<(), PerCodecError> {
+    log::trace!("encode_real: {}", value);
+
+    todo!()
+}
+
 /// Encode an ENUMERATED Value
 pub fn encode_enumerated(
     data: &mut PerCodecData,

--- a/codecs/src/per/uper/decode/mod.rs
+++ b/codecs/src/per/uper/decode/mod.rs
@@ -81,6 +81,15 @@ pub fn decode_bool(data: &mut PerCodecData) -> Result<bool, PerCodecError> {
     decode_bool_common(data, false)
 }
 
+/// Decode a Real
+///
+/// Decode a Real value. Returns the decoded value as a `f64`.
+pub fn decode_real(_data: &mut PerCodecData) -> Result<f64, PerCodecError> {
+    log::trace!("decode_real:");
+
+    todo!()
+}
+
 /// Decode an Enumerated Value
 ///
 /// Decodes an Enumerated value as an index into either `root_values` of the ENUMERATED or

--- a/codecs/src/per/uper/encode/mod.rs
+++ b/codecs/src/per/uper/encode/mod.rs
@@ -83,6 +83,15 @@ pub fn encode_bool(data: &mut PerCodecData, value: bool) -> Result<(), PerCodecE
     encode_bool_common(data, value, true)
 }
 
+/// Encode a REAL Value
+///
+/// Encodes an f64 value into the passed `PerCodecData` structure.
+pub fn encode_real(_data: &mut PerCodecData, value: f64) -> Result<(), PerCodecError> {
+    log::trace!("encode_real: {}", value);
+
+    todo!()
+}
+
 /// Encode an ENUMERATED Value
 pub fn encode_enumerated(
     data: &mut PerCodecData,

--- a/codecs_derive/src/per/mod.rs
+++ b/codecs_derive/src/per/mod.rs
@@ -12,6 +12,7 @@ mod null;
 mod octetstring;
 mod oid;
 mod open;
+mod real;
 mod seq;
 mod seqof;
 
@@ -34,6 +35,7 @@ pub(crate) fn generate_codec(
             charstring::generate_aper_codec_for_asn_charstring(ast, params, aligned)
         }
         "NULL" => null::generate_aper_codec_for_asn_null(ast, params, aligned),
+        "REAL" => real::generate_aper_codec_for_asn_real(ast, params, aligned),
         "SEQUENCE" => seq::generate_aper_codec_for_asn_sequence(ast, params, aligned),
         "OPEN" => open::generate_aper_codec_for_asn_open_type(ast, params, aligned),
         "SEQUENCE-OF" => seqof::generate_aper_codec_for_asn_sequence_of(ast, params, aligned),

--- a/codecs_derive/src/per/real.rs
+++ b/codecs_derive/src/per/real.rs
@@ -1,0 +1,48 @@
+//! Handling of ASN.1 NULL Type
+
+use quote::quote;
+
+use crate::attrs::TyCodecParams;
+
+pub(super) fn generate_aper_codec_for_asn_real(
+    ast: &syn::DeriveInput,
+    _params: &TyCodecParams,
+    aligned: bool,
+) -> proc_macro::TokenStream {
+    let name = &ast.ident;
+
+    let (codec_path, codec_encode_fn, codec_decode_fn) = if aligned {
+        (
+            quote!(asn1_codecs::aper::AperCodec),
+            quote!(aper_encode),
+            quote!(aper_decode),
+        )
+    } else {
+        (
+            quote!(asn1_codecs::uper::UperCodec),
+            quote!(uper_encode),
+            quote!(uper_decode),
+        )
+    };
+    let tokens = quote! {
+
+        impl #codec_path for #name {
+
+            type Output = Self;
+
+            fn #codec_decode_fn(_data: &mut asn1_codecs::PerCodecData) -> Result<Self::Output, asn1_codecs::PerCodecError> {
+                log::trace!(concat!("decode: ", stringify!(#name)));
+
+                todo!()
+            }
+
+            fn #codec_encode_fn(&self, _data: &mut asn1_codecs::PerCodecData) -> Result<(), asn1_codecs::PerCodecError> {
+                log::trace!(concat!("encode: ", stringify!(#name)));
+
+                todo!()
+            }
+        }
+    };
+
+    tokens.into()
+}

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -42,13 +42,16 @@ fn get_specs_files(
 }
 
 fn main() -> std::io::Result<()> {
-    let specs = vec!["ranap", "s1ap", "ngap", "e2ap", "supl", "rrc"];
-    let modules = vec!["ranap.rs", "s1ap.rs", "ngap.rs", "e2ap.rs", "supl.rs", "rrc.rs"];
+    let specs = vec!["ranap", "s1ap", "ngap", "e2ap", "e2sm", "supl", "rrc"];
+    let modules = vec![
+        "ranap.rs", "s1ap.rs", "ngap.rs", "e2ap.rs", "e2sm.rs", "supl.rs", "rrc.rs",
+    ];
     let mut codecs_map = HashMap::new();
     codecs_map.insert("ranap.rs", vec![Codec::Aper]);
     codecs_map.insert("s1ap.rs", vec![Codec::Aper]);
     codecs_map.insert("ngap.rs", vec![Codec::Aper]);
     codecs_map.insert("e2ap.rs", vec![Codec::Aper]);
+    codecs_map.insert("e2sm.rs", vec![Codec::Aper]);
     codecs_map.insert("supl.rs", vec![Codec::Uper]);
     codecs_map.insert("rrc.rs", vec![Codec::Uper]);
 
@@ -68,7 +71,7 @@ fn main() -> std::io::Result<()> {
             codecs_map.get(module).unwrap().clone(),
             vec![
                 Derive::Debug,
-                Derive::EqPartialEq,
+                Derive::PartialEq,
                 Derive::Serialize,
                 Derive::Deserialize,
             ],

--- a/examples/specs/e2sm/E2SM-KPM.asn
+++ b/examples/specs/e2sm/E2SM-KPM.asn
@@ -1,0 +1,994 @@
+-- ASN1START
+-- **************************************************************
+-- E2SM-KPM Information Element Definitions
+-- **************************************************************
+
+E2SM-KPM-IEs {
+iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) oran(53148) e2(1) version3(3) e2sm(2) e2sm-KPMMON-IEs (2)}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+-- **************************************************************
+--   IEs
+-- **************************************************************
+
+IMPORTS
+	CGI,
+	FiveQI,
+	PLMNIdentity,
+	QCI,
+	QosFlowIdentifier,
+	RANfunction-Name,
+	RIC-Format-Type,
+	RIC-Style-Name,
+	RIC-Style-Type,
+	S-NSSAI,
+	UEID
+FROM E2SM-COMMON-IEs;
+
+TimeStamp ::= OCTET STRING (SIZE(8))
+
+BinIndex ::= INTEGER (1.. 65535, ...)
+
+BinRangeValue ::= CHOICE {
+	valueInt				INTEGER,
+	valueReal			REAL,
+	...
+}
+
+GranularityPeriod ::= INTEGER (1.. 4294967295)
+
+LogicalOR ::= ENUMERATED {true, ...}
+
+MeasurementType ::= CHOICE {
+	measName				MeasurementTypeName,
+	measID				MeasurementTypeID,
+	...
+}
+
+MeasurementTypeName ::= PrintableString(SIZE(1.. 150, ...))
+
+MeasurementTypeID ::= INTEGER (1.. 65536, ...)
+
+MeasurementLabel ::= SEQUENCE {
+	noLabel					ENUMERATED {true, ...}				OPTIONAL,
+	plmnID					PLMNIdentity							OPTIONAL,
+	sliceID					S-NSSAI									OPTIONAL,
+	fiveQI					FiveQI									OPTIONAL,
+	qFI						QosFlowIdentifier						OPTIONAL,
+	qCI						QCI										OPTIONAL,
+	qCImax					QCI										OPTIONAL,
+	qCImin					QCI										OPTIONAL,
+	aRPmax					INTEGER (1.. 15, ...)				OPTIONAL,
+	aRPmin					INTEGER (1.. 15, ...)				OPTIONAL,
+	bitrateRange			INTEGER (1.. 65535, ...)			OPTIONAL,
+	layerMU-MIMO			INTEGER (1.. 65535, ...)			OPTIONAL,
+	sUM						ENUMERATED {true, ...}				OPTIONAL,
+	distBinX					INTEGER (1.. 65535, ...)			OPTIONAL,
+	distBinY					INTEGER (1.. 65535, ...)			OPTIONAL,
+	distBinZ					INTEGER (1.. 65535, ...)			OPTIONAL,
+	preLabelOverride		ENUMERATED {true, ...}				OPTIONAL,
+	startEndInd				ENUMERATED {start, end, ...}		OPTIONAL,
+	min						ENUMERATED {true, ...}				OPTIONAL,
+	max						ENUMERATED {true, ...}				OPTIONAL,
+	avg						ENUMERATED {true, ...}				OPTIONAL,
+	...,
+	ssbIndex					INTEGER (1.. 65535, ...)			OPTIONAL,
+	nonGoB-BFmode-Index	INTEGER (1.. 65535, ...)			OPTIONAL,
+	mIMO-mode-Index		INTEGER (1.. 2, ...)					OPTIONAL
+}
+
+TestCondInfo ::= SEQUENCE{
+	testType				TestCond-Type,
+	testExpr				TestCond-Expression						OPTIONAL,
+	testValue			TestCond-Value								OPTIONAL,
+	...
+}
+
+TestCond-Type ::= CHOICE{
+	gBR					ENUMERATED {true, ...},
+	aMBR					ENUMERATED {true, ...},
+	isStat				ENUMERATED {true, ...},
+	isCatM				ENUMERATED {true, ...},
+	rSRP					ENUMERATED {true, ...},
+	rSRQ					ENUMERATED {true, ...},
+	...,
+	ul-rSRP				ENUMERATED {true, ...},
+	cQI					ENUMERATED {true, ...},
+	fiveQI				ENUMERATED {true, ...},
+	qCI					ENUMERATED {true, ...},
+	sNSSAI				ENUMERATED {true, ...}
+}
+
+TestCond-Expression ::= ENUMERATED {
+equal,
+greaterthan,
+lessthan,
+contains,
+present,
+...
+}
+
+TestCond-Value ::= CHOICE{
+	valueInt				INTEGER,
+	valueEnum			INTEGER,
+	valueBool			BOOLEAN,
+	valueBitS			BIT STRING,
+	valueOctS			OCTET STRING,
+	valuePrtS			PrintableString,
+	...,
+	valueReal			REAL
+}
+
+-- **************************************************************
+--   Lists
+-- **************************************************************
+
+maxnoofCells					INTEGER ::= 16384
+maxnoofRICStyles				INTEGER ::= 63
+maxnoofMeasurementInfo		INTEGER ::= 65535
+maxnoofLabelInfo				INTEGER ::= 2147483647
+maxnoofMeasurementRecord	INTEGER ::= 65535
+maxnoofMeasurementValue		INTEGER ::= 2147483647
+maxnoofConditionInfo			INTEGER ::= 32768
+maxnoofUEID						INTEGER ::= 65535
+maxnoofConditionInfoPerSub	INTEGER ::= 32768
+maxnoofUEIDPerSub				INTEGER ::= 65535
+maxnoofUEMeasReport			INTEGER ::= 65535
+maxnoofBin						INTEGER ::= 65535
+
+BinRangeDefinition ::= SEQUENCE {
+binRangeListX		BinRangeList,
+binRangeListY		BinRangeList			OPTIONAL -- This IE shall not be present for a distribution measurement type that doesn't use Distribution Bin Y --,
+binRangeListZ		BinRangeList			OPTIONAL -- This IE shall not be present for a distribution measurement type that doesn't use Distribution Bin Z --,
+...
+}
+
+BinRangeList ::= SEQUENCE (SIZE(1..maxnoofBin)) OF BinRangeItem
+
+BinRangeItem ::= SEQUENCE {
+	binIndex				BinIndex,
+	startValue			BinRangeValue,
+	endValue				BinRangeValue,
+	...
+}
+
+DistMeasurementBinRangeList ::= SEQUENCE (SIZE(1..maxnoofMeasurementInfo)) OF DistMeasurementBinRangeItem
+
+DistMeasurementBinRangeItem ::= SEQUENCE {
+	measType				MeasurementType,
+	binRangeDef			BinRangeDefinition,
+	...
+}
+
+MeasurementInfoList ::= SEQUENCE (SIZE(1..maxnoofMeasurementInfo)) OF MeasurementInfoItem
+
+MeasurementInfoItem ::= SEQUENCE {
+	measType				MeasurementType,
+	labelInfoList		LabelInfoList,
+	...
+}
+
+LabelInfoList ::= SEQUENCE (SIZE(1..maxnoofLabelInfo)) OF LabelInfoItem
+
+LabelInfoItem ::= SEQUENCE {
+	measLabel			MeasurementLabel,
+	...
+}
+
+MeasurementData ::= SEQUENCE (SIZE(1..maxnoofMeasurementRecord)) OF MeasurementDataItem
+
+MeasurementDataItem ::= SEQUENCE {
+measRecord				MeasurementRecord,
+incompleteFlag			ENUMERATED {true, ...}					OPTIONAL,
+...
+}
+
+MeasurementRecord ::= SEQUENCE (SIZE(1..maxnoofMeasurementValue)) OF MeasurementRecordItem
+
+MeasurementRecordItem ::= CHOICE {
+	integer				INTEGER (0.. 4294967295),
+	real					REAL,
+	noValue				NULL,
+	...
+}
+
+MeasurementInfo-Action-List ::= SEQUENCE (SIZE(1..maxnoofMeasurementInfo)) OF MeasurementInfo-Action-Item
+
+MeasurementInfo-Action-Item ::= SEQUENCE {
+	measName				MeasurementTypeName,
+	measID				MeasurementTypeID				OPTIONAL,
+	...,
+	binRangeDef			BinRangeDefinition			OPTIONAL
+}
+
+MeasurementCondList ::= SEQUENCE (SIZE(1..maxnoofMeasurementInfo)) OF MeasurementCondItem
+
+MeasurementCondItem ::= SEQUENCE {
+	measType				MeasurementType,
+	matchingCond		MatchingCondList,
+	...,
+	binRangeDef			BinRangeDefinition			OPTIONAL
+}
+
+MeasurementCondUEidList ::= SEQUENCE (SIZE(1..maxnoofMeasurementInfo)) OF MeasurementCondUEidItem
+
+MeasurementCondUEidItem ::= SEQUENCE {
+	measType					MeasurementType,
+	matchingCond			MatchingCondList,
+	matchingUEidList		MatchingUEidList			OPTIONAL,
+	...,
+	matchingUEidPerGP		MatchingUEidPerGP			OPTIONAL
+}
+
+MatchingCondList ::= SEQUENCE (SIZE(1..maxnoofConditionInfo)) OF MatchingCondItem
+
+MatchingCondItem ::= SEQUENCE {
+matchingCondChoice	MatchingCondItem-Choice,
+logicalOR				LogicalOR						OPTIONAL,
+...
+}
+
+MatchingCondItem-Choice ::= CHOICE{
+	measLabel			MeasurementLabel,
+	testCondInfo		TestCondInfo,
+	...
+}
+
+MatchingUEidList ::= SEQUENCE (SIZE(1..maxnoofUEID)) OF MatchingUEidItem
+
+MatchingUEidItem ::= SEQUENCE{
+	ueID					UEID,
+	...
+}
+
+MatchingUEidPerGP ::= SEQUENCE (SIZE(1..maxnoofMeasurementRecord)) OF MatchingUEidPerGP-Item
+
+MatchingUEidPerGP-Item ::= SEQUENCE{
+	matchedPerGP				CHOICE{
+		noUEmatched 				ENUMERATED {true, ...},
+		oneOrMoreUEmatched		MatchingUEidList-PerGP,
+		...
+	},
+	...
+}
+
+MatchingUEidList-PerGP ::= SEQUENCE (SIZE(1..maxnoofUEID)) OF MatchingUEidItem-PerGP
+
+MatchingUEidItem-PerGP ::= SEQUENCE{
+	ueID					UEID,
+	...
+}
+
+
+MatchingUeCondPerSubList ::= SEQUENCE (SIZE(1..maxnoofConditionInfoPerSub)) OF MatchingUeCondPerSubItem
+
+MatchingUeCondPerSubItem ::= SEQUENCE{
+	testCondInfo		TestCondInfo,
+	...,
+	logicalOR			LogicalOR				OPTIONAL
+}
+
+MatchingUEidPerSubList ::= SEQUENCE (SIZE(2..maxnoofUEIDPerSub)) OF MatchingUEidPerSubItem
+
+MatchingUEidPerSubItem ::= SEQUENCE{
+	ueID					UEID,
+	...
+}
+
+UEMeasurementReportList ::= SEQUENCE (SIZE(1..maxnoofUEMeasReport)) OF UEMeasurementReportItem
+
+UEMeasurementReportItem ::= SEQUENCE{
+	ueID				UEID,
+	measReport		E2SM-KPM-IndicationMessage-Format1,
+	...
+}
+
+
+
+-- **************************************************************
+-- E2SM-KPM Service Model IEs
+-- **************************************************************
+
+-- **************************************************************
+--   Event Trigger Definition OCTET STRING contents
+-- **************************************************************
+
+E2SM-KPM-EventTriggerDefinition ::= SEQUENCE{
+	eventDefinition-formats			CHOICE{
+		eventDefinition-Format1			E2SM-KPM-EventTriggerDefinition-Format1,
+		...
+	},
+	...
+}
+
+E2SM-KPM-EventTriggerDefinition-Format1 ::= SEQUENCE{
+	reportingPeriod					INTEGER (1.. 4294967295),
+	...
+}
+
+-- **************************************************************
+--   Action Definition OCTET STRING contents
+-- **************************************************************
+
+E2SM-KPM-ActionDefinition ::= SEQUENCE{
+	ric-Style-Type					RIC-Style-Type,
+	actionDefinition-formats 	CHOICE{
+		actionDefinition-Format1		E2SM-KPM-ActionDefinition-Format1,
+		actionDefinition-Format2		E2SM-KPM-ActionDefinition-Format2,
+		actionDefinition-Format3		E2SM-KPM-ActionDefinition-Format3,
+		...,
+		actionDefinition-Format4		E2SM-KPM-ActionDefinition-Format4,
+		actionDefinition-Format5		E2SM-KPM-ActionDefinition-Format5
+	},
+	...
+}
+
+E2SM-KPM-ActionDefinition-Format1 ::= SEQUENCE {
+	measInfoList					MeasurementInfoList,
+	granulPeriod					GranularityPeriod,
+	cellGlobalID					CGI							OPTIONAL,
+	...,
+	distMeasBinRangeInfo			DistMeasurementBinRangeList		OPTIONAL
+}
+
+E2SM-KPM-ActionDefinition-Format2 ::= SEQUENCE {
+	ueID								UEID,
+	subscriptInfo					E2SM-KPM-ActionDefinition-Format1,
+	...
+}
+
+E2SM-KPM-ActionDefinition-Format3 ::= SEQUENCE {
+	measCondList					MeasurementCondList,
+	granulPeriod					GranularityPeriod,
+	cellGlobalID					CGI							OPTIONAL,
+	...
+}
+
+E2SM-KPM-ActionDefinition-Format4 ::= SEQUENCE {
+	matchingUeCondList			MatchingUeCondPerSubList,
+	subscriptionInfo				E2SM-KPM-ActionDefinition-Format1,
+	...
+}
+
+E2SM-KPM-ActionDefinition-Format5 ::= SEQUENCE {
+	matchingUEidList				MatchingUEidPerSubList,
+	subscriptionInfo				E2SM-KPM-ActionDefinition-Format1,
+	...
+}
+
+
+-- **************************************************************
+--   Indication Header OCTET STRING contents
+-- **************************************************************
+
+E2SM-KPM-IndicationHeader ::= SEQUENCE{
+	indicationHeader-formats		CHOICE{
+		indicationHeader-Format1		E2SM-KPM-IndicationHeader-Format1,
+		...
+	},
+	...
+}
+
+E2SM-KPM-IndicationHeader-Format1 ::= SEQUENCE{
+	colletStartTime				TimeStamp,
+	fileFormatversion				PrintableString (SIZE (0..15), ...)		OPTIONAL,
+	senderName						PrintableString (SIZE (0..400), ...)	OPTIONAL,
+	senderType						PrintableString (SIZE (0..8), ...)		OPTIONAL,
+	vendorName						PrintableString (SIZE (0..32), ...)		OPTIONAL,
+	...
+}
+
+-- **************************************************************
+--   Indication Message OCTET STRING contents
+-- **************************************************************
+
+E2SM-KPM-IndicationMessage ::= SEQUENCE{
+	indicationMessage-formats		CHOICE{
+		indicationMessage-Format1		E2SM-KPM-IndicationMessage-Format1,
+		indicationMessage-Format2		E2SM-KPM-IndicationMessage-Format2,
+		...,
+		indicationMessage-Format3		E2SM-KPM-IndicationMessage-Format3
+	},
+	...
+}
+
+E2SM-KPM-IndicationMessage-Format1 ::= SEQUENCE {
+	measData							MeasurementData,
+	measInfoList					MeasurementInfoList						OPTIONAL,
+	granulPeriod					GranularityPeriod 						OPTIONAL,
+	...
+}
+
+E2SM-KPM-IndicationMessage-Format2 ::= SEQUENCE {
+	measData							MeasurementData,
+	measCondUEidList				MeasurementCondUEidList,
+	granulPeriod					GranularityPeriod 						OPTIONAL,
+	...
+}
+
+E2SM-KPM-IndicationMessage-Format3 ::= SEQUENCE {
+	ueMeasReportList				UEMeasurementReportList,
+	...
+}
+
+
+-- ***************************************************************
+--   RAN Function Definition OCTET STRING contents
+-- ***************************************************************
+
+E2SM-KPM-RANfunction-Description ::= SEQUENCE{
+	ranFunction-Name					RANfunction-Name,
+	ric-EventTriggerStyle-List		SEQUENCE (SIZE(1..maxnoofRICStyles)) OF RIC-EventTriggerStyle-Item 		OPTIONAL,
+	ric-ReportStyle-List				SEQUENCE (SIZE(1..maxnoofRICStyles)) OF RIC-ReportStyle-Item 				OPTIONAL,
+	...
+}
+
+RIC-EventTriggerStyle-Item ::= SEQUENCE{
+	ric-EventTriggerStyle-Type			RIC-Style-Type,
+	ric-EventTriggerStyle-Name			RIC-Style-Name,
+	ric-EventTriggerFormat-Type		RIC-Format-Type,
+	...
+}
+
+RIC-ReportStyle-Item ::= SEQUENCE{
+	ric-ReportStyle-Type						RIC-Style-Type,
+	ric-ReportStyle-Name						RIC-Style-Name,
+	ric-ActionFormat-Type					RIC-Format-Type,
+	measInfo-Action-List						MeasurementInfo-Action-List,
+	ric-IndicationHeaderFormat-Type		RIC-Format-Type,
+	ric-IndicationMessageFormat-Type		RIC-Format-Type,
+	...
+}
+
+END
+
+-- ASN1STOP
+
+-- ASN1START
+-- **************************************************************
+-- E2SM
+-- Information Element Definitions
+--
+-- **************************************************************
+
+E2SM-COMMON-IEs {
+iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) 53148 e2(1) version1 (1) e2sm(2) e2sm-COMMON-IEs (0)}
+
+DEFINITIONS AUTOMATIC TAGS ::=
+
+BEGIN
+
+-- --------------------------------------------------
+-- Constants
+-- --------------------------------------------------
+
+maxE1APid				INTEGER ::= 65535
+maxF1APid				INTEGER ::= 4
+
+-- IEs derived from 3GPP 36.423 (X2AP)
+maxEARFCN				INTEGER ::= 65535
+
+-- IEs derived from 3GPP 38.473 (F1AP)
+maxNRARFCN				INTEGER ::= 3279165
+maxnoofNrCellBands		INTEGER ::= 32
+
+
+-- --------------------------------------------------
+-- E2SM Commmon IEs
+-- --------------------------------------------------
+
+CGI ::= CHOICE {
+	nR-CGI					NR-CGI,
+	eUTRA-CGI				EUTRA-CGI,
+	...
+}
+
+CoreCPID ::= CHOICE {
+	fiveGC					GUAMI,
+	ePC						GUMMEI,
+	...
+}
+
+InterfaceIdentifier ::= CHOICE {
+	nG					InterfaceID-NG,
+	xN					InterfaceID-Xn,
+	f1					InterfaceID-F1,
+	e1					InterfaceID-E1,
+	s1					InterfaceID-S1,
+	x2					InterfaceID-X2,
+	w1					InterfaceID-W1,
+	...
+}
+
+InterfaceID-NG ::= SEQUENCE {
+	guami					GUAMI,
+	...
+}
+
+InterfaceID-Xn ::= SEQUENCE {
+	global-NG-RAN-ID		GlobalNGRANNodeID,
+	...
+}
+
+InterfaceID-F1 ::= SEQUENCE {
+	globalGNB-ID			GlobalGNB-ID,
+	gNB-DU-ID				GNB-DU-ID,
+	...
+}
+
+InterfaceID-E1 ::= SEQUENCE {
+	globalGNB-ID			GlobalGNB-ID,
+	gNB-CU-UP-ID			GNB-CU-UP-ID,
+	...
+}
+
+InterfaceID-S1 ::= SEQUENCE {
+	gUMMEI					GUMMEI,
+	...
+}
+
+InterfaceID-X2 ::= SEQUENCE {
+	nodeType 				CHOICE {
+		global-eNB-ID			GlobalENB-ID,
+		global-en-gNB-ID		GlobalenGNB-ID,
+		...
+	},
+	...
+}
+
+InterfaceID-W1 ::= SEQUENCE {
+	global-ng-eNB-ID			GlobalNgENB-ID,
+	ng-eNB-DU-ID				NGENB-DU-ID,
+	...
+}
+
+Interface-MessageID ::= SEQUENCE {
+	interfaceProcedureID		INTEGER,
+	messageType					ENUMERATED {initiatingMessage, successfulOutcome, unsuccessfulOutcome, ...},
+	...
+}
+
+InterfaceType ::= ENUMERATED {nG, xn, f1, e1, s1, x2, w1, ...}
+
+GroupID ::= CHOICE {
+	fiveGC						FiveQI,
+	ePC							QCI,
+	...
+}
+
+QoSID ::= CHOICE {
+	fiveGC						FiveQI,
+	ePC							QCI,
+	...
+}
+
+RANfunction-Name ::= SEQUENCE{
+	ranFunction-ShortName		PrintableString(SIZE(1..150,...)),
+	ranFunction-E2SM-OID		PrintableString(SIZE(1..1000,...)),
+	ranFunction-Description		PrintableString(SIZE(1..150,...)),
+	ranFunction-Instance		INTEGER									OPTIONAL,
+	...
+}
+
+RIC-Format-Type ::= INTEGER
+
+RIC-Style-Type ::= INTEGER
+
+RIC-Style-Name ::= PrintableString(SIZE(1..150,...))
+
+
+RRC-MessageID ::= SEQUENCE {
+	rrcType			CHOICE {
+		lTE				RRCclass-LTE,
+		nR				RRCclass-NR,
+		...
+	},
+	messageID		INTEGER,
+	...
+}
+
+RRCclass-LTE ::= ENUMERATED {bCCH-BCH, bCCH-BCH-MBMS, bCCH-DL-SCH, bCCH-DL-SCH-BR, bCCH-DL-SCH-MBMS, mCCH, pCCH, dL-CCCH, dL-DCCH, uL-CCCH, uL-DCCH, sC-MCCH, ...}
+
+RRCclass-NR ::= ENUMERATED {bCCH-BCH, bCCH-DL-SCH, dL-CCCH, dL-DCCH, pCCH, uL-CCCH, uL-CCCH1, uL-DCCH, ...}
+
+ServingCell-ARFCN ::= CHOICE {
+	nR					NR-ARFCN,
+	eUTRA				E-UTRA-ARFCN,
+	...
+}
+
+ServingCell-PCI ::= CHOICE {
+	nR					NR-PCI,
+	eUTRA				E-UTRA-PCI,
+	...
+}
+
+
+UEID ::= CHOICE{
+	gNB-UEID			UEID-GNB,
+	gNB-DU-UEID			UEID-GNB-DU,
+	gNB-CU-UP-UEID		UEID-GNB-CU-UP,
+	ng-eNB-UEID			UEID-NG-ENB,
+	ng-eNB-DU-UEID		UEID-NG-ENB-DU,
+	en-gNB-UEID			UEID-EN-GNB,
+	eNB-UEID			UEID-ENB,
+	...
+}
+
+UEID-GNB ::= SEQUENCE{
+	amf-UE-NGAP-ID				AMF-UE-NGAP-ID,
+	guami						GUAMI,
+	gNB-CU-UE-F1AP-ID-List		UEID-GNB-CU-F1AP-ID-List		OPTIONAL,
+-- C-ifCUDUseparated: This IE shall be present in messages from E2 Node to NearRT-RIC for a CU-DU separated gNB, whereas from NearRT-RIC to E2 Node messages, this IE may not be included. More than 1 F1AP ID shall be reported by E2 Node only when NR-DC is established.
+	gNB-CU-CP-UE-E1AP-ID-List	UEID-GNB-CU-CP-E1AP-ID-List		OPTIONAL,
+-- C-ifCPUPseparated: This IE shall be present in messages from E2 Node to NearRT-RIC for a CP-UP separated gNB, whereas from NearRT-RIC to E2 Node messages, this IE may not be included.
+	ran-UEID					RANUEID							OPTIONAL,
+	m-NG-RAN-UE-XnAP-ID			NG-RANnodeUEXnAPID				OPTIONAL,
+-- C-ifDCSetup: This IE shall be present in messages from E2 Node to NearRT-RIC if DC is established, whereas from NearRT-RIC to E2 Node messages, this IE may not be included. To be reported by both MN and SN.
+	globalGNB-ID				GlobalGNB-ID					OPTIONAL,
+-- This IE shall not be used. This IE is replaced with globalNG-RANNode-ID.
+	...,
+	globalNG-RANNode-ID			GlobalNGRANNodeID				OPTIONAL
+-- C-ifDCSetup: This IE shall be present in messages from E2 Node to NearRT-RIC if DC is established, whereas from NearRT-RIC to E2 Node messages, this IE may not be included. To be reported only by SN.
+}
+
+UEID-GNB-CU-CP-E1AP-ID-List ::= SEQUENCE (SIZE(1..maxE1APid)) OF UEID-GNB-CU-CP-E1AP-ID-Item
+
+UEID-GNB-CU-CP-E1AP-ID-Item ::= SEQUENCE{
+	gNB-CU-CP-UE-E1AP-ID	GNB-CU-CP-UE-E1AP-ID,
+	...
+}
+
+UEID-GNB-CU-F1AP-ID-List ::= SEQUENCE (SIZE(1..maxF1APid)) OF UEID-GNB-CU-CP-F1AP-ID-Item
+
+UEID-GNB-CU-CP-F1AP-ID-Item ::= SEQUENCE{
+	gNB-CU-UE-F1AP-ID		GNB-CU-UE-F1AP-ID,
+	...
+}
+
+UEID-GNB-DU ::= SEQUENCE{
+	gNB-CU-UE-F1AP-ID		GNB-CU-UE-F1AP-ID,
+	ran-UEID				RANUEID							OPTIONAL,
+	...
+}
+
+UEID-GNB-CU-UP ::= SEQUENCE{
+	gNB-CU-CP-UE-E1AP-ID	GNB-CU-CP-UE-E1AP-ID,
+	ran-UEID				RANUEID							OPTIONAL,
+	...
+}
+
+UEID-NG-ENB ::= SEQUENCE{
+	amf-UE-NGAP-ID			AMF-UE-NGAP-ID,
+	guami					GUAMI,
+	ng-eNB-CU-UE-W1AP-ID	NGENB-CU-UE-W1AP-ID				OPTIONAL,
+-- C-ifCUDUseperated: This IE shall be present in messages from E2 Node to NearRT-RIC for a CU-DU seperated ng-eNB, whereas from NearRT-RIC to E2 Node messages, this IE may not be included.
+	m-NG-RAN-UE-XnAP-ID		NG-RANnodeUEXnAPID				OPTIONAL,
+-- C-ifDCSetup: This IE shall be present in messages from E2 Node to NearRT-RIC if DC is established, whereas from NearRT-RIC to E2 Node messages, this IE may not be included. To be reported by both MN and SN.
+	globalNgENB-ID			GlobalNgENB-ID					OPTIONAL,
+-- This IE shall not be used. This IE is replaced with globalNG-RANNode-ID.
+	...,
+	globalNG-RANNode-ID			GlobalNGRANNodeID			OPTIONAL
+-- C-ifDCSetup: This IE shall be present in messages from E2 Node to NearRT-RIC if DC is established, whereas from NearRT-RIC to E2 Node messages, this IE may not be included. To be reported only by SN.
+}
+
+
+UEID-NG-ENB-DU ::= SEQUENCE{
+	ng-eNB-CU-UE-W1AP-ID	NGENB-CU-UE-W1AP-ID,
+	...
+}
+
+UEID-EN-GNB ::= SEQUENCE{
+	m-eNB-UE-X2AP-ID			ENB-UE-X2AP-ID,
+	m-eNB-UE-X2AP-ID-Extension	ENB-UE-X2AP-ID-Extension	OPTIONAL,
+	globalENB-ID				GlobalENB-ID,
+	gNB-CU-UE-F1AP-ID			GNB-CU-UE-F1AP-ID			OPTIONAL,
+-- C-ifCUDUseperated: This IE shall be present in messages from E2 Node to NearRT-RIC for a CU-DU seperated en-gNB, whereas from NearRT-RIC to E2 Node messages, this IE may not be included.
+	gNB-CU-CP-UE-E1AP-ID-List	UEID-GNB-CU-CP-E1AP-ID-List	OPTIONAL,
+-- C-ifCPUPseparated: This IE shall be present in messages from E2 Node to NearRT-RIC for a CP-UP separated en-gNB, whereas from NearRT-RIC to E2 Node messages, this IE may not be included.
+	ran-UEID					RANUEID						OPTIONAL,
+	...
+}
+
+UEID-ENB ::= SEQUENCE{
+	mME-UE-S1AP-ID				MME-UE-S1AP-ID,
+	gUMMEI						GUMMEI,
+	m-eNB-UE-X2AP-ID			ENB-UE-X2AP-ID				OPTIONAL,
+-- This IE shall be present in messages from E2 Node to NearRT-RIC if DC is established, whereas from NearRT-RIC to E2 Node messages, this IE may not be included. To be reported by MeNB and SeNB.
+	m-eNB-UE-X2AP-ID-Extension	ENB-UE-X2AP-ID-Extension	OPTIONAL,
+	globalENB-ID				GlobalENB-ID				OPTIONAL,
+-- This IE shall be present in messages from E2 Node to NearRT-RIC if DC is established, whereas from NearRT-RIC to E2 Node messages, this IE may not be included. To be reported only by SeNB.
+	...
+}
+
+-- **************************************************************
+-- 3GPP derived IEs
+-- **************************************************************
+-- NOTE:
+-- - Extension fields removed and replaced with "..."
+-- - IE names modified across all extracts to use "PLMNIdentity"
+
+-- **************************************************************
+-- IEs derived from 3GPP 36.413 (S1AP)
+-- **************************************************************
+-- **************************************************************
+
+-- copied from v16.5.0
+ENB-ID ::= CHOICE {
+	macro-eNB-ID	BIT STRING (SIZE (20)),
+	home-eNB-ID		BIT STRING (SIZE (28)),
+	... ,
+	short-Macro-eNB-ID		BIT STRING (SIZE(18)),
+	long-Macro-eNB-ID		BIT STRING (SIZE(21))
+}
+
+-- copied from v16.5.0
+GlobalENB-ID ::= SEQUENCE {
+	pLMNIdentity			PLMNIdentity,
+	eNB-ID					ENB-ID,
+	...
+}
+
+
+-- copied from v16.5.0
+GUMMEI			::= SEQUENCE {
+	pLMN-Identity		PLMNIdentity,
+	mME-Group-ID		MME-Group-ID,
+	mME-Code			MME-Code,
+	...
+}
+
+-- copied from v16.5.0
+MME-Group-ID	::= OCTET STRING (SIZE (2))
+
+-- copied from v16.5.0
+MME-Code		::= OCTET STRING (SIZE (1))
+
+-- copied from v16.5.0
+MME-UE-S1AP-ID	::= INTEGER (0..4294967295)
+
+-- copied from v16.5.0
+QCI				::= INTEGER (0..255)
+
+-- copied from v16.5.0
+SubscriberProfileIDforRFP ::= INTEGER (1..256)
+
+-- **************************************************************
+-- IEs derived from 3GPP 36.423 (X2AP)
+-- **************************************************************
+-- Extension fields removed.
+-- Note: to avoid duplicate names with NGAP, XnAP, etc.:
+-- GNB-ID renamed ENGNB-ID,
+-- GlobalGNB-ID renamed GlobalenGNB-ID,
+-- UE-X2AP-ID renamed ENB-UE-X2AP-ID
+-- UE-X2AP-ID-Extension renamed ENB-UE-X2AP-ID-Extension
+-- **************************************************************
+
+-- copied from v16.5.0
+EN-GNB-ID ::= CHOICE {
+	en-gNB-ID	BIT STRING (SIZE (22..32)),
+	...
+}
+
+-- copied from v16.5.0
+ENB-UE-X2AP-ID ::= INTEGER (0..4095)
+
+-- copied from v16.5.0
+ENB-UE-X2AP-ID-Extension ::= INTEGER (0..4095, ...)
+
+-- copied from v16.5.0
+E-UTRA-ARFCN ::= INTEGER (0..maxEARFCN)
+
+-- copied from v16.5.0
+E-UTRA-PCI ::= INTEGER (0..503, ...)
+
+-- copied from v16.5.0
+E-UTRA-TAC ::= OCTET STRING (SIZE(2))
+
+-- copied from v16.5.0
+GlobalenGNB-ID ::= SEQUENCE {
+	pLMN-Identity			PLMNIdentity,
+	en-gNB-ID				EN-GNB-ID,
+	...
+}
+
+-- **************************************************************
+-- IEs derived from 3GPP 37.473 (W1AP)
+-- **************************************************************
+
+-- copied from v16.3.0
+NGENB-CU-UE-W1AP-ID	::= INTEGER (0..4294967295)
+
+-- copied from v16.3.0
+NGENB-DU-ID	::= INTEGER (0..68719476735)
+
+-- **************************************************************
+-- IEs derived from 3GPP 38.413 (NGAP)
+-- Extension fields removed and replaced with ...
+-- **************************************************************
+
+-- copied from v16.2.0
+AMFPointer ::= BIT STRING (SIZE(6))
+
+-- copied from v16.2.0
+AMFRegionID ::= BIT STRING (SIZE(8))
+
+-- copied from v16.2.0
+AMFSetID ::= BIT STRING (SIZE(10))
+
+-- copied from v16.2.0
+AMF-UE-NGAP-ID ::= INTEGER (0..1099511627775)
+
+-- copied from v16.2.0
+EUTRACellIdentity ::= BIT STRING (SIZE(28))
+
+-- copied from v16.2.0
+EUTRA-CGI ::= SEQUENCE {
+	pLMNIdentity			PLMNIdentity,
+	eUTRACellIdentity		EUTRACellIdentity,
+	...
+}
+
+-- copied from v16.2.0
+FiveQI ::= INTEGER (0..255, ...)
+
+-- copied from v16.2.0
+GlobalGNB-ID ::= SEQUENCE {
+	pLMNIdentity		PLMNIdentity,
+	gNB-ID				GNB-ID,
+	...
+}
+
+-- copied from v16.2.0
+GlobalNgENB-ID ::= SEQUENCE {
+	pLMNIdentity		PLMNIdentity,
+	ngENB-ID			NgENB-ID,
+	...
+}
+
+
+-- copied from v16.2.0
+GNB-ID ::= CHOICE {
+	gNB-ID		BIT STRING (SIZE(22..32)),
+	...
+}
+
+-- copied from v16.2.0
+GUAMI ::= SEQUENCE {
+	pLMNIdentity		PLMNIdentity,
+	aMFRegionID			AMFRegionID,
+	aMFSetID			AMFSetID,
+	aMFPointer			AMFPointer,
+	...
+}
+
+-- copied from v16.2.0
+IndexToRFSP ::= INTEGER (1..256, ...)
+
+-- copied from v16.2.0
+NgENB-ID ::= CHOICE {
+	macroNgENB-ID			BIT STRING (SIZE(20)),
+	shortMacroNgENB-ID		BIT STRING (SIZE(18)),
+	longMacroNgENB-ID		BIT STRING (SIZE(21)),
+	...
+}
+
+-- copied from v16.2.0
+NRCellIdentity ::= BIT STRING (SIZE(36))
+
+-- copied from v16.2.0
+NR-CGI ::= SEQUENCE {
+	pLMNIdentity		PLMNIdentity,
+	nRCellIdentity		NRCellIdentity,
+	...
+}
+
+-- copied from v16.2.0
+PLMNIdentity ::= OCTET STRING (SIZE(3))
+
+-- copied from v16.2.0
+QosFlowIdentifier ::= INTEGER (0..63, ...)
+
+-- copied from v16.2.0
+SD ::= OCTET STRING (SIZE(3))
+
+-- copied from v16.2.0
+S-NSSAI ::= SEQUENCE {
+	sST					SST,
+	sD					SD													OPTIONAL,
+	...
+}
+
+-- copied from v16.2.0
+SST ::= OCTET STRING (SIZE(1))
+
+-- **************************************************************
+-- IEs derived from 3GPP 38.423 (XnAP)
+-- **************************************************************
+
+-- copied from v16.2.0
+NG-RANnodeUEXnAPID ::= INTEGER (0.. 4294967295)
+
+GlobalNGRANNodeID ::= CHOICE {
+	gNB						GlobalGNB-ID,
+	ng-eNB					GlobalNgENB-ID,
+	...
+}
+
+-- **************************************************************
+-- IEs derived from 3GPP 37.483 (E1AP)
+-- **************************************************************
+
+-- copied from v17.1.0
+GNB-CU-CP-UE-E1AP-ID		::= INTEGER (0..4294967295)
+
+-- copied from v17.1.0
+GNB-CU-UP-ID				::= INTEGER (0..68719476735)
+
+-- **************************************************************
+-- IEs derived from 3GPP 38.473 (F1AP)
+-- **************************************************************
+
+-- copied from v16.5.0
+FiveGS-TAC 			::= OCTET STRING (SIZE(3))
+
+-- copied from v16.5.0
+FreqBandNrItem 		::= SEQUENCE {
+	freqBandIndicatorNr 		INTEGER (1..1024, ...),
+	...
+}
+
+-- copied from v16.5.0
+GNB-CU-UE-F1AP-ID	::= INTEGER (0..4294967295)
+
+-- copied from v16.5.0
+GNB-DU-ID			::= INTEGER (0..68719476735)
+
+-- copied from v16.5.0
+NR-PCI				::= INTEGER (0..1007)
+
+-- copied from v16.5.0
+NR-ARFCN			::= SEQUENCE {
+	nRARFCN				INTEGER (0..maxNRARFCN),
+	...
+}
+-- copied from v16.5.0
+NRFrequencyBand-List ::= SEQUENCE (SIZE(1..maxnoofNrCellBands)) OF NRFrequencyBandItem
+
+-- copied from v16.5.0
+NRFrequencyBandItem ::= SEQUENCE {
+	freqBandIndicatorNr			INTEGER (1..1024,...),
+	supportedSULBandList		SupportedSULBandList,
+	...
+}
+
+-- copied from v16.5.0
+NRFrequencyInfo ::= SEQUENCE {
+	nrARFCN					NR-ARFCN,
+	frequencyBand-List		NRFrequencyBand-List,
+	frequencyShift7p5khz	NRFrequencyShift7p5khz			OPTIONAL,
+	...
+}
+
+-- copied from v16.5.0
+NRFrequencyShift7p5khz ::= ENUMERATED {false, true, ...}
+
+
+-- copied from v16.5.0
+RANUEID 			::= OCTET STRING (SIZE (8))
+
+
+-- copied from v16.5.0
+SupportedSULBandList ::= SEQUENCE (SIZE(0..maxnoofNrCellBands)) OF SupportedSULFreqBandItem
+
+-- copied from v16.5.0
+SupportedSULFreqBandItem ::= SEQUENCE {
+	freqBandIndicatorNr 		INTEGER (1..1024,...),
+	...
+}
+
+END
+-- ASN1STOP

--- a/examples/tests/18-e2sm.rs
+++ b/examples/tests/18-e2sm.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code, unreachable_patterns, non_camel_case_types)]
+
+mod e2sm {
+    include!(concat!(env!("OUT_DIR"), "/e2sm.rs"));
+}
+
+fn main() {
+    eprintln!("E2SM");
+}

--- a/examples/tests/compile.rs
+++ b/examples/tests/compile.rs
@@ -9,4 +9,5 @@ fn tests() {
     t.pass("tests/15-supl.rs");
     t.pass("tests/16-example.rs");
     t.pass("tests/17-rrc.rs");
+    t.pass("tests/18-e2sm.rs");
 }


### PR DESCRIPTION
Basic parsing support for the `REAL` Type. Currenttly supporting handling `REAL` type definition and value definitions with `REAL` as type. Note: Currently only assignments like `pi REAL = 3.14` are supported and support for `{ mantisa: .., }` is not yet present in the value definitions.

TODO: Codec support for `REAL` definitions