### PR TITLE
Preparing for 0.6.1 and fixing GH actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'asn-compiler/**'
       - 'codecs/**'
+      - 'codecs_derive/**'
       - '!codecs/specs/**'
       - 'examples/**'
       - '!examples/specs/**'
@@ -17,6 +18,7 @@ on:
     paths:
       - 'asn-compiler/**'
       - 'codecs/**'
+      - 'codecs_derive/**'
       - '!codecs/specs/**'
       - 'examples/**'
       - '!examples/specs/**'
@@ -51,9 +53,9 @@ jobs:
       run: |
         rustc -Vv
         cargo -V
-        cargo build --verbose
+        cargo build --verbose --release
     - name: Run tests
       run: |
         rustc -Vv
         cargo -V
-        cargo test --verbose
+        cargo test --verbose --release

--- a/asn-compiler/Cargo.toml
+++ b/asn-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-compiler"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "ASN.1 Toolkit in Rust. Compiler for ASN.1 specification, ASN.1 codecs and derive macros for ASN.1 Codecs."

--- a/codecs/Cargo.toml
+++ b/codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asn1-codecs"
-version = "0.6.0"
+version = "0.6.1"
 description = "ASN.1 Codecs for Rust Types representing ASN.1 Types."
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 keywords = ["asn1", "per", "decoder", "encoder"]

--- a/codecs_derive/Cargo.toml
+++ b/codecs_derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "asn1_codecs_derive"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 description = "ASN.1 Codecs derive Macros"
 keywords = ["asn1", "per"]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/gabhijit/hampi.git"
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 log = { version = "0.4" }
-asn1-codecs = { path = "../codecs" , version = "=0.6.0"}
+asn1-codecs = { path = "../codecs" , version = "=0.6.1"}
 bitvec = { version = "1.0" }
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hampi-examples"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Abhijit Gadgil <gabhijit@iitbombay.org>"]
 edition = "2018"
 description = "Examples for usage of ASN.1 Compiler and Codecs."
@@ -8,11 +8,11 @@ license = "Apache-2.0 OR MIT"
 publish = false
 
 [build-dependencies]
-asn1-compiler = { path = "../asn-compiler", version = "=0.6.0" }
+asn1-compiler = { path = "../asn-compiler", version = "=0.6.1" }
 
 [dev-dependencies]
-asn1-codecs = { path = "../codecs", version = "=0.6.0" }
-asn1_codecs_derive = { path = "../codecs_derive", version = "=0.6.0" }
+asn1-codecs = { path = "../codecs", version = "=0.6.1" }
+asn1_codecs_derive = { path = "../codecs_derive", version = "=0.6.1" }
 trybuild = { version = "1.0" }
 hex = { version = "0.4" }
 bitvec = { version = "1.0" , features = ["serde"]}

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,0 +1,1 @@
+// No lib in examples


### PR DESCRIPTION
Fixed a GH action as the builds were not getting triggered on commits to `codecs_derive/*`. Also now run `cargo build` and `cargo test` in `--release` mode.

Updated crate version to v0.6.1