### PR TITLE
Add support for REAL type to PER codecs

### DIFF
--- a/codecs/src/per/aper/decode/mod.rs
+++ b/codecs/src/per/aper/decode/mod.rs
@@ -86,10 +86,9 @@ pub fn decode_bool(data: &mut PerCodecData) -> Result<bool, PerCodecError> {
 /// Decode a Real
 ///
 /// Decode a Boolean value. Returns the decoded value as a `f64`.
-pub fn decode_real(_data: &mut PerCodecData) -> Result<f64, PerCodecError> {
+pub fn decode_real(data: &mut PerCodecData) -> Result<f64, PerCodecError> {
     log::trace!("decode_real:");
-
-    todo!()
+    decode_real_common(data, true)
 }
 
 /// Decode an Enumerated Value

--- a/codecs/src/per/aper/encode/mod.rs
+++ b/codecs/src/per/aper/encode/mod.rs
@@ -88,10 +88,9 @@ pub fn encode_bool(data: &mut PerCodecData, value: bool) -> Result<(), PerCodecE
 /// Encode a REAL Value
 ///
 /// Encodes a boolean value into the passed `PerCodecData` structure.
-pub fn encode_real(_data: &mut PerCodecData, value: f64) -> Result<(), PerCodecError> {
+pub fn encode_real(data: &mut PerCodecData, value: f64) -> Result<(), PerCodecError> {
     log::trace!("encode_real: {}", value);
-
-    todo!()
+    encode_real_common(data, value, true)
 }
 
 /// Encode an ENUMERATED Value

--- a/codecs/src/per/common/encode/mod.rs
+++ b/codecs/src/per/common/encode/mod.rs
@@ -97,6 +97,48 @@ pub(crate) fn encode_integer_common(
     Ok(())
 }
 
+// Common function to encode a real value
+// Refer to ITU X.691 section 15 and ITU X.690 section 8.5
+pub(crate) fn encode_real_common(
+    data: &mut PerCodecData,
+    value: f64,
+    aligned: bool,
+) -> Result<(), PerCodecError> {
+    // Extract the value to encode
+    let mut encoded_data = BitVec::<u8, Msb0>::new();
+    // Encoding process is detailed in X.690 section 8.5
+    if value == 0.0 {
+        // -0.0 uses a reserved value, and +0.0 uses no data bits
+        if f64::is_sign_negative(value) {
+            encoded_data.extend_from_bitslice::<u8, Msb0>(super::NEGATIVE_ZERO.to_be_bytes().as_bits());
+        } else {
+            // This is +0.0, so there is no need to append any data bits
+        }
+    } else if value == f64::INFINITY {
+        encoded_data.extend_from_bitslice::<u8, Msb0>(super::INFINITY.to_be_bytes().as_bits());
+    } else if value == f64::NEG_INFINITY {
+        encoded_data.extend_from_bitslice::<u8, Msb0>(super::NEGATIVE_INFINITY.to_be_bytes().as_bits());
+    } else if value == f64::NAN {
+        encoded_data.extend_from_bitslice::<u8, Msb0>(super::NOT_A_NUMBER.to_be_bytes().as_bits());
+    } else {
+        // This is a standard non-zero value. For simplicity, always encode 
+        // using base 10 encoding based on ISO 6093 NR3.
+        // TODO: add in support for binary encoding, which can improve space usage.
+        encoded_data.extend_from_bitslice::<u8, Msb0>(super::BASE_10_NR3.to_be_bytes().as_bits());
+        let encoded_value = format!("{:e}", value);
+        encoded_data.extend_from_bitslice::<u8, Msb0>(encoded_value.as_bits());
+    }
+
+    // Set the length (X.691 section 15)
+    encode_length_determinent_common(data, None, None, false, encoded_data.len() / 8, aligned)?;
+
+    // Set the value
+    data.append_bits(&encoded_data);
+
+    data.dump_encode();
+    Ok(())
+}
+
 // Common function to encode a BOOLEAN Value
 pub(crate) fn encode_bool_common(
     data: &mut PerCodecData,
@@ -315,4 +357,20 @@ pub(crate) fn encode_string_common(
 
     data.dump_encode();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_encode_real_base_10_nr3() {
+        let expected_data = &[0x0A, super::super::BASE_10_NR3, b'1', b'.', b'5', b'6', b'2', b'5', b'e',b'-', b'1'];
+        let value = 0.15625f64;
+        let mut data = PerCodecData::new_aper();
+        let result = encode_real_common(&mut data, value, true);
+        assert!(result.is_ok(), "{:#?}", result.err().unwrap());
+        assert_eq!(data.into_bytes(), expected_data);
+    }
 }

--- a/codecs/src/per/common/mod.rs
+++ b/codecs/src/per/common/mod.rs
@@ -11,3 +11,12 @@ pub(crate) fn bytes_needed_for_range(range: i128) -> u8 {
     }
     bytes_needed
 }
+
+// See X.690 section 8.5.9 for details on special REAL values
+const NEGATIVE_ZERO: u8 = 0b0100_0011;
+const INFINITY: u8 = 0b0100_0000;
+const NEGATIVE_INFINITY: u8 = 0b0100_0001;
+const NOT_A_NUMBER: u8 = 0b0100_0010;
+const BASE_10_NR1: u8 = 0b0000_0001;
+const BASE_10_NR2: u8 = 0b0000_0010;
+const BASE_10_NR3: u8 = 0b0000_0011;

--- a/codecs/src/per/uper/decode/mod.rs
+++ b/codecs/src/per/uper/decode/mod.rs
@@ -84,10 +84,9 @@ pub fn decode_bool(data: &mut PerCodecData) -> Result<bool, PerCodecError> {
 /// Decode a Real
 ///
 /// Decode a Real value. Returns the decoded value as a `f64`.
-pub fn decode_real(_data: &mut PerCodecData) -> Result<f64, PerCodecError> {
+pub fn decode_real(data: &mut PerCodecData) -> Result<f64, PerCodecError> {
     log::trace!("decode_real:");
-
-    todo!()
+    decode_real_common(data, false)
 }
 
 /// Decode an Enumerated Value

--- a/codecs/src/per/uper/encode/mod.rs
+++ b/codecs/src/per/uper/encode/mod.rs
@@ -86,10 +86,9 @@ pub fn encode_bool(data: &mut PerCodecData, value: bool) -> Result<(), PerCodecE
 /// Encode a REAL Value
 ///
 /// Encodes an f64 value into the passed `PerCodecData` structure.
-pub fn encode_real(_data: &mut PerCodecData, value: f64) -> Result<(), PerCodecError> {
+pub fn encode_real(data: &mut PerCodecData, value: f64) -> Result<(), PerCodecError> {
     log::trace!("encode_real: {}", value);
-
-    todo!()
+    encode_real_common(data, value, false)
 }
 
 /// Encode an ENUMERATED Value


### PR DESCRIPTION
 * For encode, support all special values and encode standard values as base 10 ISO 6093 NR3 for now.
 * For decode, support:
   * All special values
   * All binary encoded values (base 2, 8, or 16)
   * All base 10 encoded values (ISO 6093 NR1, NR2, and NR3)
 * Future work: Add support for encoding as binary, as well as NR1 and NR2. Selection needs to be based on some additional inputs.

Addresses #100